### PR TITLE
Add downgrade compatibility CI

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,19 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  test:
+    name: Downgrade
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+    secrets: "inherit"


### PR DESCRIPTION
## Summary

- add the standard SciML reusable downgrade workflow on Julia LTS
- run it for pull requests and pushes to master, excluding documentation-only changes

This workflow-only PR should land after #1612 (manifest refresh), #1615 (custom runner actionlint configuration), and #1616 (MbedTLS 1.1.1 minimum). #1614 fixes the unrelated spelling failure currently present on master.

## Local verification

- ran the reusable workflow's minimum-version resolver locally on the #1612 + #1616 stack with Julia 1.10/LTS
- the locked graph selected HTTP 1.11.0 and MbedTLS 1.1.1; `Pkg.build()` exited 0 and strict `Pkg.test()` passed Explicit Imports 2/2 and Weave 1/1
- actionlint 1.7.7 passed the new workflow directly
- actionlint passed the complete workflow tree when supplied #1615's `benchmark` runner-label configuration; without that prerequisite it reproduces the known master-only custom-label errors
- Julia Runic 1.7.0 and `git diff --cached --check` passed

## Review

Ignore this PR until it has been reviewed by @ChrisRackauckas.
