### PR TITLE
Add notebook folder if it doesn't exist.

### DIFF
--- a/src/SciMLBenchmarks.jl
+++ b/src/SciMLBenchmarks.jl
@@ -123,6 +123,7 @@ end
 function open_notebooks()
   Base.eval(Main, Meta.parse("import IJulia"))
   path = joinpath(repo_directory,"notebook")
+  mkpath(path)
   IJulia.notebook(;dir=path)
 end
 


### PR DESCRIPTION
When following the instructions for [Interactive Notebooks](https://github.com/SciML/SciMLBenchmarks.jl#interactive-notebooks), I got an error:
```
ERROR: IOError: could not spawn setenv(`/home/greg/.local/bin/jupyter notebook`; dir="/home/greg/.julia/packages/SciMLBenchmarks/qtI01/src/../notebook"): no such file or directory (ENOENT)
```
This error appears to be caused by the folder `notebook` not existing in the repo. This PR adds `mkpath`, which will create all folders in the path if they don't exist, and will not fail if they already exist. 