### PR TITLE
.buildkite: run_benchmark: use `v1` of `coppermind` plugin

### DIFF
--- a/.buildkite/run_benchmark.yml
+++ b/.buildkite/run_benchmark.yml
@@ -22,7 +22,7 @@ steps:
           workspaces:
             # Include the julia we just downloaded
             - "/cache/julia-buildkite-plugin:/cache/julia-buildkite-plugin"
-      - staticfloat/coppermind:
+      - staticfloat/coppermind#v1:
           inputs:
             # We are sensitive to the actual benchmark changing
             - {PATH}
@@ -93,7 +93,7 @@ steps:
       # Use coppermind to download the benchmark results that were calculated in the
       # benchmarking job above.  Note we still list `outputs` here, since we have the
       # option to extract only a subset of them here.
-      - staticfloat/coppermind:
+      - staticfloat/coppermind#v1:
           input_from: "benchmark-{SANITIZED_PATH}"
           outputs:
             #- html/**/*.html


### PR DESCRIPTION
Since `v1` release of the `coppermind` plugin has been made, explicitly specify that the `v1` of the plugin must be used.
