### PR TITLE
A few improvements to MatrixDepot benchmarks

### DIFF
--- a/benchmarks/LinearSolve/MatrixDepot.jmd
+++ b/benchmarks/LinearSolve/MatrixDepot.jmd
@@ -53,7 +53,6 @@ for z in 1:length(matrices)
         end
         p = bar(algnames, times[z, :];
             ylabel = "Time/s",
-            labels = algnames,
             yscale = :log10,
             title = "Time on $(matrices[z])",
             legend = :outertopright)

--- a/benchmarks/LinearSolve/MatrixDepot.jmd
+++ b/benchmarks/LinearSolve/MatrixDepot.jmd
@@ -4,7 +4,7 @@ author: Jürgen Fuhrmann, Anastasia Dunca
 ---
 
 ```julia
-using BenchmarkTools, Random, VectorizationBase
+using BenchmarkTools, Random, VectorizationBase, Statistics
 using LinearAlgebra, SparseArrays, LinearSolve, Sparspak
 import Pardiso
 using Plots
@@ -21,19 +21,15 @@ algs = [
     MKLPardisoFactorize(),
     SparspakFactorization(),
 ]
-
-__parameterless_type(T) = Base.typename(T).wrapper
-parameterless_type(x) = __parameterless_type(typeof(x))
-parameterless_type(::Type{T}) where {T} = __parameterless_type(T)
-algnames = string.(Symbol.(parameterless_type.(algs)))
+algnames = ["UMFPACK", "KLU", "Pardiso", "Sparspak"]
 
 cols = [:red, :blue, :green, :magenta, :turqoise] # one color per alg
 
 matrices = ["HB/1138_bus", "HB/494_bus", "HB/662_bus", "HB/685_bus", "HB/bcsstk01", "HB/bcsstk02", "HB/bcsstk03", "HB/bcsstk04", 
             "HB/bcsstk05", "HB/bcsstk06", "HB/bcsstk07", "HB/bcsstk08", "HB/bcsstk09", "HB/bcsstk10", "HB/bcsstk11", "HB/bcsstk12",
             "HB/bcsstk13", "HB/bcsstk14", "HB/bcsstk15", "HB/bcsstk16"]
-                
-res = [Float64[] for i in 1:length(algs)]
+
+times = fill(NaN, length(matrices), length(algs))
 ```
 
 ```julia
@@ -53,9 +49,9 @@ for z in 1:length(matrices)
                 u0 = copy($u0),
                 alias_A = true,
                 alias_b = true))
-            push!(res[j], bt)
+            times[z,j] = bt
         end
-        p = bar(algnames, res[j];
+        p = bar(algnames, times[z, :];
             ylabel = "Time/s",
             labels = algnames,
             yscale = :log10,
@@ -70,11 +66,11 @@ end
 ```
 
 ```julia
-meantimes = mean.(res)
+meantimes = vec(mean(times, dims=1))
 p = bar(algnames, meantimes;
     ylabel = "Time/s",
     yscale = :log10,
-    title = "Mean factorization time for NxN sparse LU Factorization of all Matrices",
+    title = "Mean factorization time",
     legend = :outertopright)
 ```
 

--- a/benchmarks/LinearSolve/MatrixDepot.jmd
+++ b/benchmarks/LinearSolve/MatrixDepot.jmd
@@ -39,7 +39,7 @@ for z in 1:length(matrices)
         A = mdopen(matrices[z]).A
         A = convert(SparseMatrixCSC, A)
         n = size(A, 1)
-        @info "dim=$(dim): $n × $n"
+        @info "$n × $n"
         b = rand(rng, n)
         u0 = rand(rng, n)
 

--- a/benchmarks/LinearSolve/MatrixDepot.jmd
+++ b/benchmarks/LinearSolve/MatrixDepot.jmd
@@ -55,21 +55,22 @@ for z in 1:length(matrices)
                 alias_b = true))
             push!(res[j], bt)
         end
-        p = bar(algnames, res;
+        p = bar(algnames, res[j];
             ylabel = "Time/s",
+            labels = algnames,
             yscale = :log10,
-            title = "Time for NxN  sparse LU Factorization of $(matrices[z])",
+            title = "Time on $(matrices[z])",
             legend = :outertopright)
         display(p)
-    catch
+    catch e
         println("$(matrices[z]) failed to factorize.")
+        println(e)
     end
 end
 ```
 
 ```julia
-algtimes = [[res[i][j] for i in 1:length(matrices)] for j in 1:length(algs)]
-meantimes = mean.(algtimes)
+meantimes = mean.(res)
 p = bar(algnames, meantimes;
     ylabel = "Time/s",
     yscale = :log10,

--- a/benchmarks/LinearSolve/MatrixDepot.jmd
+++ b/benchmarks/LinearSolve/MatrixDepot.jmd
@@ -21,82 +21,60 @@ algs = [
     MKLPardisoFactorize(),
     SparspakFactorization(),
 ]
+
+__parameterless_type(T) = Base.typename(T).wrapper
+parameterless_type(x) = __parameterless_type(typeof(x))
+parameterless_type(::Type{T}) where {T} = __parameterless_type(T)
+algnames = string.(Symbol.(parameterless_type.(algs)))
+
 cols = [:red, :blue, :green, :magenta, :turqoise] # one color per alg
 
 matrices = ["HB/1138_bus", "HB/494_bus", "HB/662_bus", "HB/685_bus", "HB/bcsstk01", "HB/bcsstk02", "HB/bcsstk03", "HB/bcsstk04", 
             "HB/bcsstk05", "HB/bcsstk06", "HB/bcsstk07", "HB/bcsstk08", "HB/bcsstk09", "HB/bcsstk10", "HB/bcsstk11", "HB/bcsstk12",
             "HB/bcsstk13", "HB/bcsstk14", "HB/bcsstk15", "HB/bcsstk16"]
                 
-__parameterless_type(T) = Base.typename(T).wrapper
-parameterless_type(x) = __parameterless_type(typeof(x))
-parameterless_type(::Type{T}) where {T} = __parameterless_type(T)
+res = [Float64[] for i in 1:length(algs)]
+```
 
-#
-# kmax=12 gives ≈ 40_000 unknowns max, can be watched in real time
-# kmax=15 gives ≈ 328_000 unknows, you can go make a coffee.
-# Main culprit is KLU factorization in 3D.
-#
-function run_and_plot(dim; kmax = 12)
-    ns = [10 * 2^k for k in 0:kmax]
+```julia
+for z in 1:length(matrices)
+    try
+        rng = MersenneTwister(123)
+        A = mdopen(matrices[z]).A
+        A = convert(SparseMatrixCSC, A)
+        n = size(A, 1)
+        @info "dim=$(dim): $n × $n"
+        b = rand(rng, n)
+        u0 = rand(rng, n)
 
-    res = [Float64[] for i in 1:length(algs)]
-
-    
-    for z in 1:length(matrices)
-        try
-            for i in 1:length(ns)
-                rng = MersenneTwister(123)
-                A = mdopen(matrices[z]).A
-                A = convert(SparseMatrixCSC, A)
-                n = size(A, 1)
-                @info "dim=$(dim): $n × $n"
-                b = rand(rng, n)
-                u0 = rand(rng, n)
-
-                for j in 1:length(algs)
-                    bt = @belapsed solve(prob, $(algs[j])).u setup=(prob = LinearProblem(copy($A),
-                        copy($b);
-                        u0 = copy($u0),
-                        alias_A = true,
-                        alias_b = true))
-                    push!(res[j], bt)
-                end
-            end
-
-            p = plot(;
-                ylabel = "Time/s",
-                xlabel = "N",
-                yscale = :log10,
-                xscale = :log10,
-                title = "Time for NxN  sparse LU Factorization $(dim)D",
-                label = string(Symbol(parameterless_type(algs[1]))),
-                legend = :outertopright)
-
-            for i in 1:length(algs)
-                plot!(p, ns, res[i];
-                    linecolor = cols[i],
-                    label = "$(string(Symbol(parameterless_type(algs[i]))))")
-            end
-            display(p)
-        catch
-            println(matrices[z])
+        for j in 1:length(algs)
+            bt = @belapsed solve(prob, $(algs[j])).u setup=(prob = LinearProblem(copy($A),
+                copy($b);
+                u0 = copy($u0),
+                alias_A = true,
+                alias_b = true))
+            push!(res[j], bt)
         end
-        end
-       
+        p = bar(algnames, res;
+            ylabel = "Time/s",
+            yscale = :log10,
+            title = "Time for NxN  sparse LU Factorization of $(matrices[z])",
+            legend = :outertopright)
+        display(p)
+    catch
+        println("$(matrices[z]) failed to factorize.")
+    end
 end
 ```
 
-
 ```julia
-run_and_plot(1)
-```
-
-```julia
-run_and_plot(2)
-```
-
-```julia
-run_and_plot(3)
+algtimes = [[res[i][j] for i in 1:length(matrices)] for j in 1:length(algs)]
+meantimes = mean.(algtimes)
+p = bar(algnames, meantimes;
+    ylabel = "Time/s",
+    yscale = :log10,
+    title = "Mean factorization time for NxN sparse LU Factorization of all Matrices",
+    legend = :outertopright)
 ```
 
 ## Appendix

--- a/benchmarks/LinearSolve/Project.toml
+++ b/benchmarks/LinearSolve/Project.toml
@@ -11,6 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLBenchmarks = "31c91b34-3c75-11e9-0341-95557aab0344"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Sparspak = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]


### PR DESCRIPTION
1. Make the try/catch be per matrix, so that it can continue onto the next matrix. This is preparing it for a larger run.
2. Setup a mean factorization time display. In theory this should be the mean over classes of matrices, but for now this is just the mean over all.
3. Removes the extra functions, keep it simple