### PR TITLE
Fix RingModulator: use permutedims for Vector{String} title

### DIFF
--- a/benchmarks/StiffODE/RingModulator.jmd
+++ b/benchmarks/StiffODE/RingModulator.jmd
@@ -85,7 +85,7 @@ inputs at 1kHz and 10kHz.
 Reference plots from the IVP Test Set show oscillatory behavior in all components over [0, 1e-3]:
 
 ```julia
-plot(sol, layout=(3,5), size=(1200,600), title=["y$i" for i in 1:15]',
+plot(sol, layout=(3,5), size=(1200,600), title=permutedims(["y$i" for i in 1:15]),
     legend=false, fmt=:png)
 ```
 


### PR DESCRIPTION
## Summary
- `'` (adjoint) is not defined for `Vector{String}` in modern Julia, causing `MethodError: no method matching adjoint(::String)` at line 88 of `RingModulator.jmd`
- Replace with `permutedims(...)` which produces the same row-vector layout needed for per-subplot titles in Plots.jl

This bug only surfaced now because RingModulator had no published output before — PR #1546's retrigger ran the benchmark for the first time after PR #1533's `OrdinaryDiffEqCore` fix made it possible to even reach the plotting step.

## Test plan
- [ ] RingModulator runs without `MethodError: no method matching adjoint(::String)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)