### PR TITLE
Serialize benchmark jobs to fix amdci3-1 rapid-dispatch corruption

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -71,10 +71,30 @@ jobs:
         (needs.manual-matrix.result == 'success' && needs.manual-matrix.outputs.has_changes == 'true')
       )
     runs-on: ${{ matrix.runner }}
+    # Serialize all benchmark jobs across all workflow runs to one at a time.
+    # Background: amdci3-1 corrupts its workspace under rapid dispatch — when
+    # multiple jobs arrive within seconds, all but one die with errors like
+    # "Missing file at path: ..._runner_file_commands/..." and "Can't find
+    # action.yml under .../_actions/actions/checkout/...". Single jobs run
+    # cleanly; the bug is purely a concurrency-on-same-runner issue.
+    #
+    # Job-level concurrency with a constant group + cancel-in-progress:false
+    # makes every matrix entry across every Benchmarks run queue behind any
+    # other in-flight matrix entry. The detect-changes / manual-matrix /
+    # publish jobs are unaffected (they're separate jobs and run normally).
+    #
+    # Throughput cost: even when both self-hosted runners are healthy and
+    # idle, only one benchmark job runs at a time. When the runner pool's
+    # rapid-dispatch bug is fixed, this can be relaxed (e.g. parameterized
+    # by matrix.runner to allow one job per runner concurrently).
+    concurrency:
+      group: benchmark-runner-pool
+      cancel-in-progress: false
     strategy:
       matrix:
         include: ${{ fromJson(needs.detect-changes.outputs.matrix || needs.manual-matrix.outputs.matrix) }}
       fail-fast: false
+      max-parallel: 1
     timeout-minutes: ${{ matrix.timeout }}
     env:
       JULIA_NUM_THREADS: auto


### PR DESCRIPTION
## Summary

Add job-level concurrency + `max-parallel: 1` to the matrix so only one benchmark job runs at a time across all Benchmarks workflow runs. This works around a runner-pool bug where **amdci3-1 corrupts its workspace under rapid dispatch**.

## Symptom

When 2+ benchmark jobs are dispatched to amdci3-1 within seconds, all but the last one die with infra errors. Reproduced three times now:

| Date (UTC) | Cause | Jobs lost |
|---|---|---|
| 2026-05-10 | Original v7 merge (run 25374549824) | 3 cancelled-mid-checkout |
| 2026-05-16 07:58 | First runner-free burst (PRs #1559/#1560/#1561) | **6 lost, including StiffODE that had been running cleanly for 16h** |
| 2026-05-16 08:31 | Single-folder PRs #1563–#1567 dispatched together | All 5 lost |

Errors are always one of:
- `##[error]The operation was canceled.` (during actions/checkout)
- `##[error]Missing file at path: ..._runner_file_commands/set_output_...`
- `##[error]Can't find action.yml under .../_actions/actions/checkout/v6. Did you forget to run actions/checkout before running your local action?`

amdci1-1 doesn't show this pattern. Single jobs on amdci3-1 also run cleanly (StiffODE, StiffSDE, AutomaticDifferentiation, NBodySimulator all completed normally when they had the runner to themselves).

## Fix

```yaml
benchmark:
  ...
  concurrency:
    group: benchmark-runner-pool
    cancel-in-progress: false
  strategy:
    matrix: ...
    fail-fast: false
    max-parallel: 1
```

Every matrix entry across every Benchmarks workflow run shares the constant group `benchmark-runner-pool`, so they queue one at a time. Other jobs (detect-changes, manual-matrix, publish) are unaffected.

## Tradeoff

Even with both runners healthy and idle, only one benchmark job runs at a time. Halves throughput in the best case. Acceptable given the alternative is ~60% job-loss rate from rapid-dispatch corruption.

Can be relaxed once the underlying runner bug is fixed (e.g. parameterize the group by `matrix.runner` to allow one job per runner instead of one job globally).

## Test plan

- [ ] Merge → next master push or PR triggers Benchmarks → matrix entries queue serially → all entries either succeed or fail on real bugs, none on infra
- [ ] Reopen retrigger PRs #1563–#1567 (already exist) — they should succeed one at a time

## Note for review

Please ignore until reviewed by @ChrisRackauckas. This is an architectural choice, not a no-op fix.