### PR TITLE
Move `OMJulia.quit` before returning figure from code block

### DIFF
--- a/benchmarks/ModelingToolkit/RCCircuit.jmd
+++ b/benchmarks/ModelingToolkit/RCCircuit.jmd
@@ -118,6 +118,7 @@ total_times = fill(NaN, length(N), length(max_sizes));
 for (i, n) in enumerate(N)
   @time run_and_time!(ss_times, times, max_sizes, i, n)
 end
+OMJulia.quit(omod) 
 
 f = Figure(size=(800,1200));
 ss_names = ["MTK", "JSIR-Scalar", "JSIR-Loop"];
@@ -142,7 +143,6 @@ let method_names_m = vcat(method_names, "OpenModelica");
   Legend(f[5, 2], _lines, method_names_m)
 end
 f
-OMJulia.quit(omod) 
 ```
 
 All three backends compiled more quickly with loops, but the C and LLVM backends are so much quicker to compile than the Julia backend that this made much less difference for them.


### PR DESCRIPTION
I had not tested it, but I am guessing the current version will not display the plot in the compiled markdown file. This PR addresses that.