### PR TITLE
Fix ND problems stack overflow in Enright-Pryce benchmarks

### DIFF
--- a/benchmarks/NonStiffODE/enright_pryce.jl
+++ b/benchmarks/NonStiffODE/enright_pryce.jl
@@ -502,11 +502,14 @@ const NC_PROBLEMS = [nc1prob, nc2prob, nc3prob, nc4prob, nc5prob]
 y = collect(y)
 @parameters ε
 nd1sys = complete(let
-    r = sqrt(y[1]^2 + y[2]^2)^3
+    # Use intermediate variable to avoid complex symbolic expansion
+    # r_cubed = (x^2 + y^2)^(3/2) for the gravitational force law
+    r_squared = y[1]^2 + y[2]^2
+    r_cubed = r_squared * sqrt(r_squared)
     nd1eqs = [D(y[1]) ~ y[3],
         D(y[2]) ~ y[4],
-        D(y[3]) ~ (-y[1]) / r,
-        D(y[4]) ~ (-y[2]) / r
+        D(y[3]) ~ (-y[1]) / r_cubed,
+        D(y[4]) ~ (-y[2]) / r_cubed
     ]
     ODESystem(nd1eqs, t, name = :nd1)
 end)


### PR DESCRIPTION
## Summary

- Fixed stack overflow errors in ND1-ND5 problems in the Enright-Pryce benchmark suite
- Simplified symbolic expressions to avoid ModelingToolkit compilation issues  
- Maintained mathematical correctness while improving compilation stability

## Problem

The ND problems (orbital mechanics/Kepler orbit benchmarks) were causing stack overflow errors during compilation. The root cause was the complex symbolic expression:

```julia
r = sqrt(y[1]^2 + y[2]^2)^3
```

When used in the gravitational force equations `(-y[1]) / r` and `(-y[2]) / r`, this created overly complex symbolic manipulations that caused ModelingToolkit's symbolic engine to exceed stack limits during compilation.

## Solution

Replaced the complex expression with mathematically equivalent intermediate variables:

```julia  
# Before (causes stack overflow):
r = sqrt(y[1]^2 + y[2]^2)^3

# After (compiles successfully):
r_squared = y[1]^2 + y[2]^2
r_cubed = r_squared * sqrt(r_squared)  
```

This represents the same physics (gravitational force law `F ∝ 1/r³`) but breaks down the symbolic computation into manageable steps.

## Test Plan

- [x] Verified ND problems compile without stack overflow
- [x] Confirmed mathematical equivalence of the expressions
- [x] All five ND problems (ND1-ND5) with different eccentricities should now work
- [ ] Run full benchmark suite to verify performance characteristics unchanged

The fix specifically addresses the compilation issue reported in the [Enright-Pryce benchmarks documentation](https://docs.sciml.ai/SciMLBenchmarksOutput/dev/NonStiffODE/EnrightPryce_wpd/) where all ND problems showed "StackOverflowError".

🤖 Generated with [Claude Code](https://claude.ai/code)