### PR TITLE
Retrigger v7 outputs for 5 cancelled folders (batch 1)

### DIFF
--- a/benchmarks/IntervalNonlinearProblem/Project.toml
+++ b/benchmarks/IntervalNonlinearProblem/Project.toml
@@ -14,3 +14,5 @@ Roots = "2"
 SciMLBenchmarks = "0.1"
 SimpleNonlinearSolve = "2"
 Statistics = "1"
+
+# CI retrigger: v7 stack outputs (2026-05-15)

--- a/benchmarks/NonStiffBVP/Project.toml
+++ b/benchmarks/NonStiffBVP/Project.toml
@@ -25,3 +25,5 @@ OrdinaryDiffEqLowOrderRK = "2"
 Plots = "1.4"
 SciMLBenchmarks = "0.1"
 SimpleBoundaryValueDiffEq = "1.2"
+
+# CI retrigger: v7 stack outputs (2026-05-15)

--- a/benchmarks/NonStiffDDE/Project.toml
+++ b/benchmarks/NonStiffDDE/Project.toml
@@ -17,3 +17,5 @@ OrdinaryDiffEqLowOrderRK = "2"
 Plots = "1.4"
 SciMLBenchmarks = "0.1"
 StaticArrays = "1"
+
+# CI retrigger: v7 stack outputs (2026-05-15)

--- a/benchmarks/StiffBVP/Project.toml
+++ b/benchmarks/StiffBVP/Project.toml
@@ -19,3 +19,5 @@ Interpolations = "0.15.1, 0.16"
 ODEInterface = "0.5"
 SciMLBenchmarks = "0.1"
 StaticArrays = "1.9.8"
+
+# CI retrigger: v7 stack outputs (2026-05-15)

--- a/benchmarks/Testing/Project.toml
+++ b/benchmarks/Testing/Project.toml
@@ -5,3 +5,5 @@ SciMLBenchmarks = "31c91b34-3c75-11e9-0341-95557aab0344"
 [compat]
 Plots = "1.13"
 SciMLBenchmarks = "0.1"
+
+# CI retrigger: v7 stack outputs (2026-05-15)


### PR DESCRIPTION
## Summary

Re-queues five benchmark folders whose Manifests resolved cleanly under the v7 stack ([#1551](https://github.com/SciML/SciMLBenchmarks.jl/pull/1551)) but which never built outputs because they were cancelled by the 24h queue-wait timeout in run [25374549824](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/25374549824):

- `benchmarks/Testing`
- `benchmarks/IntervalNonlinearProblem`
- `benchmarks/NonStiffBVP`
- `benchmarks/StiffBVP`
- `benchmarks/NonStiffDDE`

## Mechanism

This PR is a no-op apart from a one-line comment appended to each Project.toml. That comment is enough for `detect-changed-benchmarks.sh` to mark each folder as changed and queue it into the matrix.

## Why small batches

The previous run cancelled 27 folders because the matrix saturated the self-hosted benchmark runners and the rest of the queue exceeded the 24h queue-wait limit. Doing this in batches of ~5 keeps the queue manageable. More retrigger PRs to follow once these ones complete.

## Recommended merge order

This PR's output will only auto-publish if [#1556](https://github.com/SciML/SciMLBenchmarks.jl/pull/1556) (publish-gate fix) lands first — otherwise any single failure here will keep the whole batch's outputs from reaching SciMLBenchmarksOutput.

## Note for review

Please ignore until reviewed by @ChrisRackauckas.