### PR TITLE
Make benchmark change detection cumulative on master pushes

### DIFF
--- a/.github/scripts/detect-changed-benchmarks.sh
+++ b/.github/scripts/detect-changed-benchmarks.sh
@@ -22,8 +22,32 @@ if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
     git fetch origin "${BASE_SHA}" --depth=1 2>/dev/null || true
     CHANGED_FILES=$(git diff --name-only "origin/${BASE_SHA}...HEAD" -- 'benchmarks/')
 else
-    # Push event: compare with parent commit
-    CHANGED_FILES=$(git diff --name-only HEAD~1 -- 'benchmarks/' 2>/dev/null || true)
+    # Push event: compare against the last commit that was successfully published
+    # to SciMLBenchmarksOutput. This makes change detection cumulative — if a
+    # previous master push run was cancelled (because rapid merges queue and
+    # GHA cancels queued runs), this run still picks up its changes.
+    #
+    # The output repo's build commits have format "build based on <SHA>" or
+    # "Published by build of: SciML/SciMLBenchmarks.jl@<SHA>". We fetch the
+    # most recent one and diff against that SHA.
+    LAST_BUILT_SHA=""
+    if command -v curl >/dev/null 2>&1; then
+        LAST_BUILT_SHA=$(curl -s -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/SciML/SciMLBenchmarksOutput/commits?per_page=20" 2>/dev/null \
+            | grep -oE '"message":[^"]*"[^"]*"' \
+            | grep -oE 'SciMLBenchmarks\.jl@[a-f0-9]{40}' \
+            | head -1 \
+            | sed 's/SciMLBenchmarks\.jl@//')
+    fi
+
+    if [[ -n "${LAST_BUILT_SHA}" ]] && git cat-file -e "${LAST_BUILT_SHA}^{commit}" 2>/dev/null; then
+        echo "Diffing against last published SHA: ${LAST_BUILT_SHA}" >&2
+        CHANGED_FILES=$(git diff --name-only "${LAST_BUILT_SHA}" HEAD -- 'benchmarks/' 2>/dev/null || true)
+    else
+        # Fallback: compare with parent commit (original behavior)
+        echo "Last published SHA not available; falling back to HEAD~1 diff" >&2
+        CHANGED_FILES=$(git diff --name-only HEAD~1 -- 'benchmarks/' 2>/dev/null || true)
+    fi
 fi
 
 declare -A FILES     # .jmd file -> its project directory


### PR DESCRIPTION
## Summary

When multiple PRs merge in rapid succession, GitHub Actions cancels **queued** workflow runs when newer commits arrive on the same branch's concurrency group — even with \`cancel-in-progress: false\`. The protection only applies to the *currently running* job, not queued ones.

This caused real production issues: PRs #1533, #1535, #1538, #1540, #1541, #1543 all had their master push CI runs cancelled, leaving SciMLBenchmarksOutput with stale outputs that didn't reflect the merged source fixes. Verified directly via API: those runs have \`conclusion: cancelled\` and \`jobs: []\`.

## Root cause

\`detect-changed-benchmarks.sh\` diffs against \`HEAD~1\` on push events. So when N commits land but only the last one's run survives, only the last commit's diff gets detected — the cancelled-in-between commits' changes are silently lost.

## Fix

On master pushes, query SciMLBenchmarksOutput's recent commits via the GitHub API and find the most recent \"Published by build of: SciML/SciMLBenchmarks.jl@<SHA>\" message. Use that SHA as the diff base instead of \`HEAD~1\`.

This makes change detection **cumulative**: the surviving run rebuilds everything changed since the last successful publish, regardless of how many in-between runs were cancelled.

Falls back to the original \`HEAD~1\` behavior if the API call fails or the SHA isn't reachable in the local clone.

## Why this is safe

- PR events are unchanged (still diffs against \`origin/<base>...HEAD\`)
- Only affects the diff base for push events
- The detected target list only contains files that exist in the current tree, so already-deleted files won't trigger spurious rebuilds
- \`fetch-depth: 0\` is already set in the workflow, so any historical SHA is reachable

## Test plan
- [ ] After merge, simulate the cancellation scenario by checking detection works correctly when given an older SHA
- [ ] Future rapid PR merges produce a single cumulative rebuild instead of losing changes
- [ ] PR #1546 (which manually retriggers the lost builds) becomes unnecessary for this category of issue going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)