### PR TITLE
Fix typo in BrussScaling.jmd

### DIFF
--- a/benchmarks/AutomaticDifferentiation/BrussScaling.jmd
+++ b/benchmarks/AutomaticDifferentiation/BrussScaling.jmd
@@ -256,8 +256,8 @@ csa = map(csan) do n
     @info "Running $alg"
     f = SciMLSensitivity.alg_autodiff(alg) ? bfun : ODEFunction(bfun, jac=brusselator_jac)
     solver = Rodas5(autodiff=false)
-    @time diffeq_sen_l2(bfun, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
-    t = @elapsed diffeq_sen_l2(bfun, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
+    @time diffeq_sen_l2(f, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
+    t = @elapsed diffeq_sen_l2(f, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
     return t
   end
   @show n,ts
@@ -310,8 +310,8 @@ csavjp = map(csan) do n
     @info "Running $alg"
     f = SciMLSensitivity.alg_autodiff(alg) ? bfun : ODEFunction(bfun, jac=brusselator_jac)
     solver = Rodas5(autodiff=false)
-    @time diffeq_sen_l2(bfun, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
-    t = @elapsed diffeq_sen_l2(bfun, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
+    @time diffeq_sen_l2(f, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
+    t = @elapsed diffeq_sen_l2(f, b_u0, tspan, b_p, bt, solver; sensalg=alg, tols...)
     return t
   end
   @show n,ts


### PR DESCRIPTION
Function `f` was not used and because of that user-defined `brusselator_jac` was not used either.

## Additional context

Bug was found during the discussion on Julia Discourse ([link to the discussion](https://discourse.julialang.org/t/discrepancy-of-ode-sensitivity-analysis-paper-results-with-benchmarks/129853/26))