### PR TITLE
Retrigger v7 outputs for 5 cancelled folders (batch 2)

### DIFF
--- a/benchmarks/AutomaticDifferentiation/Project.toml
+++ b/benchmarks/AutomaticDifferentiation/Project.toml
@@ -47,3 +47,5 @@ SciMLSensitivity = "7"
 StaticArrays = "1"
 Tracker = "0.2"
 Zygote = "0.7"
+
+# CI retrigger: v7 stack outputs batch 2 (2026-05-15)

--- a/benchmarks/AutomaticDifferentiationSparse/Project.toml
+++ b/benchmarks/AutomaticDifferentiationSparse/Project.toml
@@ -38,3 +38,5 @@ SparseMatrixColorings = "0.4"
 Symbolics = "7"
 Weave = "0.10"
 Zygote = "0.7"
+
+# CI retrigger: v7 stack outputs batch 2 (2026-05-15)

--- a/benchmarks/MultiLanguage/Project.toml
+++ b/benchmarks/MultiLanguage/Project.toml
@@ -24,3 +24,5 @@ ParameterizedFunctions = "5.3"
 SciMLBenchmarks = "0.1"
 SciMLLogging = "1, 2"
 StaticArrays = "1"
+
+# CI retrigger: v7 stack outputs batch 2 (2026-05-15)

--- a/benchmarks/NBodySimulator/Project.toml
+++ b/benchmarks/NBodySimulator/Project.toml
@@ -19,3 +19,5 @@ ProgressLogging = "0.1"
 SciMLBenchmarks = "0.1"
 StaticArrays = "1.0"
 StatsPlots = "0.14, 0.15"
+
+# CI retrigger: v7 stack outputs batch 2 (2026-05-15)

--- a/benchmarks/NonlinearProblem/Project.toml
+++ b/benchmarks/NonlinearProblem/Project.toml
@@ -61,3 +61,5 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+
+# CI retrigger: v7 stack outputs batch 2 (2026-05-15)


### PR DESCRIPTION
## Summary

Re-queues five more benchmark folders whose Manifests resolved cleanly under the v7 stack ([#1551](https://github.com/SciML/SciMLBenchmarks.jl/pull/1551)) but were cancelled by the 24h queue-wait timeout in run [25374549824](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/25374549824):

- `benchmarks/AutomaticDifferentiation`
- `benchmarks/AutomaticDifferentiationSparse`
- `benchmarks/NBodySimulator`
- `benchmarks/MultiLanguage`
- `benchmarks/NonlinearProblem`

Builds on [#1558](https://github.com/SciML/SciMLBenchmarks.jl/pull/1558) (batch 1). With [#1556](https://github.com/SciML/SciMLBenchmarks.jl/pull/1556) already in master, partial successes will auto-publish.

Mechanism: one-line comment appended to each Project.toml so `detect-changed-benchmarks.sh` queues them.

## Note for review

Please ignore until reviewed by @ChrisRackauckas.