### PR TITLE
Remove sparse from NLPModels

### DIFF
--- a/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
+++ b/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
@@ -1095,8 +1095,21 @@ function build_opf_nlpmodels_prob(dataset)
 
     model_variables = length(var_init)
     model_constraints = length(opf_constraints!(similar(con_lbs), var_init))
+    backend = ADModelBackend(gradient_backend = ReverseDiffADGradient,
+                   hprod_backend = SDTForwardDiffADHvprod,
+                   jprod_backend = ForwardDiffADJprod, 
+                   jtprod_backend = ReverseDiffADJtprod, 
+                   jacobian_backend = ForwardDiffADJacobian, # SDTSparseADJacobian, 
+                   hessian_backend = ForwardDiffADHessian, # SparseADJacobian, 
+                   ghjvprod_backend = ForwardDiffADGHjvprod, 
+                   hprod_residual_backend = ReverseDiffADHvprod, 
+                   jprod_residual_backend = ForwardDiffADJprod, 
+                   jtprod_residual_backend = ReverseDiffADJtprod, 
+                   jacobian_residual_backend = ForwardDiffADHessian, # SparseADJacobian, 
+                   hessian_residual_backend = ForwardDiffADHessian
+                   )
 
-    nlp = ADNLPModels.ADNLPModel!(opf_objective, var_init, var_lb, var_ub, opf_constraints!, con_lbs, con_ubs, backend = :optimized)
+    nlp = ADNLPModels.ADNLPModel!(opf_objective, var_init, var_lb, var_ub, opf_constraints!, con_lbs, con_ubs, backend = backend)
 end
 
 function solve_opf_nlpmodels(dataset)
@@ -2114,6 +2127,7 @@ function multidata_multisolver_benchmark(dataset_files; sizelimit = SIZE_LIMIT)
             continue
         end
         
+        @info "Running Optimization.jl"
         model, res = solve_opf_optimization(dataset)
         push!(cases, split(file,"/")[end])
         push!(vars, res["variables"])
@@ -2123,24 +2137,28 @@ function multidata_multisolver_benchmark(dataset_files; sizelimit = SIZE_LIMIT)
         push!(optimization_time_compilation, res["time_solve_compilation"])
         push!(optimization_cost, res["cost"])
 
+        @info "Running JuMP.jl"
         model, res = solve_opf_jump(dataset)
         push!(jump_time, res["time_solve"])
         push!(jump_time_modelbuild, res["time_build"])
         push!(jump_time_compilation, res["time_solve_compilation"])
         push!(jump_cost, res["cost"])
 
+        @info "Running NLPModels.jl"
         model, res = solve_opf_nlpmodels(dataset)
         push!(nlpmodels_time, res["time_solve"])
         push!(nlpmodels_time_modelbuild, res["time_build"])
         push!(nlpmodels_time_compilation, res["time_solve_compilation"])
         push!(nlpmodels_cost, res["cost"])
         
+        @info "Running Nonconvex.jl"
         model, res = solve_opf_nonconvex(dataset)
         push!(nonconvex_time, res["time_solve"])
         push!(nonconvex_time_modelbuild, res["time_build"])
         push!(nonconvex_time_compilation, res["time_solve_compilation"])
         push!(nonconvex_cost, res["cost"])
 
+        @info "Running Optim.jl"
         model, res = solve_opf_optim(dataset)
         push!(optim_time, res["time_solve"])
         push!(optim_time_modelbuild, res["time_build"])

--- a/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
+++ b/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
@@ -1111,7 +1111,7 @@ function build_opf_nlpmodels_prob(dataset)
                    hessian_residual_backend = ADNLPModels.ForwardDiffADHessian
                    )
     =#
-    nlp = ADNLPModels.ADNLPModel!(opf_objective, var_init, var_lb, var_ub, opf_constraints!, con_lbs, con_ubs, backend = :default) # backend = :optimized)
+    nlp = ADNLPModels.ADNLPModel!(opf_objective, var_init, var_lb, var_ub, opf_constraints!, con_lbs, con_ubs, backend = :optimized)
 end
 
 function solve_opf_nlpmodels(dataset)
@@ -1370,14 +1370,14 @@ function solve_opf_nonconvex(dataset)
         model,
         IpoptAlg(),
         NonconvexCore.getinit(model);
-        options = IpoptOptions(; first_order=false, symbolic=true, sparse=true, print_level = PRINT_LEVEL, max_cpu_time = MAX_CPU_TIME),
+        options = IpoptOptions(; first_order=false, symbolic=false, sparse=true, print_level = PRINT_LEVEL, max_cpu_time = MAX_CPU_TIME),
     )
 
     solve_time_without_compilation = @elapsed result = Nonconvex.optimize(
         model,
         IpoptAlg(),
         NonconvexCore.getinit(model);
-        options = IpoptOptions(; first_order=false, symbolic=true, sparse=true, print_level = PRINT_LEVEL, max_cpu_time = MAX_CPU_TIME),
+        options = IpoptOptions(; first_order=false, symbolic=false, sparse=true, print_level = PRINT_LEVEL, max_cpu_time = MAX_CPU_TIME),
     )
 
     cost = result.minimum

--- a/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
+++ b/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
@@ -2153,13 +2153,15 @@ function multidata_multisolver_benchmark(dataset_files; sizelimit = SIZE_LIMIT)
         push!(nlpmodels_time_compilation, res["time_solve_compilation"])
         push!(nlpmodels_cost, res["cost"])
         
+        #=
         @info "Running Nonconvex.jl"
         model, res = solve_opf_nonconvex(dataset)
         push!(nonconvex_time, res["time_solve"])
         push!(nonconvex_time_modelbuild, res["time_build"])
         push!(nonconvex_time_compilation, res["time_solve_compilation"])
         push!(nonconvex_cost, res["cost"])
-
+        =#
+        
         @info "Running Optim.jl"
         model, res = solve_opf_optim(dataset)
         push!(optim_time, res["time_solve"])
@@ -2171,7 +2173,7 @@ function multidata_multisolver_benchmark(dataset_files; sizelimit = SIZE_LIMIT)
               :optimization => optimization_time, :optimization_modelbuild => optimization_time_modelbuild, :optimization_wcompilation => optimization_time_compilation, :optimization_cost => optimization_cost,
               :jump => jump_time, :jump_modelbuild => jump_time_modelbuild, :jump_wcompilation => jump_time_compilation, :jump_cost => jump_cost, 
               :nlpmodels => nlpmodels_time, :nlpmodels_modelbuild => nlpmodels_time_modelbuild, :nlpmodels_wcompilation => nlpmodels_time_compilation,  :nlpmodels_cost => nlpmodels_cost, 
-              :nonconvex => nonconvex_time, :nonconvex_modelbuild => nonconvex_time_modelbuild, :nonconvex_wcompilation => nonconvex_time_compilation,  :nonconvex_cost => nonconvex_cost,
+              #:nonconvex => nonconvex_time, :nonconvex_modelbuild => nonconvex_time_modelbuild, :nonconvex_wcompilation => nonconvex_time_compilation,  :nonconvex_cost => nonconvex_cost,
               :optim => optim_time, :optim_modelbuild => optim_time_modelbuild, :optim_wcompilation => optim_time_compilation,  :optim_cost => optim_cost)
 end
 

--- a/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
+++ b/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
@@ -1095,7 +1095,9 @@ function build_opf_nlpmodels_prob(dataset)
 
     model_variables = length(var_init)
     model_constraints = length(opf_constraints!(similar(con_lbs), var_init))
-    backend = ADNLPModels.ADModelBackend(gradient_backend = ADNLPModels.ReverseDiffADGradient,
+    #=
+    backend = ADNLPModels.ADModelBackend(model_variables, opf_objective, model_constraints, opf_constraints!;
+                   gradient_backend = ADNLPModels.ReverseDiffADGradient,
                    hprod_backend = ADNLPModels.SDTForwardDiffADHvprod,
                    jprod_backend = ADNLPModels.ForwardDiffADJprod, 
                    jtprod_backend = ADNLPModels.ReverseDiffADJtprod, 
@@ -1108,8 +1110,8 @@ function build_opf_nlpmodels_prob(dataset)
                    jacobian_residual_backend = ADNLPModels.ForwardDiffADHessian, # SparseADJacobian, 
                    hessian_residual_backend = ADNLPModels.ForwardDiffADHessian
                    )
-
-    nlp = ADNLPModels.ADNLPModel!(opf_objective, var_init, var_lb, var_ub, opf_constraints!, con_lbs, con_ubs, backend = backend)
+    =#
+    nlp = ADNLPModels.ADNLPModel!(opf_objective, var_init, var_lb, var_ub, opf_constraints!, con_lbs, con_ubs, backend = :default) # backend = :optimized)
 end
 
 function solve_opf_nlpmodels(dataset)

--- a/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
+++ b/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
@@ -1095,18 +1095,18 @@ function build_opf_nlpmodels_prob(dataset)
 
     model_variables = length(var_init)
     model_constraints = length(opf_constraints!(similar(con_lbs), var_init))
-    backend = ADModelBackend(gradient_backend = ReverseDiffADGradient,
-                   hprod_backend = SDTForwardDiffADHvprod,
-                   jprod_backend = ForwardDiffADJprod, 
-                   jtprod_backend = ReverseDiffADJtprod, 
-                   jacobian_backend = ForwardDiffADJacobian, # SDTSparseADJacobian, 
-                   hessian_backend = ForwardDiffADHessian, # SparseADJacobian, 
-                   ghjvprod_backend = ForwardDiffADGHjvprod, 
-                   hprod_residual_backend = ReverseDiffADHvprod, 
-                   jprod_residual_backend = ForwardDiffADJprod, 
-                   jtprod_residual_backend = ReverseDiffADJtprod, 
-                   jacobian_residual_backend = ForwardDiffADHessian, # SparseADJacobian, 
-                   hessian_residual_backend = ForwardDiffADHessian
+    backend = ADModelBackend(gradient_backend = ADNLPModels.ReverseDiffADGradient,
+                   hprod_backend = ADNLPModels.SDTForwardDiffADHvprod,
+                   jprod_backend = ADNLPModels.ForwardDiffADJprod, 
+                   jtprod_backend = ADNLPModels.ReverseDiffADJtprod, 
+                   jacobian_backend = ADNLPModels.ForwardDiffADJacobian, # SDTSparseADJacobian, 
+                   hessian_backend = ADNLPModels.ForwardDiffADHessian, # SparseADJacobian, 
+                   ghjvprod_backend = ADNLPModels.ForwardDiffADGHjvprod, 
+                   hprod_residual_backend = ADNLPModels.ReverseDiffADHvprod, 
+                   jprod_residual_backend = ADNLPModels.ForwardDiffADJprod, 
+                   jtprod_residual_backend = ADNLPModels.ReverseDiffADJtprod, 
+                   jacobian_residual_backend = ADNLPModels.ForwardDiffADHessian, # SparseADJacobian, 
+                   hessian_residual_backend = ADNLPModels.ForwardDiffADHessian
                    )
 
     nlp = ADNLPModels.ADNLPModel!(opf_objective, var_init, var_lb, var_ub, opf_constraints!, con_lbs, con_ubs, backend = backend)

--- a/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
+++ b/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
@@ -1095,7 +1095,7 @@ function build_opf_nlpmodels_prob(dataset)
 
     model_variables = length(var_init)
     model_constraints = length(opf_constraints!(similar(con_lbs), var_init))
-    backend = ADModelBackend(gradient_backend = ADNLPModels.ReverseDiffADGradient,
+    backend = ADNLPModels.ADModelBackend(gradient_backend = ADNLPModels.ReverseDiffADGradient,
                    hprod_backend = ADNLPModels.SDTForwardDiffADHvprod,
                    jprod_backend = ADNLPModels.ForwardDiffADJprod, 
                    jtprod_backend = ADNLPModels.ReverseDiffADJtprod, 


### PR DESCRIPTION
It's using Symbolics incorrectly, so it is causing failures at larger sizes:

```julia
_bk;t=1694823702792Internal error: stack overflow in type inference of (::RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(:ˍ₋arg1,), Symbolics.var"#_RGF_ModTag", Symbolics.var"#_RGF_ModTag", (0xaa552898, 0xaf8490d0, 0x20badbf9, 0xf8e30c84, 0x637debea), Expr})(Array{Symbolics.Num, 1}).

_bk;t=1694828646696This might be caused by recursion over very long tuples or argument lists.

_bk;t=1694828646696Internal error: stack overflow in type inference of (::RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(:ˍ₋arg1,), Symbolics.var"#_RGF_ModTag", Symbolics.var"#_RGF_ModTag", (0xaa552898, 0xaf8490d0, 0x20badbf9, 0xf8e30c84, 0x637debea), Expr})(Array{Float64, 1}).

_bk;t=1694828656064This might be caused by recursion over very long tuples or argument lists.

_bk;t=1694828656064Internal error: stack overflow in type inference of (::RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(:ˍ₋arg1,), Symbolics.var"#_RGF_ModTag", Symbolics.var"#_RGF_ModTag", (0xccb40d2a, 0x291b25aa, 0xb313de73, 0xc2fe367a, 0x85a9f745), Expr})(Array{Symbolics.Num, 1}).

_bk;t=1694828679462This might be caused by recursion over very long tuples or argument lists.

_bk;t=1694828679462Internal error: stack overflow in type inference of (::RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(:ˍ₋arg1,), Symbolics.var"#_RGF_ModTag", Symbolics.var"#_RGF_ModTag", (0xccb40d2a, 0x291b25aa, 0xb313de73, 0xc2fe367a, 0x85a9f745), Expr})(Array{Float64, 1}).

_bk;t=1694830468077This might be caused by recursion over very long tuples or argument lists.

_bk;t=1694830468077
```
