### PR TITLE
Update simpleintervalrootfind.jmd

### DIFF
--- a/benchmarks/IntervalNonlinearProblem/simpleintervalrootfind.jmd
+++ b/benchmarks/IntervalNonlinearProblem/simpleintervalrootfind.jmd
@@ -22,7 +22,7 @@ out = zeros(N);
 myfun(x, lv) = x * sin(x) - lv
 function froots(out, levels, u0)
     for i in 1:N
-        out[i] = find_zero(myfun, u0, levels[i])
+        out[i] = solve(ZeroProblem(myfun, u0), levels[i])
     end
 end
 


### PR DESCRIPTION
A slightly more comparable comparison.

This uses `solve` not `find_zero` which in `Roots` is a bit faster as it return `NaN` on an error.

## Checklist

- [ NA] Appropriate tests were added
- [ NA] Any code changes were done in a way that does not break public API
- [ NA] All documentation related to code changes were updated
- [ NA] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ NA] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
