### PR TITLE
Add ADTypes to ComplicatedPDE Project.toml [deps]/[compat]

### DIFF
--- a/benchmarks/ComplicatedPDE/Manifest.toml
+++ b/benchmarks/ComplicatedPDE/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "610e72053261b6e729295f58269038b922de1d74"
+project_hash = "32509a1843f928d5cbca41ba5b44657851cf5044"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "bbc22a9a08a0ef6460041086d8a7b27940ed4ffd"

--- a/benchmarks/ComplicatedPDE/Project.toml
+++ b/benchmarks/ComplicatedPDE/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 GaussianRandomFields = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
@@ -26,6 +27,7 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
+ADTypes = "1"
 DiffEqDevTools = "3"
 GaussianRandomFields = "2"
 IJulia = "1"


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Follow-up fix to #1580 (just merged). Filament.jmd does \`using SciMLLogging, ADTypes\` but ADTypes was only present in the Manifest as a transitive dep, not in Project.toml [deps]. The chunk eval fails at the \`using\` line:

\`\`\`
ERROR: ArgumentError: Package ADTypes not found in current path.
in expression starting at .../benchmarks/ComplicatedPDE/Filament.jmd:6
\`\`\`

CI marked the merged PR green only because \`SciMLBenchmarks.weave_file\` catches per-file \`ProcessFailedException\` via \`@error\` at \`src/SciMLBenchmarks.jl:100\` and doesn't re-throw — so \`benchmark.jl\` exits 0 even though Filament.jmd actually failed.

This PR adds:
- \`ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"\` to [deps]
- \`ADTypes = "1"\` to [compat]

No Manifest changes (ADTypes was already pinned there as a transitive dep).