### PR TITLE
Fix detect-changed-benchmarks: handle shallow base fetch (no merge base)

### DIFF
--- a/.github/scripts/detect-changed-benchmarks.sh
+++ b/.github/scripts/detect-changed-benchmarks.sh
@@ -20,7 +20,15 @@ source "${SCRIPT_DIR}/read-benchmark-config.sh"
 if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
     BASE_SHA="${GITHUB_BASE_REF}"
     git fetch origin "${BASE_SHA}" --depth=1 2>/dev/null || true
-    CHANGED_FILES=$(git diff --name-only "origin/${BASE_SHA}...HEAD" -- 'benchmarks/')
+    CHANGED_FILES=$(git diff --name-only "origin/${BASE_SHA}...HEAD" -- 'benchmarks/' 2>/dev/null || true)
+    if [[ -z "${CHANGED_FILES}" ]]; then
+        # The three-dot range needs a merge base, which a shallow (--depth=1)
+        # fetch of the base lacks once master advances past the PR's branch
+        # point — git then aborts with "no merge base". PR builds check out
+        # refs/pull/N/merge, so HEAD~1 is the base tip; diffing against it
+        # yields exactly the PR's changes without requiring a merge base.
+        CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD -- 'benchmarks/' 2>/dev/null || true)
+    fi
 else
     # Push event: compare against the last commit that was successfully published
     # to SciMLBenchmarksOutput. This makes change detection cumulative — if a


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## Problem

`.github/scripts/detect-changed-benchmarks.sh` fails the **Detect Changed Benchmarks** job on PR re-runs with:

```
fatal: origin/master...HEAD: no merge base
##[error]Process completed with exit code 128.
```

The PR path does:

```bash
git fetch origin "${BASE_SHA}" --depth=1 2>/dev/null || true
CHANGED_FILES=$(git diff --name-only "origin/${BASE_SHA}...HEAD" -- 'benchmarks/')
```

The three-dot range `origin/master...HEAD` diffs from the **merge base** of the two commits, which requires a common ancestor to exist locally. But the base is re-fetched at `--depth=1` (an orphan graft with no ancestors). Once `master` advances past the PR's branch point, the depth=1 base tip shares no ancestor with `HEAD`, so git aborts with *"no merge base"* (exit 128). That line has no `|| true`, so under `set -eo pipefail` the whole step fails.

This is why it's intermittent: a freshly-dispatched PR (base == current master tip) finds a merge base, but a **re-run after master moves on** does not.

### Observed
- **#1581** (Refresh DynamicalODE): detect passed on the 2026-05-22 dispatch, then failed on the 2026-05-23 re-run.
- **#1570** (Fix NBodySimulator): failed on the 2026-05-25 re-run.

Both fail at this exact line; it is latent for the whole v7-refresh batch on any re-run.

## Fix

Suppress the three-dot error and fall back to diffing the PR merge commit against its first parent (`HEAD~1` = base tip), which yields exactly the PR's changes without needing a merge base. This mirrors the robust `2>/dev/null || true` + `HEAD~1` pattern already used on the **push** path in the same script.

```bash
CHANGED_FILES=$(git diff --name-only "origin/${BASE_SHA}...HEAD" -- 'benchmarks/' 2>/dev/null || true)
if [[ -z "${CHANGED_FILES}" ]]; then
    CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD -- 'benchmarks/' 2>/dev/null || true)
fi
```

## Verification

Reproduced the failure locally in a scratch repo recreating the CI condition (master advanced past the merge ref's base; base re-fetched at `--depth=1`):

- **Old code:** `fatal: origin/master...HEAD: no merge base` (exit 128) — matches CI exactly.
- **New code:** three-dot returns empty (suppressed), fallback returns exactly the PR's changed benchmark file.

`bash -n` passes on the edited script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)