### PR TITLE
Retrigger StiffODE (single-folder, infra-failed in burst-dispatch)

### DIFF
--- a/benchmarks/StiffODE/Project.toml
+++ b/benchmarks/StiffODE/Project.toml
@@ -68,3 +68,5 @@ StaticArrays = "1"
 Sundials = "6"
 Symbolics = "7"
 TimerOutputs = "0.5"
+
+# CI retrigger (single-folder): StiffODE infra-failed in burst-dispatch on amdci3-1 (2026-05-16)


### PR DESCRIPTION
## Summary

Single-folder retrigger PR for `benchmarks/StiffODE`. It failed in the 2026-05-16 07:58 UTC burst on amdci3-1 with the runner-state-corruption pattern (`Missing file at path: ..._runner_file_commands/...`), not a real benchmark failure.

Single-folder matrix to avoid intra-PR collisions per Chris's direction. Once the master detect-changes fix ([#1562](https://github.com/SciML/SciMLBenchmarks.jl/pull/1562)) is merged, this will auto-publish on merge.

Please ignore until reviewed by @ChrisRackauckas.