### PR TITLE
Retrigger v7 outputs for 6 cancelled folders (batch 4: optimization/PINN/NN)

### DIFF
--- a/benchmarks/GlobalOptimization/Project.toml
+++ b/benchmarks/GlobalOptimization/Project.toml
@@ -31,3 +31,5 @@ OptimizationPyCMA = "1"
 OptimizationSciPy = "0.4.1"
 Plots = "1.4"
 SciMLBenchmarks = "0.1"
+
+# CI retrigger: v7 stack outputs batch 4 (2026-05-15)

--- a/benchmarks/NeuralNetworks/Project.toml
+++ b/benchmarks/NeuralNetworks/Project.toml
@@ -28,3 +28,5 @@ Reactant = "0.2"
 SimpleChains = "0.4"
 Statistics = "1"
 Zygote = "0.6, 0.7"
+
+# CI retrigger: v7 stack outputs batch 4 (2026-05-15)

--- a/benchmarks/OptimizationCUTEst/Project.toml
+++ b/benchmarks/OptimizationCUTEst/Project.toml
@@ -33,3 +33,5 @@ Statistics = "1"
 StatsBase = "0.34"
 StatsPlots = "0.15"
 julia = "1"
+
+# CI retrigger: v7 stack outputs batch 4 (2026-05-15)

--- a/benchmarks/OptimizationFrameworks/Project.toml
+++ b/benchmarks/OptimizationFrameworks/Project.toml
@@ -49,3 +49,5 @@ ReverseDiff = "1"
 StableRNGs = "1"
 SymbolicIndexingInterface = "0.3"
 Symbolics = "7"
+
+# CI retrigger: v7 stack outputs batch 4 (2026-05-15)

--- a/benchmarks/PINNErrorsVsTime/Project.toml
+++ b/benchmarks/PINNErrorsVsTime/Project.toml
@@ -33,3 +33,5 @@ Plots = "1"
 QuasiMonteCarlo = "0.3"
 ReverseDiff = "1"
 SciMLBenchmarks = "0.1"
+
+# CI retrigger: v7 stack outputs batch 4 (2026-05-15)

--- a/benchmarks/PINNOptimizers/Project.toml
+++ b/benchmarks/PINNOptimizers/Project.toml
@@ -17,3 +17,5 @@ OptimizationOptimJL = "0.4"
 OptimizationOptimisers = "0.3"
 Plots = "1"
 SciMLBenchmarks = "0.1"
+
+# CI retrigger: v7 stack outputs batch 4 (2026-05-15)


### PR DESCRIPTION
## Summary

Re-queues six more cancelled folders from the v7 stack rollout (optimization, PINN, neural networks family). Builds on [#1558](https://github.com/SciML/SciMLBenchmarks.jl/pull/1558), [#1559](https://github.com/SciML/SciMLBenchmarks.jl/pull/1559), [#1560](https://github.com/SciML/SciMLBenchmarks.jl/pull/1560):

- `benchmarks/GlobalOptimization`
- `benchmarks/OptimizationCUTEst`
- `benchmarks/OptimizationFrameworks`
- `benchmarks/PINNErrorsVsTime`
- `benchmarks/PINNOptimizers`
- `benchmarks/NeuralNetworks`

Mechanism: one-line comment appended to each Project.toml.

## Coordination note

`OptimizationCUTEst` overlaps with the work in open PR [#1555](https://github.com/SciML/SciMLBenchmarks.jl/pull/1555) (Optimization.jl interface alignment, currently with failing CI). If #1555 lands first, this retrigger for CUTEst is redundant.

## Note for review

Please ignore until reviewed by @ChrisRackauckas.