### PR TITLE
Bump Weekly Update workflow to Julia 1.10

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
       - name: update step
         uses: julia-actions/setup-julia@v3
         with:
-          version: 1.6.0
+          version: '1.10'
       - name: Check for updates and create a PR
         run: |
               git config --local user.email "$(git log --format='%ae' HEAD^!)"


### PR DESCRIPTION
## Summary

`.github/workflows/update.yml` (the cron-driven Weekly Update job that produces dependency-bump PRs) pins Julia to **1.6.0**. Since current Manifests in this repo are written by Julia 1.10+, the 1.6.0 `Pkg.update()` fails with:

```
ERROR: LoadError: MethodError: no method matching get(::Pair{String, Any}, ::String, ::Nothing)
... in Pkg.update() at update.jl:33
```

This has been failing every Saturday — most recent failure run [25594289462](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/25594289462) on 2026-05-09. The implication is that no weekly dependency-bump PRs have been opened for some time.

## Change

Bump to `'1.10'` (the current LTS, matching the Julia floor in `.github/benchmark_defaults.toml`).

## Test plan

- [ ] Merge → next Saturday cron fires successfully, OR trigger via `workflow_dispatch` to verify.

## Note for review

Please ignore until reviewed by @ChrisRackauckas.