### PR TITLE
Add ADTypes to ComplicatedPDE Project.toml [deps]/[compat]

### DIFF
--- a/benchmarks/ComplicatedPDE/Project.toml
+++ b/benchmarks/ComplicatedPDE/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 GaussianRandomFields = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
@@ -26,6 +27,7 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
+ADTypes = "1"
 DiffEqDevTools = "3"
 GaussianRandomFields = "2"
 IJulia = "1"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary

`benchmarks/ComplicatedPDE/Filament.jmd` does `using SciMLLogging, ADTypes` (line 21), but `ADTypes` was only in the Manifest as a transitive dep, not in `[deps]`. Julia's `using` only resolves top-level project deps, so the chunk evaluation fails:

```
ERROR: ArgumentError: Package ADTypes not found in current path.
- Run `import Pkg; Pkg.add("ADTypes")` to install the ADTypes package.
in expression starting at .../benchmarks/ComplicatedPDE/Filament.jmd:6
```

This was masked in CI because `SciMLBenchmarks.weave_file` catches per-file `ProcessFailedException` via `@error` at `src/SciMLBenchmarks.jl:100` and does not re-throw — so `benchmark.jl` exits 0 and the workflow appears successful even though `Filament.jmd` failed to weave.

This is a follow-up to #1580 (now merged). The bug is currently live on master.

## Changes

`benchmarks/ComplicatedPDE/Project.toml`:
- `[deps]`: add `ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"` (UUID matches the existing Manifest entry; ADTypes v1.22.0).
- `[compat]`: add `ADTypes = "1"`.

No other `.jmd` files in `ComplicatedPDE` reference packages missing from `[deps]` (scanned `Filament.jmd` and `SpringBlockNonLinearResistance.jmd`).

## Test plan

- [x] `julia +1.11 --project=benchmarks/ComplicatedPDE -e 'using Pkg; Pkg.instantiate(); using ADTypes; println(pathof(ADTypes))'` succeeds locally → `ADTypes loaded OK: /home/.../packages/ADTypes/tzjfw/src/ADTypes.jl`.
- [ ] CI weaves `Filament.jmd` without the "Package ADTypes not found" error.