### PR TITLE
Fix NBodySimulator under v7 stack: shrink liquid_argon problem size

### DIFF
--- a/benchmarks/NBodySimulator/liquid_argon.jmd
+++ b/benchmarks/NBodySimulator/liquid_argon.jmd
@@ -19,7 +19,11 @@ function setup(t)
     σ = 3.4e-10 # m
     ρ = 1374 # kg/m^3
     m = 39.95 * 1.6747 * 1e-27 # kg
-    N = 350
+    # N=128 keeps the relative-cost calibration in `c_symplectic`/`c_adaptive`
+    # below valid (per-step cost ratios are essentially N-independent) while
+    # keeping CI wall time tractable; the larger N=350 case took >40h per
+    # parameter sweep under the OrdinaryDiffEq v7 stack.
+    N = 128
     L = (m*N/ρ)^(1/3)
     R = 3.5σ
     v_dev = sqrt(kb * T / m) # m/s
@@ -153,7 +157,7 @@ c_symplectic = [
 Let us now benchmark the solvers for a fixed simulation time and variable timestep
 
 ```julia
-t = 40.0
+t = 10.0
 τs = 10 .^ range(-4, -3, length = 10)
 
 results = DataFrame(:integrator=>String[], :runtime=>Float64[], :τ=>Float64[],
@@ -200,7 +204,7 @@ end
 rt = Dict()
 ts = Dict()
 configs = config(symplectic_integrators, c_symplectic, 2.3e-4)
-benchmark(ΔE, rt, ts, 40.0, configs)
+benchmark(ΔE, rt, ts, 10.0, configs)
 
 plt = plot(xlabel = "Rescaled Time", ylabel = "Energy error", legend = :bottomleft);
 for c in configs
@@ -261,7 +265,7 @@ c_adaptive = [
 Let us now benchmark the solvers for a fixed simulation time and variable timestep
 
 ```julia
-t = 40.0
+t = 10.0
 
 results = DataFrame(:integrator=>String[], :runtime=>Float64[], :abstol=>Float64[],
     :reltol=>Float64[], :EnergyError=>Float64[], :timesteps=>Int[], :f_evals=>Int[], :cost=>Float64[]);
@@ -285,7 +289,7 @@ If we consider the number of function evaluations instead, we obtain
 We will now compare the best performing solvers
 
 ```julia
-t = 40.0
+t = 10.0
 
 symplectic_integrators = [
     VelocityVerlet,

--- a/benchmarks/NBodySimulator/liquid_argon_long.jmd
+++ b/benchmarks/NBodySimulator/liquid_argon_long.jmd
@@ -19,7 +19,8 @@ function setup(t)
     σ = 3.4e-10 # m
     ρ = 1374 # kg/m^3
     m = 39.95 * 1.6747 * 1e-27 # kg
-    N = 350
+    # See liquid_argon.jmd for the reasoning behind N=128 (was 350).
+    N = 128
     L = (m*N/ρ)^(1/3)
     R = 3.5σ
     v_dev = sqrt(kb * T / m) # m/s
@@ -142,7 +143,7 @@ c_symplectic = [
 We will consider a longer simulation time
 
 ```julia
-t = 200.0
+t = 50.0
 
 results = DataFrame(:integrator=>String[], :runtime=>Float64[], :τ=>Float64[],
     :EnergyError=>Float64[], :timesteps=>Int[], :f_evals=>Int[], :cost=>Float64[]);
@@ -205,7 +206,7 @@ c_adaptive = [
 We will consider a longer simulation time
 
 ```julia
-t = 200.0
+t = 50.0
 
 results = DataFrame(:integrator=>String[], :runtime=>Float64[], :abstol=>Float64[],
     :reltol=>Float64[], :EnergyError=>Float64[], :timesteps=>Int[], :f_evals=>Int[], :cost=>Float64[]);
@@ -222,7 +223,7 @@ The energy error as a function of runtime is given by
 We will now compare the best performing solvers
 
 ```julia
-t = 200.0
+t = 50.0
 
 symplectic_integrators = [
     VelocityVerlet,


### PR DESCRIPTION
## Summary

NBodySimulator/liquid_argon was the only folder in PR #1559 (run [25912449328](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/25912449328), job [76160856440](https://github.com/SciML/SciMLBenchmarks.jl/actions/jobs/76160856440)) that ran for ~47h before the runner workspace was reaped mid-run on amdci1-1. The failing logs trace a `SystemError: opening file ... markdown/NBodySimulator/figures/liquid_argon_6_1.png: No such file or directory` after Weave reports "Weaved all chunks / progress = 1" — i.e. the .jmd was *still progressing* when the workspace got cleaned out from under it.

Timeline from the CI log:
- chunk 4 (line 119) finished at `2026-05-16T01:57:36`
- chunk 5 (line 155, the `run_benchmark!(symplectic, 10 τs, t=40)` sweep) started immediately after
- chunk 6 (just a `@df` plot) started at `2026-05-18T02:06:13` — i.e. chunk 5 alone ran for ~47 hours

So the .jmd is not "broken" in the v7-API sense; the problem-size simply exploded out of any reasonable CI budget under the v7 solver stack.

## What this PR does

Reduce the workload in both .jmd files in this folder so the suite finishes in a sensible window. The integrator-comparison benchmark just needs enough particles/steps to exercise force kernels and integrate at a range of timesteps; the absolute N and t are not load-bearing.

- `liquid_argon.jmd`: `N = 350 → 128`, `t = 40.0 → 10.0`
- `liquid_argon_long.jmd`: `N = 350 → 128`, `t = 200.0 → 50.0`

Net work reduction is roughly `(350/128)² × (40/10) ≈ 30×` for both suites (the long suite is dominated by step count, so reducing t by 4× nets a similar factor).

The hardcoded `c_symplectic` / `c_adaptive` cost ratios remain valid: they are per-step cost ratios normalised to `VelocityVerlet`, and per-step cost is essentially N-independent (all symplectic methods scale the same way in the pair-force kernel cost).

## Local verification

`julia +1.11 --project=benchmarks/NBodySimulator` instantiates cleanly. A microbenchmark at `N=64, dt=1e-3, t=1.0` (1000 steps) on this branch's stack:

```
VelocityVerlet dt=1e-3, t=1.0 (1000 steps), N=64: 0.118s
VerletLeapfrog                                    0.120s (after warmup)
McAte5                                            ≈0.8s
SofSpa10                                          ≈4.2s
```

Extrapolating with `(N/64)² × (steps/1000)`, the full liquid_argon.jmd chunk 5 under the new parameters (`N=128, t=10, 10 τs`) lands at ~20–30 minutes, vs the observed ~47h previously. End-to-end I expect the whole folder under ~3h on amdci1-class hardware.

## Note for review

Please ignore until reviewed by @ChrisRackauckas.