### PR TITLE
add clarification for SciMLBenchmarksOutput readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ will add all of the packages required to run any benchmark in the `NonStiffODE` 
 
 ## Contributing
 
-All of the files are generated from the Weave.jl files in the `benchmarks` folder. The generation process runs automatically,
+All of the files are generated from the Weave.jl files in the `benchmarks` folder of the [SciMLBenchmarks.jl](https://github.com/SciML/SciMLBenchmarks.jl) repository. The generation process runs automatically,
 and thus one does not necessarily need to test the Weave process locally. Instead, simply open a PR that adds/updates a
-file in the "benchmarks" folder and the PR will generate the benchmark on demand. Its artifacts can then be inspected in the
+file in the `benchmarks` folder and the PR will generate the benchmark on demand. Its artifacts can then be inspected in the
 Buildkite as described below before merging. Note that it will use the Project.toml and Manifest.toml of the subfolder, so
 any changes to dependencies requires that those are updated.
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I looked at this README on the SciMLBenchmarksOutput repo for a while and struggled to find the `benchmarks` folder. To avoid such confusion arising from this readme being mirrored there, it might make sense to clarify which repo is meant.

This is not new code, so nothing of the above applies, I believe.
