### PR TITLE
Update Sundials version for NonStiffODE

### DIFF
--- a/benchmarks/NonStiffODE/Manifest.toml
+++ b/benchmarks/NonStiffODE/Manifest.toml
@@ -1118,9 +1118,9 @@ uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
 
 [[Sundials]]
 deps = ["CEnum", "DataStructures", "DiffEqBase", "Libdl", "LinearAlgebra", "Logging", "Reexport", "SparseArrays", "Sundials_jll"]
-git-tree-sha1 = "e55ce5df8d9e1ff8fde2e75c4bf29ac6151a46e4"
+git-tree-sha1 = "a816e2d2f9b536ef5805dda603347cb1c9108cf0"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "4.4.2"
+version = "4.4.3"
 
 [[Sundials_jll]]
 deps = ["CompilerSupportLibraries_jll", "Libdl", "OpenBLAS_jll", "Pkg", "SuiteSparse_jll"]


### PR DESCRIPTION
Should remove all of the excess printing