### PR TITLE
Fix preconditioner precs interface for v7 (#1601)

### DIFF
--- a/benchmarks/Bio/BCR.jmd
+++ b/benchmarks/Bio/BCR.jmd
@@ -135,13 +135,9 @@ function precilu(z, r, p, t, y, fy, gamma, delta, lr)
     ldiv!(z, preccache[], r)
 end
 
-function incompletelu(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = ilu(convert(AbstractMatrix, W), τ = τ2)
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function incompletelu(newW, p)
+    Pl = ilu(convert(AbstractMatrix, newW), τ = τ2)
+    Pl, I
 end;
 ```
 

--- a/benchmarks/Bio/fceri_gamma2.jmd
+++ b/benchmarks/Bio/fceri_gamma2.jmd
@@ -126,13 +126,9 @@ function precilu(z, r, p, t, y, fy, gamma, delta, lr)
 end
 
 const τ2 = 5
-function incompletelu(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = ilu(convert(AbstractMatrix, W), τ = τ2)
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function incompletelu(newW, p)
+    Pl = ilu(convert(AbstractMatrix, newW), τ = τ2)
+    Pl, I
 end;
 ```
 

--- a/benchmarks/SimpleHandwrittenPDE/allen_cahn_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/allen_cahn_fdm_wpd.jmd
@@ -233,41 +233,29 @@ Base.@kwdef struct WeightedDiagonalPreconBuilder
     w::Float64
 end
 
-(builder::WeightedDiagonalPreconBuilder)(A, du, u, p, t, newW, Plprev, Prprev, solverdata) = (builder.w * LA.Diagonal(convert(AbstractMatrix, A)), LA.I)
+(builder::WeightedDiagonalPreconBuilder)(newW, p) = (builder.w * LA.Diagonal(convert(AbstractMatrix, newW)), LA.I)
 
 # Incomplete LU factorization
 using IncompleteLU
-function incompletelu(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = ilu(convert(AbstractMatrix, W), τ = 50.0)
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function incompletelu(newW, p)
+    Pl = ilu(convert(AbstractMatrix, newW), τ = 50.0)
+    Pl, LA.I
 end
 
 # Algebraic multigrid
 using AlgebraicMultigrid
-function algebraicmultigrid(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = aspreconditioner(ruge_stuben(convert(AbstractMatrix, W)))
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function algebraicmultigrid(newW, p)
+    Pl = aspreconditioner(ruge_stuben(convert(AbstractMatrix, newW)))
+    Pl, LA.I
 end
-function algebraicmultigrid2(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        A = convert(AbstractMatrix, W)
-        Pl = AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(A,
-            presmoother = AlgebraicMultigrid.Jacobi(rand(size(A,
-                1))),
-            postsmoother = AlgebraicMultigrid.Jacobi(rand(size(A,
-                1)))))
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function algebraicmultigrid2(newW, p)
+    A = convert(AbstractMatrix, newW)
+    Pl = AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(A,
+        presmoother = AlgebraicMultigrid.Jacobi(rand(size(A,
+            1))),
+        postsmoother = AlgebraicMultigrid.Jacobi(rand(size(A,
+            1)))))
+    Pl, LA.I
 end
 
 # Aliases

--- a/benchmarks/SimpleHandwrittenPDE/burgers_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/burgers_fdm_wpd.jmd
@@ -232,44 +232,32 @@ Base.@kwdef struct WeightedDiagonalPreconBuilder
     w::Float64
 end
 
-(builder::WeightedDiagonalPreconBuilder)(A, du, u, p, t, newW, Plprev, Prprev, solverdata) = (builder.w * LA.Diagonal(convert(AbstractMatrix, A)), LA.I)
+(builder::WeightedDiagonalPreconBuilder)(newW, p) = (builder.w * LA.Diagonal(convert(AbstractMatrix, newW)), LA.I)
 
 # Incomplete LU factorization
 using IncompleteLU
 Base.@kwdef struct IncompleteLUPreconBuilder
     τ::Float64
 end
-function (builder::IncompleteLUPreconBuilder)(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = ilu(convert(AbstractMatrix, W), τ = builder.τ)
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function (builder::IncompleteLUPreconBuilder)(newW, p)
+    Pl = ilu(convert(AbstractMatrix, newW), τ = builder.τ)
+    Pl, LA.I
 end
 
 # Algebraic multigrid
 using AlgebraicMultigrid
-function algebraicmultigrid(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = aspreconditioner(ruge_stuben(convert(AbstractMatrix, W)))
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function algebraicmultigrid(newW, p)
+    Pl = aspreconditioner(ruge_stuben(convert(AbstractMatrix, newW)))
+    Pl, LA.I
 end
-function algebraicmultigrid2(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        A = convert(AbstractMatrix, W)
-        Pl = AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(A,
-            presmoother = AlgebraicMultigrid.Jacobi(rand(size(A,
-                1))),
-            postsmoother = AlgebraicMultigrid.Jacobi(rand(size(A,
-                1)))))
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function algebraicmultigrid2(newW, p)
+    A = convert(AbstractMatrix, newW)
+    Pl = AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(A,
+        presmoother = AlgebraicMultigrid.Jacobi(rand(size(A,
+            1))),
+        postsmoother = AlgebraicMultigrid.Jacobi(rand(size(A,
+            1)))))
+    Pl, LA.I
 end
 
 # Aliases

--- a/benchmarks/StiffODE/Bruss.jmd
+++ b/benchmarks/StiffODE/Bruss.jmd
@@ -286,22 +286,14 @@ plot(sol, idxs = 10)
 ### OrdinaryDiffEq
 
 ```julia
-function incompletelu(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = ilu(convert(AbstractMatrix, W), τ = 50.0)
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function incompletelu(newW, p)
+    Pl = ilu(convert(AbstractMatrix, newW), τ = 50.0)
+    Pl, I
 end
 
-function algebraicmultigrid(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = aspreconditioner(ruge_stuben(convert(AbstractMatrix, W)))
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function algebraicmultigrid(newW, p)
+    Pl = aspreconditioner(ruge_stuben(convert(AbstractMatrix, newW)))
+    Pl, I
 end
 ```
 


### PR DESCRIPTION
Fixes #1601. The `precs` interface changed in v7 from the 9-argument `(W, du, u, p, t, newW, Plprev, Prprev, solverdata)` to the 2-argument `(newW, p)`, so the hand-written preconditioner builders in the benchmarks were failing with a `MethodError` on the old signature.

This migrates all of them to `(newW, p)` and returns `I` instead of `nothing` for the right preconditioner, since the solver now applies it via `ldiv!` and `nothing` has no method. `convert(AbstractMatrix, newW)` materializes the passed `WOperator` to its sparse matrix, so `concrete_jac = true` keeps working.

Updated 12 builders across `SimpleHandwrittenPDE/burgers_fdm_wpd.jmd`, `SimpleHandwrittenPDE/allen_cahn_fdm_wpd.jmd`, `StiffODE/Bruss.jmd`, `Bio/BCR.jmd`, and `Bio/fceri_gamma2.jmd`.

Checked locally by running the affected builders on the real problems: the four SimpleHandwrittenPDE preconditioners solve the burgers problem with `KenCarp4`, and `KenCarp47` solves with the ILU builder. The Bio problems use a sparse Jacobian, so the `ilu(convert(...))` path is unchanged from before.
