### PR TITLE
Refresh nested manifests before benchmark builds

### DIFF
--- a/src/SciMLBenchmarks.jl
+++ b/src/SciMLBenchmarks.jl
@@ -16,6 +16,13 @@ macro subprocess(ex, wait = true)
     end
 end
 
+function manifest_julia_version(folder)
+    manifest_file = joinpath(folder, "Manifest.toml")
+    isfile(manifest_file) || return nothing
+    version_match = match(r"^julia_version\s*=\s*\"([^\"]+)\""m, read(manifest_file, String))
+    return isnothing(version_match) ? nothing : VersionNumber(only(version_match.captures))
+end
+
 function weave_file(folder, file, build_list = (:script, :github))
     Weave.set_chunk_defaults!(:error => false)
     target = joinpath(folder, file)
@@ -25,6 +32,13 @@ function weave_file(folder, file, build_list = (:script, :github))
         @info("Instantiating", folder)
         Pkg.activate(folder)
         withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+            manifest_version = manifest_julia_version(folder)
+            # Older Julia releases cannot resolve stdlibs pinned by a newer manifest.
+            if manifest_version === nothing ||
+                    (VERSION.major, VERSION.minor) >=
+                    (manifest_version.major, manifest_version.minor)
+                Pkg.resolve()
+            end
             Pkg.instantiate()
         end
         Pkg.build()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,29 @@ using SciMLBenchmarks, Test
     include("explicit_imports.jl")
 end
 
+@testset "weave_file resolves stale manifests" begin
+    mktempdir() do folder
+        write(
+            joinpath(folder, "Project.toml"),
+            """
+            [deps]
+            Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+            """,
+        )
+        write(
+            joinpath(folder, "Manifest.toml"),
+            """
+            julia_version = "$(VERSION)"
+            manifest_format = "2.0"
+            project_hash = "0000000000000000000000000000000000000000"
+            """,
+        )
+
+        @test SciMLBenchmarks.weave_file(folder, "unused.jmd", ()) === nothing
+        @test occursin("[[deps.Dates]]", read(joinpath(folder, "Manifest.toml"), String))
+    end
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

Depends on #1612 for the Julia 1.10-compatible `Testing` manifest.

## Summary

- Resolve a nested benchmark manifest before instantiation when the running Julia minor is the same as or newer than the manifest's Julia minor.
- Preserve manifests produced by a newer Julia when running on an older Julia, whose resolver may not know the newer stdlibs.
- Add a regression test using a stale minimal manifest.

## Root cause

Julia 1.12 no longer bundles `MbedTLS_jll`, while the checked-in Julia 1.11 `Testing` manifest records it as a stdlib without a source tree. `Pkg.instantiate()` therefore leaves no package path for the subsequent `Pkg.build()` call.

A full bisect found `cc4abfcee7f55d5be8be72060f382c1de5d1742f` as the first bad commit because it introduced and activated the nested `Testing` environment. Resolving the manifest on same-or-newer Julia versions converts historical stdlibs such as `MbedTLS_jll` to normal registered packages before building.

## Verification

- Julia 1.12: full `Pkg.test()` passes on this branch, including ExplicitImports, the stale-manifest regression, and the real woven benchmark test.
- Julia 1.10: full `Pkg.test()` passes when stacked on #1612.
- Runic 1.7.0: full-repository check passes.
