### PR TITLE
Add CHOLMODFactorization (SPD solver) to SparsePDE benchmark

### DIFF
--- a/benchmarks/LinearSolve/SparsePDE.jmd
+++ b/benchmarks/LinearSolve/SparsePDE.jmd
@@ -4,7 +4,7 @@ author: Jürgen Fuhrmann
 ---
 
 ```julia
-using BenchmarkTools, Random, VectorizationBase
+using BenchmarkTools, Random
 using LinearAlgebra, SparseArrays, LinearSolve, Sparspak
 import Pardiso
 import ParU_jll
@@ -44,9 +44,10 @@ algs = [
     KLUFactorization(),
     MKLPardisoFactorize(),
     SparspakFactorization(),
-    ParUFactorization()
+    ParUFactorization(),
+    CHOLMODFactorization()
 ]
-cols = [:red, :blue, :green, :magenta, :turqoise, :cyan] # one color per alg
+cols = [:red, :blue, :green, :magenta, :turqoise, :cyan, :black] # one color per alg
 
 __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = __parameterless_type(typeof(x))


### PR DESCRIPTION
## What

The `LinearSolve/SparsePDE` benchmark discretizes **−Δu + δu** on 1D/2D/3D grids. That operator is **symmetric positive definite**, but the benchmark currently only compares *general* (LU) sparse solvers (UMFPACK, KLU, MKL Pardiso, Sparspak, ParU). This adds **`CHOLMODFactorization`** — SuiteSparse's sparse Cholesky — which is the natural, textbook baseline for an SPD system and the solver a reader would expect to see win here.

It also drops the unused `using ... VectorizationBase` import from the benchmark (it is imported but never referenced in the file).

## Why

- The matrix is SPD (verified `isposdef == true` on the `fdmatrix` output), so a Cholesky factorization is the appropriate direct method and a meaningful point of comparison against the LU solvers already present.
- **No new dependency**: `CHOLMODFactorization` ships via `SparseArrays` (like `UMFPACKFactorization`) and is already exported by `LinearSolve`.

## Verification

Ran the benchmark's exact solver list (with `CHOLMODFactorization` added) locally on Julia 1.12 / LinearSolve 3.82 across all three dimensionalities at small sizes. All six solvers return correct solutions (relative residual ~1e-14), e.g. at the 3D smoke size CHOLMOD solved with residual 1.0e-13 and was the second-fastest solver behind KLU. The figures themselves are regenerated by the SciMLBenchmarks server, so this PR only changes the `.jmd` source.

## Note

Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>