### PR TITLE
Configure actionlint for benchmark runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - benchmark


### PR DESCRIPTION
## Summary

- declare SciMLBenchmarks' real `benchmark` self-hosted runner label in actionlint's repository configuration
- make repository-wide actionlint validation pass without changing any workflow behavior
- keep the configuration exact and focused: no ignore patterns or diagnostic suppression

## Root cause

Clean `master` at `0498ef2519fdc2f60a1a2d78502f971bdf0b3448` fails `actionlint .github/workflows/*.yml` because the literal `[self-hosted, benchmark]` runner selections in `benchmarks.yml` and `test.yml` use a legitimate custom label that actionlint cannot discover from GitHub.

The regression boundary is exact:

- `f22f3158` (the parent) passes repository-wide actionlint.
- `029ff067` (PR #1501) first adds the GitHub Actions benchmark workflows and fails on the custom labels it introduces.
- GitHub job `74335603240` later completed successfully on runner `amdci1-1` with labels `["self-hosted", "benchmark"]`, confirming that `benchmark` is an active runner label rather than a workflow typo.

Actionlint's supported native mechanism is `.github/actionlint.yaml` with `self-hosted-runner.labels`, so this PR records that repository fact directly.

## Local validation

- actionlint 1.7.12 (current upstream release): `actionlint .github/workflows/*.yml` — exit 0, all 9 workflows linted with 0 errors
- actionlint 1.7.7 (currently installed fleet tool): same repository-wide command — exit 0, all 9 workflows linted with 0 errors
- targeted assertions: both literal `[self-hosted, benchmark]` workflow selections are present and the configuration declares `benchmark` exactly once — exit 0
- Runic 1.7.0 on Julia 1.12: 10/10 Julia files pass
- `git diff --check` — exit 0

`Pkg.test()` was not run because this patch changes only actionlint metadata; it does not change Julia source, dependencies, tests, or executable workflow behavior. The relevant executable regression test is the repository-wide actionlint invocation above.

## Review status

**Ignore this draft until reviewed by @ChrisRackauckas.**
