### PR TITLE
Only use autodiff for the Julia backend

### DIFF
--- a/benchmarks/ModelingToolkit/ThermalFluid.jmd
+++ b/benchmarks/ModelingToolkit/ThermalFluid.jmd
@@ -282,7 +282,7 @@ function build_run_problem(fsys, N; target=JuliaSimCompiler.JuliaTarget())
   t_ss, t_fode, t_run
 end
 
-function test_speed(fsys, N; solver=FBDF(), target=JuliaSimCompiler.JuliaTarget())
+function test_speed(fsys, N; target=JuliaSimCompiler.JuliaTarget(), solver=FBDF(;autodiff = target===JuliaSimCompiler.JuliaTarget()))
     tspan = (0.0, 19*3600)
     t_total = @elapsed begin
         @named testbench = TestBenchPreinsulated(L=470, N=N, dn=0.3127, t_layer=[0.0056, 0.058])


### PR DESCRIPTION
The LLVM and C backends do not support autodiff. Due to a bug, they did not perform type checking. This will be fixed in the next release, so that the `solve`s would error instead of silently being wrong. Note that currently, the solves regularly report that they are succesful despite being wrong.