### PR TITLE
Publish partial successes instead of all-or-nothing

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -112,7 +112,12 @@ jobs:
   publish:
     name: Publish Results
     needs: benchmark
-    if: always() && github.ref == 'refs/heads/master' && needs.benchmark.result == 'success'
+    # Publish whenever the benchmark stage actually ran (success OR failure),
+    # so one folder's failure doesn't block other folders' artifacts from
+    # reaching SciMLBenchmarksOutput. download-artifact pulls only artifacts
+    # that were actually uploaded (only successful builds upload), and
+    # publish_benchmark_output.sh is a no-op when there's nothing new.
+    if: always() && github.ref == 'refs/heads/master' && (needs.benchmark.result == 'success' || needs.benchmark.result == 'failure')
     runs-on: [self-hosted, benchmark]
     concurrency:
       group: scimlbenchmarks-deploy
@@ -125,6 +130,7 @@ jobs:
         with:
           pattern: benchmark-*
           merge-multiple: true
+        continue-on-error: true
 
       - name: Publish to SciMLBenchmarksOutput
         run: .github/scripts/publish_benchmark_output.sh


### PR DESCRIPTION
## Summary

The publish job in `.github/workflows/benchmarks.yml` was gated on `needs.benchmark.result == 'success'`, requiring *every* matrix job to succeed before any folder's artifacts could reach SciMLBenchmarksOutput. In practice, one failed (or queued-then-cancelled-by-timeout) folder strands every other folder's output indefinitely.

This was the root cause of v7-stack outputs sitting unpublished for 10+ days — run [25374549824](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/25374549824) had 5 successes, 4 failures, 27 cancellations, and 1 stuck job, so the publish gate never opened.

## Change

Relax the gate to fire when the matrix completes with `success` OR `failure`. Safety holds:

- `download-artifact` only retrieves artifacts that were actually uploaded; `upload-artifact` is already gated on `if: success()`, so only successful folders' outputs are pulled.
- `publish_benchmark_output.sh` is already a no-op when there's nothing to commit, so a fully-failed matrix doesn't push anything spurious.
- Added `continue-on-error: true` to `download-artifact` as belt-and-suspenders.

The `cancelled` and `skipped` cases stay excluded — those shouldn't trigger a publish.

## Test plan

- [ ] Merge → next normal master push triggers publish path
- [ ] A run with mixed success/failure publishes only the successful folders' outputs

## Note for review

Please ignore until reviewed by @ChrisRackauckas.