### PR TITLE
Nicer AD benchmark table

### DIFF
--- a/benchmarks/AutomaticDifferentiation/JuliaAD.jmd
+++ b/benchmarks/AutomaticDifferentiation/JuliaAD.jmd
@@ -4,11 +4,11 @@ author: Guillaume Dalle and Chris Rackauckas
 ---
 
 ```julia
-using DifferentiationInterface, DifferentiationInterfaceTest, DataFrames
+using DifferentiationInterface, DifferentiationInterfaceTest, DataFrames, DataFramesMeta
 import Enzyme, Zygote, Tapir
-import Markdown, PrettyTables
+import Markdown, PrettyTables, Printf
 
-function f(x::AbstractVector{T}) where {T}
+function paritytrig(x::AbstractVector{T}) where {T}
     y = zero(T)
     for i in eachindex(x)
         if iseven(i)
@@ -20,11 +20,35 @@ function f(x::AbstractVector{T}) where {T}
     return y
 end
 
-backends = [AutoEnzyme(Enzyme.Reverse), AutoZygote(), AutoTapir()];
-scenarios = [GradientScenario(f, x=rand(100)), GradientScenario(f, x=rand(10_000))];
-result = benchmark_differentiation(backends, scenarios, logging=true)
-data = DataFrame(result)
-Markdown.parse(PrettyTables.pretty_table(String, data; backend=Val(:markdown), header=names(data)))
+backends = [
+    AutoEnzyme(Enzyme.Reverse),
+    AutoTapir(),
+    AutoZygote(),
+];
+
+scenarios = [
+    GradientScenario(paritytrig, x=rand(100)),
+    GradientScenario(paritytrig, x=rand(10_000))
+];
+
+result = benchmark_differentiation(backends, scenarios, logging=false);
+
+data = DataFrame(result);
+
+filtered_data = @chain data begin
+    @select(Not([:mode, :scenario, :mutating, :output_type, :output_size, :calls, :samples, :evals]))
+    @rsubset(string(:operator) in ["gradient!!"])
+end
+
+table = PrettyTables.pretty_table(
+    String,
+    filtered_data;
+    backend=Val(:markdown),
+    header=names(filtered_data),
+    formatters=PrettyTables.ft_printf("%.1e"),
+)
+
+Markdown.parse(table)
 ```
 
 ## Appendix

--- a/benchmarks/AutomaticDifferentiation/JuliaAD.jmd
+++ b/benchmarks/AutomaticDifferentiation/JuliaAD.jmd
@@ -51,8 +51,6 @@ table = PrettyTables.pretty_table(
 Markdown.parse(table)
 ```
 
-## Appendix
-
 ```julia, echo = false
 using SciMLBenchmarks
 SciMLBenchmarks.bench_footer(WEAVE_ARGS[:folder],WEAVE_ARGS[:file])

--- a/benchmarks/AutomaticDifferentiation/Manifest.toml
+++ b/benchmarks/AutomaticDifferentiation/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.2"
 manifest_format = "2.0"
-project_hash = "de834a127a4088bae2eac5b55ae09f9583d0d7a8"
+project_hash = "b6784f42a972b63a72274bb17079aece6bb5c494"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "016833eb52ba2d6bea9fcb50ca295980e728ee24"
@@ -82,6 +82,11 @@ version = "1.5.0"
 git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 version = "0.5.0"
+
+[[deps.Chain]]
+git-tree-sha1 = "9ae9be75ad8ad9d26395bf625dea9beac6d519f1"
+uuid = "8be319e6-bccf-4806-a6f7-6fae938471bc"
+version = "0.6.0"
 
 [[deps.ChainRules]]
 deps = ["Adapt", "ChainRulesCore", "Compat", "Distributed", "GPUArraysCore", "IrrationalConstants", "LinearAlgebra", "Random", "RealDot", "SparseArrays", "SparseInverseSubset", "Statistics", "StructArrays", "SuiteSparse"]
@@ -202,6 +207,12 @@ git-tree-sha1 = "04c738083f29f86e62c8afc341f0967d8717bdb8"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 version = "1.6.1"
 
+[[deps.DataFramesMeta]]
+deps = ["Chain", "DataFrames", "MacroTools", "OrderedCollections", "Reexport", "TableMetadataTools"]
+git-tree-sha1 = "f912a2126c99ff9783273efa38b0181bfbf9d322"
+uuid = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
+version = "0.15.2"
+
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
 git-tree-sha1 = "0f4b5d62a88d8f59003e43c25a8a90de9eb76317"
@@ -277,7 +288,7 @@ version = "0.1.0"
 
 [[deps.DifferentiationInterfaceTest]]
 deps = ["ADTypes", "Chairmarks", "ComponentArrays", "DifferentiationInterface", "DocStringExtensions", "JET", "JLArrays", "LinearAlgebra", "ProgressMeter", "SparseArrays", "StaticArrays", "Test"]
-git-tree-sha1 = "306b2cfc49d13b81b764a7eb44857b497a2347c5"
+git-tree-sha1 = "9a08dfcfc2850955f0dd12b465f6d337b7fb4196"
 repo-rev = "main"
 repo-subdir = "DifferentiationInterfaceTest"
 repo-url = "https://github.com/gdalle/DifferentiationInterface.jl"
@@ -925,6 +936,12 @@ deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 version = "1.0.3"
 
+[[deps.TableMetadataTools]]
+deps = ["DataAPI", "Dates", "TOML", "Tables", "Unitful"]
+git-tree-sha1 = "c0405d3f8189bb9a9755e429c6ea2138fca7e31f"
+uuid = "9ce81f87-eacc-4366-bf80-b621a3098ee2"
+version = "0.1.0"
+
 [[deps.TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
 git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
@@ -968,6 +985,20 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Unitful]]
+deps = ["Dates", "LinearAlgebra", "Random"]
+git-tree-sha1 = "3c793be6df9dd77a0cf49d80984ef9ff996948fa"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.19.0"
+
+    [deps.Unitful.extensions]
+    ConstructionBaseUnitfulExt = "ConstructionBase"
+    InverseFunctionsUnitfulExt = "InverseFunctions"
+
+    [deps.Unitful.weakdeps]
+    ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[deps.VersionParsing]]
 git-tree-sha1 = "58d6e80b4ee071f5efd07fda82cb9fbe17200868"

--- a/benchmarks/AutomaticDifferentiation/Project.toml
+++ b/benchmarks/AutomaticDifferentiation/Project.toml
@@ -1,11 +1,13 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DataFramesMeta = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 DifferentiationInterfaceTest = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SciMLBenchmarks = "31c91b34-3c75-11e9-0341-95557aab0344"
 Tapir = "07d77754-e150-4737-8c94-cd238a1fb45b"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"


### PR DESCRIPTION
Remove useless columns from the output of `DifferentiationInterfaceTest.benchmark_differentiation`