### PR TITLE
Retrigger DynamicalODE (single-folder, infra-failed in burst-dispatch)

### DIFF
--- a/benchmarks/DynamicalODE/Project.toml
+++ b/benchmarks/DynamicalODE/Project.toml
@@ -29,3 +29,4 @@ SciMLBenchmarks = "0.1"
 StaticArrays = "1.0"
 Statistics = "1"
 TaylorIntegration = "0.18"
+# CI retrigger (single-folder): DynamicalODE infra-failed in burst-dispatch on amdci3-1 (2026-05-16)


### PR DESCRIPTION
## Summary

Single-folder retrigger PR for `benchmarks/DynamicalODE`. It failed in the 2026-05-16 07:58 UTC burst on amdci3-1 with the runner-state-corruption pattern (`Missing file at path: ..._runner_file_commands/...`), not a real benchmark failure.

Single-folder matrix to avoid intra-PR collisions per Chris's direction. Once the master detect-changes fix ([#1562](https://github.com/SciML/SciMLBenchmarks.jl/pull/1562)) is merged, this will auto-publish on merge.

Please ignore until reviewed by @ChrisRackauckas.