### PR TITLE
Retrigger NonlinearProblem (single-folder, infra-failed in burst-dispatch)

### DIFF
--- a/benchmarks/NonlinearProblem/Project.toml
+++ b/benchmarks/NonlinearProblem/Project.toml
@@ -61,3 +61,5 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+
+# CI retrigger (single-folder): NonlinearProblem infra-failed in burst-dispatch on amdci3-1 (2026-05-16)


### PR DESCRIPTION
## Summary

Single-folder retrigger PR for `benchmarks/NonlinearProblem`. It failed in the 2026-05-16 07:58 UTC burst on amdci3-1 with the runner-state-corruption pattern (`Missing file at path: ..._runner_file_commands/...`), not a real benchmark failure.

Single-folder matrix to avoid intra-PR collisions per Chris's direction. Once the master detect-changes fix ([#1562](https://github.com/SciML/SciMLBenchmarks.jl/pull/1562)) is merged, this will auto-publish on merge.

Please ignore until reviewed by @ChrisRackauckas.