### PR TITLE
Fix StiffBVP: replace obsolete nest_tol with nested_nlsolve_kwargs

### DIFF
--- a/benchmarks/StiffBVP/ionic_liquid_dehumidifier.jmd
+++ b/benchmarks/StiffBVP/ionic_liquid_dehumidifier.jmd
@@ -227,7 +227,7 @@ bvp_fun = BVPFunction(
 )
 
 prob = TwoPointBVProblem(bvp_fun, u0, tspan, p)
-sol = solve(prob, RadauIIa7(nested_nlsolve = true, nest_tol = 1e-3), dt = dt, abstol = 1e-5)
+sol = solve(prob, RadauIIa7(nested_nlsolve = true, nested_nlsolve_kwargs = (; abstol = 1e-3, reltol = 1e-3)), dt = dt, abstol = 1e-5)
 testsol = TestSolution(sol)
 wp_set = WorkPrecisionSet(prob, abstols, reltols, getfield.(solvers_all, :solver);
     names = getfield.(solvers_all, :name), appxsol = testsol, maxiters = Int(1e4))


### PR DESCRIPTION
## Summary
`BoundaryValueDiffEqFIRK` removed the `nest_tol` keyword from FIRK algorithm constructors. It is replaced by `nested_nlsolve_kwargs::NamedTuple`.

## Change
```diff
- RadauIIa7(nested_nlsolve = true, nest_tol = 1e-3)
+ RadauIIa7(nested_nlsolve = true, nested_nlsolve_kwargs = (; abstol = 1e-3, reltol = 1e-3))
```

in `benchmarks/StiffBVP/ionic_liquid_dehumidifier.jmd`.

## Notes
- Please ignore until reviewed by @ChrisRackauckas.
- Complements draft #1578 (Manifest-only refresh) which does not fix this keyword.
- Related to the StiffBVP code-failure list in the v7 publish backlog.