### PR TITLE
Fix incorrect scaleflop count in LUFactorization benchmark's luflop

### DIFF
--- a/benchmarks/LinearSolve/LUFactorization.jmd
+++ b/benchmarks/LinearSolve/LUFactorization.jmd
@@ -13,13 +13,8 @@ BenchmarkTools.DEFAULT_PARAMETERS.seconds = 0.5
 function luflop(m, n = m; innerflop = 2)
     sum(1:min(m, n)) do k
         invflop = 1
-        scaleflop = isempty((k + 1):m) ? 0 : sum((k + 1):m)
-        updateflop = isempty((k + 1):n) ? 0 :
-                     sum((k + 1):n) do j
-            isempty((k + 1):m) ? 0 : sum((k + 1):m) do i
-                innerflop
-            end
-        end
+        scaleflop = max(m - k, 0)
+        updateflop = innerflop * max(m - k, 0) * max(n - k, 0)
         invflop + scaleflop + updateflop
     end
 end


### PR DESCRIPTION
> Please ignore until reviewed by @ChrisRackauckas.

## Summary

`luflop` in `benchmarks/LinearSolve/LUFactorization.jmd` uses `sum((k+1):m)` for the scaling step. That sums the indices `k+1, k+2, ..., m` instead of counting the `m - k` scaling multiplications, so the GFLOPs reported by the benchmark are systematically inflated. This was raised against the matching helper in RecursiveFactorization.jl in [JuliaLinearAlgebra/RecursiveFactorization.jl#109](https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl/issues/109).

Replace the buggy formula with the textbook closed forms:

- `scaleflop = max(m - k, 0)` (counts the scaling multiplications)
- `updateflop = innerflop * max(m - k, 0) * max(n - k, 0)` (the rank-1 update)

The `isempty` guards and the nested `do`-blocks were just there to dodge `sum` on empty ranges; with the closed forms they are no longer needed.

## Numerical check (square, default `innerflop = 2`)

| `n` | old `luflop(n)` | new `luflop(n)` | textbook `2n³/3` | new / textbook |
|----:|----------------:|----------------:|-----------------:|---------------:|
|   4 |              52 |              38 |               43 |          0.884 |
|  50 |         122,550 |          82,125 |           83,333 |          0.986 |
| 100 |         990,100 |         661,750 |          666,667 |          0.993 |
| 500 |     124,750,500 |      83,208,750 |       83,333,333 |          0.999 |

The closed form is `(2/3)n³ − (1/2)n² + (5/6)n`, which matches both the new code and the standard count for an unpivoted LU.

## Test plan

- [ ] Manual: `julia> luflop(500)` returns `83_208_750` (was `124_750_500`).
- [ ] The benchmark builds and produces a GFLOPs plot whose curves shift down by the same factor for every algorithm (ratios between algorithms unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)