### PR TITLE
Make weave_folder re-throw at end if any .jmd failed (make CI accurate)

### DIFF
--- a/src/SciMLBenchmarks.jl
+++ b/src/SciMLBenchmarks.jl
@@ -89,6 +89,7 @@ function weave_folder(folder, build_list = (:script, :github))
 
     weave_files = weave_files[sortperm(priorities; rev = true)]
 
+    failures = Tuple{String,String}[]
     for file in weave_files
         try
             @eval @subprocess begin
@@ -98,8 +99,10 @@ function weave_folder(folder, build_list = (:script, :github))
         catch e
             @show folder, file
             @error(e)
+            push!(failures, (folder, file))
         end
     end
+    isempty(failures) || error("weave_folder: $(length(failures)) file(s) failed: $failures")
     return
 end
 


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## What

`weave_folder` in `src/SciMLBenchmarks.jl` previously caught per-file `ProcessFailedException` and only `@error`'d it, then returned normally. As a result, `benchmark.jl` always exits 0 and the GHA job always goes green — even when one or more `.jmd` files actually failed.

This PR collects per-file failures and throws at the end of `weave_folder` if any happened. The 'continue past per-file failure' behaviour is preserved (so one bad `.jmd` doesn't block others from producing partial artifacts), but the job now exits non-zero if anything failed.

## Why

Real example: ComplicatedPDE was merged green in #1580 even though `Filament.jmd` was failing with `Package ADTypes not found in current path`. Fix landed in follow-up #1589. Without this PR, future bugs of that shape will keep getting masked.

## Expected impact

Master CI will start showing red for folders that have been silently failing. Known candidates as of this writing:

- ComplicatedPDE/Filament.jmd — fixed in #1589, will go green after that merges
- ModelingToolkit/Multibody_Robot.jmd — `using Multibody` but Multibody is not in [deps] AND not in Manifest. Pre-existing.

These should be addressed separately; this PR just makes CI tell the truth.

## Diff

Three new lines in `weave_folder`:
- `failures = Tuple{String,String}[]` before the loop
- `push!(failures, (folder, file))` inside the catch block
- `isempty(failures) || error(...)` after the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)