### PR TITLE
Retrigger v7 outputs for 5 cancelled folders (batch 3)

### DIFF
--- a/benchmarks/ComplicatedPDE/Project.toml
+++ b/benchmarks/ComplicatedPDE/Project.toml
@@ -50,3 +50,5 @@ SciMLLogging = "1, 2"
 StableRNGs = "1"
 Sundials = "6"
 Symbolics = "7"
+
+# CI retrigger: v7 stack outputs batch 3 (2026-05-15)

--- a/benchmarks/DynamicalODE/Project.toml
+++ b/benchmarks/DynamicalODE/Project.toml
@@ -29,3 +29,4 @@ SciMLBenchmarks = "0.1"
 StaticArrays = "1.0"
 Statistics = "1"
 TaylorIntegration = "0.18"
+# CI retrigger: v7 stack outputs batch 3 (2026-05-15)

--- a/benchmarks/StiffODE/Project.toml
+++ b/benchmarks/StiffODE/Project.toml
@@ -68,3 +68,5 @@ StaticArrays = "1"
 Sundials = "6"
 Symbolics = "7"
 TimerOutputs = "0.5"
+
+# CI retrigger: v7 stack outputs batch 3 (2026-05-15)

--- a/benchmarks/StiffSDE/Project.toml
+++ b/benchmarks/StiffSDE/Project.toml
@@ -19,3 +19,5 @@ SciMLBenchmarks = "0.1"
 SciMLLogging = "1, 2"
 Statistics = "1"
 StochasticDiffEq = "7"
+
+# CI retrigger: v7 stack outputs batch 3 (2026-05-15)

--- a/benchmarks/Surrogates/Project.toml
+++ b/benchmarks/Surrogates/Project.toml
@@ -17,3 +17,5 @@ PythonCall = "0.9"
 Statistics = "1"
 Surrogates = "7"
 XGBoost = "2"
+
+# CI retrigger: v7 stack outputs batch 3 (2026-05-15)


### PR DESCRIPTION
## Summary

Re-queues five more cancelled folders from the v7 stack rollout. Builds on [#1558](https://github.com/SciML/SciMLBenchmarks.jl/pull/1558) (batch 1) and [#1559](https://github.com/SciML/SciMLBenchmarks.jl/pull/1559) (batch 2):

- `benchmarks/ComplicatedPDE`
- `benchmarks/DynamicalODE`
- `benchmarks/StiffODE`
- `benchmarks/StiffSDE`
- `benchmarks/Surrogates`

Mechanism: one-line comment appended to each Project.toml.

## Note for review

Please ignore until reviewed by @ChrisRackauckas.