### PR TITLE
Try running `Pkg.build()` for `conda`

### DIFF
--- a/.buildkite/run_benchmark.yml
+++ b/.buildkite/run_benchmark.yml
@@ -39,9 +39,9 @@ steps:
           s3_prefix: s3://julialang-buildkite-artifacts/scimlbenchmarks
     timeout_in_minutes: 1000
     commands: |
-      # Instantiate, to install the overall project dependencies
+      # Instantiate, to install the overall project dependencies, and `build()` for conda
       echo "--- Instantiate"
-      julia --project=. -e 'using Pkg; Pkg.instantiate()'
+      julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build()'
 
       # Run benchmark
       echo "+++ Run benchmark for {PATH}"


### PR DESCRIPTION
Let's see if this fixes the conda issues; I think it may be mad because its directory can get cleaned out (since it's putting stuff not in a scratch space but in other random places in the depot), while the package source itself persists.