### PR TITLE
CompatHelper: consolidate version bumps for multiple packages

### DIFF
--- a/benchmarks/HybridJumps/Project.toml
+++ b/benchmarks/HybridJumps/Project.toml
@@ -19,7 +19,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 BenchmarkTools = "1.4"
 Catalyst = "15"
-DataStructures = "0.18"
+DataStructures = "0.19"
 DiffEqCallbacks = "4"
 Distributions = "0.25"
 JumpProcesses = "9.9"

--- a/benchmarks/HybridJumps/Project.toml
+++ b/benchmarks/HybridJumps/Project.toml
@@ -19,7 +19,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 BenchmarkTools = "1.4"
 Catalyst = "15"
-DataStructures = "0.19"
+DataStructures = "0.18, 0.19"
 DiffEqCallbacks = "4"
 Distributions = "0.25"
 JumpProcesses = "9.9"

--- a/benchmarks/SimpleHandwrittenPDE/Project.toml
+++ b/benchmarks/SimpleHandwrittenPDE/Project.toml
@@ -13,8 +13,13 @@ SummationByPartsOperators = "9f78cca6-572e-554e-b819-917d2f1cf240"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 
 [compat]
+ClassicalOrthogonalPolynomials = "0.15"
 DiffEqDevTools = "2.22"
+LinearSolve = "3"
 LSODA = "0.6, 0.7"
+OrdinaryDiffEq = "6"
 Plots = "1.4"
 SciMLBenchmarks = "0.1"
+SciMLOperators = "1"
+SummationByPartsOperators = "0.5"
 Sundials = "4.2"


### PR DESCRIPTION
## Summary
This PR consolidates all pending CompatHelper version bumps into a single PR:

- **SimpleHandwrittenPDE**: Added compat entries for:
  - SciMLOperators = "1"
  - LinearSolve = "3" 
  - OrdinaryDiffEq = "6"
  - SummationByPartsOperators = "0.5"
  - ClassicalOrthogonalPolynomials = "0.15"

- **HybridJumps**: Bumped DataStructures from "0.18" to "0.19"

## Test plan
- [x] Applied all version bumps to respective Project.toml files
- [x] Verified package instantiation and precompilation works correctly
- [ ] Individual benchmark tests may be run as needed

This consolidates PRs #1315, #1314, #1313, #1312, #1311, and #1310.

🤖 Generated with [Claude Code](https://claude.ai/code)