### PR TITLE
Fix extrapolation methods plots for better visibility

### DIFF
--- a/benchmarks/NonStiffODE/LotkaVolterra_wpd.jmd
+++ b/benchmarks/NonStiffODE/LotkaVolterra_wpd.jmd
@@ -133,6 +133,8 @@ Now let's test Tsit5 and Vern9 against parallel extrapolation methods and an
 Adams-Bashforth-Moulton:
 
 ```julia
+abstols = 1.0 ./ 10.0 .^ (8:13)
+reltols = 1.0 ./ 10.0 .^ (8:13)
 setups = [Dict(:alg=>Tsit5())
           Dict(:alg=>Vern9())
           Dict(:alg=>VCABM())

--- a/benchmarks/NonStiffODE/RigidBody_wpd.jmd
+++ b/benchmarks/NonStiffODE/RigidBody_wpd.jmd
@@ -87,6 +87,8 @@ Now let's test Tsit5 and Vern9 against parallel extrapolation methods and an
 Adams-Bashforth-Moulton:
 
 ```julia
+abstols = 1.0 ./ 10.0 .^ (8:13)
+reltols = 1.0 ./ 10.0 .^ (8:13)
 setups = [Dict(:alg=>Tsit5())
           Dict(:alg=>Vern9())
           Dict(:alg=>VCABM())


### PR DESCRIPTION
Fixed by adjusting tolerances for Lotka Volterra and Rigid Body diagrams.

@ChrisRackauckas 