### PR TITLE
Fix detect-changes failing on unauth API rate limit

### DIFF
--- a/.github/scripts/detect-changed-benchmarks.sh
+++ b/.github/scripts/detect-changed-benchmarks.sh
@@ -32,12 +32,24 @@ else
     # most recent one and diff against that SHA.
     LAST_BUILT_SHA=""
     if command -v curl >/dev/null 2>&1; then
-        LAST_BUILT_SHA=$(curl -s -H "Accept: application/vnd.github+json" \
+        # Use GITHUB_TOKEN when available to bypass the 60-req/hour anonymous
+        # rate limit (the unauth limit is shared per IP across all GHA runners
+        # and gets hit easily — when it does, the API returns a JSON error,
+        # the SciMLBenchmarks.jl@<sha> grep finds nothing, pipefail trips, and
+        # `set -e` aborts the script before fallback can kick in).
+        AUTH_HEADER=()
+        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+            AUTH_HEADER=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+        fi
+        # Wrap in `|| true` so a non-matching grep (e.g. rate limited, network
+        # blip, or output repo briefly empty) cleanly falls through to the
+        # HEAD~1 fallback rather than aborting the whole workflow.
+        LAST_BUILT_SHA=$( { curl -s "${AUTH_HEADER[@]}" -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/SciML/SciMLBenchmarksOutput/commits?per_page=20" 2>/dev/null \
             | grep -oE '"message":[^"]*"[^"]*"' \
             | grep -oE 'SciMLBenchmarks\.jl@[a-f0-9]{40}' \
             | head -1 \
-            | sed 's/SciMLBenchmarks\.jl@//')
+            | sed 's/SciMLBenchmarks\.jl@//'; } || true)
     fi
 
     if [[ -n "${LAST_BUILT_SHA}" ]] && git cat-file -e "${LAST_BUILT_SHA}^{commit}" 2>/dev/null; then

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Detect changed benchmarks
         id: detect
         run: .github/scripts/detect-changed-benchmarks.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # When manually triggered with a specific target
   manual-matrix:


### PR DESCRIPTION
## Summary

Master Benchmarks run [25920610513](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/25920610513) (triggered by PR #1558 merge) failed at `Detect Changed Benchmarks` with exit code 1 in **~200ms** — before any visible work. As a result, the v7 batch-1 outputs from that run never made it to SciMLBenchmarksOutput.

## Root cause

`.github/scripts/detect-changed-benchmarks.sh` calls `api.github.com/repos/SciML/SciMLBenchmarksOutput/commits` with no auth header, so it uses the anonymous **60-req/hour/IP** rate limit. That limit is shared across all GHA-hosted runners on the same egress IP and is easy to hit.

When the limit is hit:
1. The API returns `{"message":"API rate limit exceeded..."}` (HTTP 403).
2. The first `grep -oE` matches the literal `message` field but the second `grep -oE 'SciMLBenchmarks\.jl@[a-f0-9]{40}'` finds nothing → exits 1.
3. `set -eo pipefail` is in effect → pipefail propagates to the `LAST_BUILT_SHA=$(...)` assignment.
4. `set -e` kills the script before the `[[ -n "${LAST_BUILT_SHA}" ]]` check can fall through to the HEAD~1 fallback the comment claims it will.

## Fix

1. **Auth the curl** with `Authorization: Bearer ${GITHUB_TOKEN}` when the env var is set. Bumps the limit to 5000 req/hour and is per-installation, not per-IP.
2. **Wrap the pipeline in `{ ...; } || true`** so a transient API hiccup or empty output repo cleanly falls through to the HEAD~1 fallback instead of aborting the whole workflow.
3. **Pass `secrets.GITHUB_TOKEN`** to the Detect step in `benchmarks.yml`.

## Test plan

- [ ] Merge → next master push triggers detect-changes → completes successfully on the v7 batch-1 commit set
- [ ] Confirm publish step actually runs and pushes to SciMLBenchmarksOutput

## Urgency

This is the *only* thing blocking the v7 batch-1 outputs from publishing — without this fix, master 25920610513's failure means the 5 batch-1 folders (Testing, IntervalNonlinearProblem, NonStiffBVP, StiffBVP, NonStiffDDE) never make it to the docs site, and every future master push will hit the same wall.

Please ignore until reviewed by @ChrisRackauckas.