### PR TITLE
change sigmoid to tanh in PINNs' benchmarks

### DIFF
--- a/benchmarks/PINNErrorsVsTime/allen_cahn_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/allen_cahn_et.jmd
@@ -77,7 +77,7 @@ function allen_cahn(strategy, minimizer, maxIters)
 
     ## NEURAL NETWORK
     n = 10   #neuron number
-    chain = Lux.Chain(Lux.Dense(5, n, Lux.σ), Lux.Dense(n, n, Lux.σ), Lux.Dense(n, 1))   #Neural network from OptimizationFlux library
+    chain = Lux.Chain(Lux.Dense(5, n, tanh), Lux.Dense(n, n, tanh), Lux.Dense(n, 1))   #Neural network from OptimizationFlux library
 
     indvars = [t, x1, x2, x3, x4]   #phisically independent variables
     depvars = [u(t, x1, x2, x3, x4)]       #dependent (target) variable

--- a/benchmarks/PINNErrorsVsTime/diffusion_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/diffusion_et.jmd
@@ -45,7 +45,7 @@ function diffusion(strategy, minimizer, maxIters)
     indvars = [x,t]
     depvars = [u(x,t)]
 
-    chain = Lux.Chain(Lux.Dense(2,10,Lux.σ),Lux.Dense(10,10,Lux.σ),Lux.Dense(10,1))
+    chain = Lux.Chain(Lux.Dense(2,10,tanh),Lux.Dense(10,10,tanh),Lux.Dense(10,1))
 
     losses = []
     error = []

--- a/benchmarks/PINNErrorsVsTime/hamilton_jacobi_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/hamilton_jacobi_et.jmd
@@ -85,7 +85,7 @@ function hamilton_jacobi(strategy, minimizer, maxIters)
     ## NEURAL NETWORK
     n = 10   #neuron number
 
-    chain = Lux.Chain(Lux.Dense(5, n, Lux.σ), Lux.Dense(n, n, Lux.σ), Lux.Dense(n, 1))   #Neural network from OptimizationFlux library
+    chain = Lux.Chain(Lux.Dense(5, n, tanh), Lux.Dense(n, n, tanh), Lux.Dense(n, 1))   #Neural network from OptimizationFlux library
 
     indvars = [t, x1, x2, x3, x4]   #phisically independent variables
     depvars = [u(t, x1, x2, x3, x4)]       #dependent (target) variable

--- a/benchmarks/PINNErrorsVsTime/level_set_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/level_set_et.jmd
@@ -81,7 +81,7 @@ function level_set(strategy, minimizer, maxIters)
     ## NEURAL NETWORK
     n = 10   #neuron number
 
-    chain = Lux.Chain(Lux.Dense(3, n, Lux.σ), Lux.Dense(n, n, Lux.σ), Lux.Dense(n, 1))   #Neural network from OptimizationFlux library
+    chain = Lux.Chain(Lux.Dense(3, n, tanh), Lux.Dense(n, n, tanh), Lux.Dense(n, 1))   #Neural network from OptimizationFlux library
 
     indvars = [t, x, y]   #phisically independent variables
     depvars = [u(t, x, y)]       #dependent (target) variable

--- a/benchmarks/PINNErrorsVsTime/nernst_planck_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/nernst_planck_et.jmd
@@ -83,7 +83,7 @@ function nernst_planck(strategy, minimizer, maxIters)
     ## NEURAL NETWORK
     n = 16   #neuron number
 
-    chain = Lux.Chain(Lux.Dense(4,n,Lux.σ),Lux.Dense(n,n,Lux.σ),Lux.Dense(n,1))   #Neural network from OptimizationFlux library
+    chain = Lux.Chain(Lux.Dense(4,n,tanh),Lux.Dense(n,n,tanh),Lux.Dense(n,1))   #Neural network from OptimizationFlux library
 
     indvars = [t,x,y,z]   #independent variables
     depvars = [c(t,x,y,z)]       #dependent (target) variable

--- a/benchmarks/PINNOptimizers/1d_diffusion.jmd
+++ b/benchmarks/PINNOptimizers/1d_diffusion.jmd
@@ -35,7 +35,7 @@ function solve(opt)
     domains = [x ∈ Interval(-1.0,1.0),
                t ∈ Interval(0.0,1.0)]
 
-    chain = Lux.Chain(Lux.Dense(2,18,Lux.σ),Lux.Dense(18,18,Lux.σ),Lux.Dense(18,1))
+    chain = Lux.Chain(Lux.Dense(2,18,tanh),Lux.Dense(18,18,tanh),Lux.Dense(18,1))
 
     discretization = PhysicsInformedNN(chain,strategy)
 

--- a/benchmarks/PINNOptimizers/1d_poisson_nernst_planck.jmd
+++ b/benchmarks/PINNOptimizers/1d_poisson_nernst_planck.jmd
@@ -107,17 +107,17 @@ function solve(opt)
     dim = length(domains)
     output = length(eqs)
     neurons = 16
-    chain1 = Lux.Chain( Lux.Dense(dim, neurons, Lux.σ),
-                        Lux.Dense(neurons, neurons, Lux.σ),
-                        Lux.Dense(neurons, neurons, Lux.σ),
+    chain1 = Lux.Chain( Lux.Dense(dim, neurons, tanh),
+                        Lux.Dense(neurons, neurons, tanh),
+                        Lux.Dense(neurons, neurons, tanh),
                         Lux.Dense(neurons, 1))
-    chain2 = Lux.Chain( Lux.Dense(dim, neurons, Lux.σ),
-                        Lux.Dense(neurons, neurons, Lux.σ),
-                        Lux.Dense(neurons, neurons, Lux.σ),
+    chain2 = Lux.Chain( Lux.Dense(dim, neurons, tanh),
+                        Lux.Dense(neurons, neurons, tanh),
+                        Lux.Dense(neurons, neurons, tanh),
                         Lux.Dense(neurons, 1))
-    chain3 = Lux.Chain( Lux.Dense(dim, neurons, Lux.σ),
-                        Lux.Dense(neurons, neurons, Lux.σ),
-                        Lux.Dense(neurons, neurons, Lux.σ),
+    chain3 = Lux.Chain( Lux.Dense(dim, neurons, tanh),
+                        Lux.Dense(neurons, neurons, tanh),
+                        Lux.Dense(neurons, neurons, tanh),
                         Lux.Dense(neurons, 1))
 
     discretization = PhysicsInformedNN([chain1, chain2, chain3], strategy)

--- a/benchmarks/PINNOptimizers/allen_cahn.jmd
+++ b/benchmarks/PINNOptimizers/allen_cahn.jmd
@@ -77,7 +77,7 @@ function solve(opt)
     ## NEURAL NETWORK
     n = 20   #neuron number
 
-    chain = Lux.Chain(Lux.Dense(5,n,Lux.σ),Lux.Dense(n,n,Lux.σ),Lux.Dense(n,1))   #Neural network from OptimizationFlux library
+    chain = Lux.Chain(Lux.Dense(5,n,tanh),Lux.Dense(n,n,tanh),Lux.Dense(n,1))   #Neural network from OptimizationFlux library
 
     discretization = PhysicsInformedNN(chain, strategy)
 

--- a/benchmarks/PINNOptimizers/burgers_equation.jmd
+++ b/benchmarks/PINNOptimizers/burgers_equation.jmd
@@ -52,7 +52,7 @@ function burgers(strategy, minimizer)
     domains = [x ∈ Interval(0.0, x_max),
         t ∈ Interval(0.0, t_max)]
 
-    chain = Lux.Chain(Lux.Dense(2, 16, Lux.σ), Lux.Dense(16, 16, Lux.σ), Lux.Dense(16, 1))
+    chain = Lux.Chain(Lux.Dense(2, 16, tanh), Lux.Dense(16, 16, tanh), Lux.Dense(16, 1))
     discretization = PhysicsInformedNN(chain, strategy)
 
     indvars = [x, t]   #physically independent variables

--- a/benchmarks/PINNOptimizers/hamilton_jacobi.jmd
+++ b/benchmarks/PINNOptimizers/hamilton_jacobi.jmd
@@ -85,7 +85,7 @@ function solve(opt)
     ## NEURAL NETWORK
     n = 20   #neuron number
 
-    chain = Lux.Chain(Lux.Dense(5,n,Lux.σ),Lux.Dense(n,n,Lux.σ),Lux.Dense(n,1))   #Neural network from OptimizationFlux library
+    chain = Lux.Chain(Lux.Dense(5,n,tanh),Lux.Dense(n,n,tanh),Lux.Dense(n,1))   #Neural network from OptimizationFlux library
 
     discretization = PhysicsInformedNN(chain, strategy)
 

--- a/benchmarks/PINNOptimizers/poisson.jmd
+++ b/benchmarks/PINNOptimizers/poisson.jmd
@@ -38,7 +38,7 @@ function solve(opt)
 
     # Neural network
     dim = 2 # number of dimensions
-    chain = Lux.Chain(Lux.Dense(dim,16,Lux.σ),Lux.Dense(16,16,Lux.σ),Lux.Dense(16,1))
+    chain = Lux.Chain(Lux.Dense(dim,16,tanh),Lux.Dense(16,16,tanh),Lux.Dense(16,1))
 
     discretization = PhysicsInformedNN(chain,strategy)
 


### PR DESCRIPTION
The sigmoid function is suboptimal, especially when the inputs are all positive, it leads to all positive gradients. 

See https://rohanvarma.me/inputnormalization/ for details.

It shouldn't change the conclusions drawn by the current benchmarks, but I believe the losses will drop overall.