### PR TITLE
Update bio benchmarks with comparisson

### DIFF
--- a/benchmarks/Bio/BCR.jmd
+++ b/benchmarks/Bio/BCR.jmd
@@ -34,13 +34,13 @@ obs = [eq.lhs for eq in observed(rn)]
 show(to)
 
 tspan = (0.,tf)
-@timeit to "ODEProb No Jac" oprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[])
+@timeit to "ODEProb No Jac" oprob = ODEProblem(osys, Float64[], tspan, Float64[])
 show(to)
-oprob_sparse = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[]; sparse=true);
+oprob_sparse = ODEProblem(osys, Float64[], tspan, Float64[]; sparse=true);
 ```
 
 ```julia
-@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
+@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
 show(to)
 ```
 
@@ -188,7 +188,7 @@ setups = [
 wp = WorkPrecisionSet([oprob,oprob_sparse,sparsejacprob],abstols,reltols,setups;error_estimate=:l2,
                     saveat=tf/10000.,appxsol=[test_sol,test_sol,test_sol],maxiters=Int(1e6),numruns=1)
 
-names = ["lsoda" "CVODE_BDF" "CVODE_BDF (LapackDense)" "CVODE_BDF (GMRES)" "CVODE_BDF (GMRES, iLU)" "CVODE_BDF (KLU, sparse jac)"]
+names = ["lsoda" "CVODE_BDF" "CVODE_BDF (LapackDense)" "CVODE_BDF (GMRES)" "CVODE_BDF (GMRES, iLU)"]
 xlimit,ylimit = plot_settings(wp)
 plot(wp;label=names,xlimit=xlimit,ylimit=ylimit)
 ```
@@ -284,6 +284,35 @@ wp = WorkPrecisionSet(sparsejacprob,abstols,reltols,setups;error_estimate=:l2,
 names = ["TRBDF2 (KLU, sparse jac)" "QNDF (KLU, sparse jac)" "FBDF (KLU, sparse jac)" "KenCarp4 (KLU, sparse jac)"]
 xlimit,ylimit = plot_settings(wp)
 plot(wp;label=names,xlimit=xlimit,ylimit=ylimit)
+```
+
+## Summary of results
+Finally, we compute a single diagram comparing the various solvers used.
+
+#### Declare solvers
+We designate the solvers we wish to compare.
+```julia
+setups = [
+        Dict(:alg=>CVODE_BDF(linear_solver=:GMRES,prec=precilu,psetup=psetupilu,prec_side=1), :prob_choice => 2),
+        Dict(:alg=>QNDF(linsolve=KrylovJL_GMRES(),autodiff=false,precs=incompletelu,concrete_jac=true), :prob_choice => 3),
+        Dict(:alg=>FBDF(linsolve=KrylovJL_GMRES(),autodiff=false,precs=incompletelu,concrete_jac=true), :prob_choice => 3),
+        Dict(:alg=>QNDF(linsolve=KLUFactorization(),autodiff=false), :prob_choice => 3),
+        Dict(:alg=>FBDF(linsolve=KLUFactorization(),autodiff=false), :prob_choice => 3),
+        Dict(:alg=>KenCarp4(linsolve=KLUFactorization(),autodiff=false), :prob_choice => 3)
+        ];
+```
+
+#### Plot Work-Precision Diagram
+
+For these, we generate a work-precision diagram for the selection of solvers.
+```julia
+wp = WorkPrecisionSet([oprob,oprob_sparse,sparsejacprob],abstols,reltols,setups;error_estimate=:l2,
+                      saveat=tf/10000.,appxsol=test_sol,maxiters=Int(1e9),numruns=200)
+
+names = ["CVODE_BDF (GMRES, iLU)" "QNDF (GMRES, iLU)" "FBDF (GMRES, iLU)" "QNDF (KLU, sparse jac)" "FBDF (KLU, sparse jac)" "KenCarp4 (KLU, sparse jac)"]
+colors = [:green :deepskyblue1 :dodgerblue2 :deepskyblue1 :dodgerblue2 :lightskyblue]
+xlimit,ylimit = plot_settings(wp)
+plot(wp;label=names,xlimit=xlimit,ylimit=ylimit,xticks=[1e-10,1e-9,1e-8,1e-7,1e-6,1e-5,1e-4,1e-3],yticks=[],color=colors,legendfontsize=15,tickfontsize=15,guidefontsize=15, legend=:topright, lw=20, la=0.8, markersize=20,markerstrokealpha=1.0, markerstrokewidth=1.5, gridalpha=0.3, markershape=:diamond, gridlinewidth=7.5,size=(1100,1000))
 ```
 
 ```julia, echo = false

--- a/benchmarks/Bio/egfr_net.jmd
+++ b/benchmarks/Bio/egfr_net.jmd
@@ -34,12 +34,12 @@ obs = [eq.lhs for eq in observed(rn)]
 show(to) 
 
 tspan = (0.,tf)
-@timeit to "ODEProb No Jac" oprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[])
+@timeit to "ODEProb No Jac" oprob = ODEProblem(osys, Float64[], tspan, Float64[])
 show(to);
 ```
 
 ```julia
-@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
+@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
 show(to)
 ```
 
@@ -249,6 +249,36 @@ wp = WorkPrecisionSet(oprob,abstols,reltols,setups;error_estimate=:l2,
 names = ["ROCK2"]
 xlimit,ylimit = plot_settings(wp)
 plot(wp;label=names,xlimit=xlimit,ylimit=ylimit)
+```
+
+## Summary of results
+Finally, we compute a single diagram comparing the various solvers used.
+
+#### Declare solvers
+We designate the solvers we wish to compare.
+```julia
+setups = [
+          Dict(:alg=>lsoda()),
+          Dict(:alg=>CVODE_BDF(linear_solver=:GMRES)),
+          Dict(:alg=>QNDF(linsolve=KrylovJL_GMRES())),
+          Dict(:alg=>QNDF(linsolve=KLUFactorization())),
+          Dict(:alg=>BS5()),     
+          Dict(:alg=>Vern6()), 
+          Dict(:alg=>ROCK4())
+          ];
+```
+
+#### Plot Work-Precision Diagram
+
+For these, we generate a work-precision diagram for the selection of solvers.
+```julia
+wp = WorkPrecisionSet(oprob,abstols,reltols,setups;error_estimate=:l2,
+                      saveat=tf/10000.,appxsol=test_sol,maxiters=Int(1e9),numruns=200)
+
+names = ["lsoda" "CVODE_BDF (GMRES)" "QNDF (GMRES)" "BS5" "Vern6" "ROCK4"]
+colors = [:seagreen1 :darkgreen :deepskyblue1 :lightsteelblue2 :mediumpurple1 :darkorchid4]
+xlimit,ylimit = plot_settings(wp)
+plot(wp;label=names,xlimit=xlimit,ylimit=ylimit,xticks=[1e-10,1e-9,1e-8,1e-7,1e-6,1e-5,1e-4,1e-3],yticks=[],color=colors,legendfontsize=15,tickfontsize=15,guidefontsize=15, legend=:topright, lw=20, la=0.8, markersize=20,markerstrokealpha=1.0, markerstrokewidth=1.5, gridalpha=0.3, markershape=:diamond, gridlinewidth=7.5,size=(1100,1000))
 ```
 
 

--- a/benchmarks/Bio/fceri_gamma2.jmd
+++ b/benchmarks/Bio/fceri_gamma2.jmd
@@ -33,11 +33,11 @@ obs = [eq.lhs for eq in observed(rn)]
 show(to)
 
 tspan = (0.,tf)
-@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
+@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
 show(to)
-@timeit to "ODEProb No Jac" oprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[])
+@timeit to "ODEProb No Jac" oprob = ODEProblem(osys, Float64[], tspan, Float64[])
 show(to)
-oprob_sparse = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[]; sparse=true);
+oprob_sparse = ODEProblem(osys, Float64[], tspan, Float64[]; sparse=true);
 ```
 
 ```julia
@@ -295,6 +295,34 @@ wp = WorkPrecisionSet(oprob,abstols,reltols,setups;error_estimate=:l2,
 names = ["CVODE_Adams" "Tsit5" "BS5" "Vern6" "Vern7" "Vern8" "Vern9"]
 xlimit,ylimit = plot_settings(wp)
 plot(wp;label=names,xlimit=xlimit,ylimit=ylimit)
+```
+
+## Summary of results
+Finally, we compute a single diagram comparing the various solvers used.
+
+#### Declare solvers
+We designate the solvers we wish to compare.
+```julia
+setups = [
+        Dict(:alg=>CVODE_BDF(linear_solver=:GMRES), :prob_choice => 1),
+        Dict(:alg=>CVODE_BDF(linear_solver=:GMRES,prec=precilu,psetup=psetupilu,prec_side=1), :prob_choice => 2),
+        Dict(:alg=>QNDF(linsolve=KrylovJL_GMRES(),autodiff=false,precs=incompletelu,concrete_jac=true), :prob_choice => 3),
+        Dict(:alg=>FBDF(linsolve=KrylovJL_GMRES(),autodiff=false,precs=incompletelu,concrete_jac=true), :prob_choice => 3),
+        Dict(:alg=>Tsit5())
+        ];
+```
+
+#### Plot Work-Precision Diagram
+
+For these, we generate a work-precision diagram for the selection of solvers.
+```julia
+wp = WorkPrecisionSet([oprob,oprob_sparse,sparsejacprob],abstols,reltols,setups;error_estimate=:l2,
+                      saveat=tf/10000.,appxsol=test_sol,maxiters=Int(1e9),numruns=200)
+
+names = ["CVODE_BDF (GMRES)" "CVODE_BDF (GMRES, iLU)" "QNDF (GMRES, iLU)" "FBDF (GMRES, iLU)" "Tsit5"]
+colors = [:darkgreen :green :deepskyblue1 :dodgerblue2 :deepskyblue1 :dodgerblue2 :thistle2]
+xlimit,ylimit = plot_settings(wp)
+plot(wp;label=names,xlimit=xlimit,ylimit=ylimit,xticks=[1e-10,1e-9,1e-8,1e-7,1e-6,1e-5,1e-4,1e-3],yticks=[],color=colors,legendfontsize=15,tickfontsize=15,guidefontsize=15, legend=:topright, lw=20, la=0.8, markersize=20,markerstrokealpha=1.0, markerstrokewidth=1.5, gridalpha=0.3, markershape=:diamond, gridlinewidth=7.5,size=(1100,1000))
 ```
 
 ```julia

--- a/benchmarks/Bio/multisite2.jmd
+++ b/benchmarks/Bio/multisite2.jmd
@@ -32,12 +32,12 @@ obs = [eq.lhs for eq in observed(rn)]
 show(to) 
 
 tspan = (0.,tf)
-@timeit to "ODEProb No Jac" oprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[])
+@timeit to "ODEProb No Jac" oprob = ODEProblem(osys, Float64[], tspan, Float64[])
 show(to);
 ```
 
 ```julia
-@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
+@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
 show(to)
 ```
 
@@ -214,6 +214,38 @@ wp = WorkPrecisionSet(oprob,abstols,reltols,setups;error_estimate=:l2,
 names = ["ROCK2"]
 xlimit,ylimit = plot_settings(wp)
 plot(wp;label=names,xlimit=xlimit,ylimit=ylimit)
+```
+
+## Summary of results
+Finally, we compute a single diagram comparing the various solvers used.
+
+#### Declare solvers
+We designate the solvers we wish to compare.
+```julia
+setups = [
+          Dict(:alg=>lsoda()),
+          Dict(:alg=>CVODE_BDF(linear_solver=:GMRES)),
+          Dict(:alg=>QNDF()),
+          Dict(:alg=>FBDF()),
+          Dict(:alg=>Rodas5P()),
+          Dict(:alg=>Tsit5()), 
+          Dict(:alg=>BS5()), 
+          Dict(:alg=>Vern6()), 
+          Dict(:alg=>ROCK4())
+          ];
+```
+
+#### Plot Work-Precision Diagram
+
+For these, we generate a work-precision diagram for the selection of solvers.
+```julia
+wp = WorkPrecisionSet(oprob,abstols,reltols,setups;error_estimate=:l2,
+                      saveat=tf/10000.,appxsol=test_sol,maxiters=Int(1e9),numruns=200)
+
+names = ["lsoda" "CVODE_BDF (GMRES)" "QNDF" "FBDF" "Rodas5P" "Tsit5" "BS5" "Vern6" "ROCK4"]
+colors = [:seagreen1 :darkgreen :deepskyblue1 :dodgerblue2 :blue :thistle2 :lightsteelblue2 :mediumpurple1 :darkorchid4]
+xlimit,ylimit = plot_settings(wp)
+plot(wp;label=names,xlimit=xlimit,ylimit=ylimit,xticks=[1e-10,1e-9,1e-8,1e-7,1e-6,1e-5,1e-4,1e-3],yticks=[],color=colors,legendfontsize=15,tickfontsize=15,guidefontsize=15, legend=:topright, lw=20, la=0.8, markersize=20,markerstrokealpha=1.0, markerstrokewidth=1.5, gridalpha=0.3, markershape=:diamond, gridlinewidth=7.5,size=(1100,1000))
 ```
 
 

--- a/benchmarks/Bio/multistate.jmd
+++ b/benchmarks/Bio/multistate.jmd
@@ -31,12 +31,12 @@ obs = [eq.lhs for eq in observed(rn)]
 show(to) 
 
 tspan = (0.,tf)
-@timeit to "ODEProb No Jac" oprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[])
+@timeit to "ODEProb No Jac" oprob = ODEProblem(osys, Float64[], tspan, Float64[])
 show(to);
 ```
 
 ```julia
-@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
+@timeit to "ODEProb SparseJac" sparsejacprob = ODEProblem(osys, Float64[], tspan, Float64[], jac=true, sparse=true)
 show(to)
 ```
 
@@ -212,6 +212,38 @@ wp = WorkPrecisionSet(oprob,abstols,reltols,setups;error_estimate=:l2,
 names = ["CVODE_Adams" "ROCK2"]
 xlimit,ylimit = plot_settings(wp)
 plot(wp;label=names,xlimit=xlimit,ylimit=ylimit)
+```
+
+## Summary of results
+Finally, we compute a single diagram comparing the various solvers used.
+
+#### Declare solvers
+We designate the solvers we wish to compare.
+```julia
+setups = [
+          Dict(:alg=>lsoda()),
+          Dict(:alg=>CVODE_BDF()),
+          Dict(:alg=>QNDF()),
+          Dict(:alg=>KenCarp4()),
+          Dict(:alg=>Rodas5P()),
+          Dict(:alg=>Tsit5()), 
+          Dict(:alg=>BS5()), 
+          Dict(:alg=>VCABM()),   
+          Dict(:alg=>Vern7())
+          ];
+```
+
+#### Plot Work-Precision Diagram
+
+For these, we generate a work-precision diagram for the selection of solvers.
+```julia
+wp = WorkPrecisionSet(oprob,abstols,reltols,setups;error_estimate=:l2,
+                      saveat=tf/10000.,appxsol=test_sol,maxiters=Int(1e9),numruns=200)
+
+names = ["lsoda" "CVODE_BDF" "QNDF" "KenCarp4" "Rodas5P" "Tsit5" "BS5" "VCABM" "Vern7"]
+colors = [:seagreen1 :chartreuse1 :deepskyblue1 :lightskyblue :blue :thistle2 :lightsteelblue2 :lightslateblue :mediumpurple3]
+xlimit,ylimit = plot_settings(wp)
+plot(wp;label=names,xlimit=xlimit,ylimit=ylimit,xticks=[1e-10,1e-9,1e-8,1e-7,1e-6,1e-5,1e-4,1e-3],yticks=[],color=colors,legendfontsize=15,tickfontsize=15,guidefontsize=15, legend=:topright, lw=20, la=0.8, markersize=20,markerstrokealpha=1.0, markerstrokewidth=1.5, gridalpha=0.3, markershape=:diamond, gridlinewidth=7.5,size=(1100,1000))
 ```
 
 ```julia, echo = false


### PR DESCRIPTION
This will add a final WP plot at the end of each of the Bio benchmarks files. 

The idea is that for the Catalyst paper, we can just download the figures from the SciMLBenchmakrs docs directly (since they only compare within Catalyst, unlike the main figure where we compare between tools). So I am basically adding proposed paper supplementary figures at the end here.

For each summary plot, I basically pick the best benchmarks across the docs. In some cases I also try and pick the best from each set (unless where a set only have really bad ones).