### PR TITLE
Cap DynamicalODE energy-conservation work to free CI runners

### DIFF
--- a/benchmarks/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jmd
+++ b/benchmarks/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jmd
@@ -112,24 +112,33 @@ function compare(mode = :inplace, all = true, plt = nothing; tmax = 1e2)
     prob_taylor = ODEProblem{true, SciMLBase.FullSpecialize}(
         hamilton_taylor!, vcat(iip_p0, iip_q0), (0.0, tmax))
 
+    # Cap saved points so energy-error plots stay CI-friendly. Default
+    # save_everystep+dense at tmax=5e4 stores ~5e6 states per symplectic
+    # solve and Plots.jl of multi-million-point series is what pinned the
+    # self-hosted runner for multi-day runs (see CI run 30654781033).
+    nsave = clamp(Int(round(tmax)) + 1, 101, 1001)
+    saveat = range(0.0, tmax; length = nsave)
+    common = (; dense = false, saveat)
+
     GC.gc()
     (mode == :inplace && all) &&
-        @time sol1 = solve(prob, Vern9(), callback = cb, abstol = 1e-14, reltol = 1e-14)
+        @time sol1 = solve(prob, Vern9(), callback = cb, abstol = 1e-14, reltol = 1e-14;
+            common...)
     GC.gc()
-    @time sol2 = solve(prob, KahanLi8(), dt = 1e-2, maxiters = 1e10)
+    @time sol2 = solve(prob, KahanLi8(), dt = 1e-2, maxiters = 1e7; common...)
     GC.gc()
-    @time sol3 = solve(prob, SofSpa10(), dt = 1e-2, maxiters = 1e8)
+    @time sol3 = solve(prob, SofSpa10(), dt = 1e-2, maxiters = 1e7; common...)
     GC.gc()
-    @time sol4 = solve(prob, Vern9(), abstol = 1e-14, reltol = 1e-14)
+    @time sol4 = solve(prob, Vern9(), abstol = 1e-14, reltol = 1e-14; common...)
     GC.gc()
-    @time sol5 = solve(prob, DPRKN12(), abstol = 1e-14, reltol = 1e-14)
+    @time sol5 = solve(prob, DPRKN12(), abstol = 1e-14, reltol = 1e-14; common...)
     GC.gc()
     (mode == :inplace && all) &&
-        @time sol6 = solve(prob_linear, TaylorMethod(50), abstol = 1e-20)
+        @time sol6 = solve(prob_linear, TaylorMethod(50), abstol = 1e-20; common...)
     GC.gc()
     (mode == :inplace && all) &&
         @time sol7 = solve(prob_taylor, ExplicitTaylor(order = Val(8)),
-            abstol = 1e-14, reltol = 1e-14)
+            abstol = 1e-14, reltol = 1e-14; common...)
 
     (mode == :inplace && all) && println("Vern9 + ManifoldProjection max energy error:\t" *
             "$(maximum(abs_energy_err(sol1)))\tin\t$(length(sol1.u))\tsteps.")
@@ -183,11 +192,10 @@ compare(tmax = 1e3)
 ```
 
 ```julia
-compare(tmax = 1e4)
-```
-
-```julia
-compare(tmax = 5e4)
+# Long-horizon comparison without Taylor / ExplicitTaylor / ManifoldProjection
+# (those are the expensive paths; energy-trend story is carried by the symplectic
+# and high-order RK methods already).
+compare(:inplace, false; tmax = 1e4)
 ```
 
 We can see that as the simulation time increases, the energy error increases. For this particular example
@@ -209,10 +217,11 @@ function in_vs_out(; all = false, tmax = 1e2)
 end
 ```
 
-First, here is a summary of all the available methods for `tmax = 1e3`:
+First, here is a summary of all the available methods for `tmax = 1e2`
+(kept short so Taylor / ExplicitTaylor stay in the CI budget):
 
 ```julia
-in_vs_out(all = true, tmax = 1e3)
+in_vs_out(all = true, tmax = 1e2)
 ```
 
 Now we will compare the in place and the out of place versions, but only for the integrators
@@ -224,14 +233,6 @@ in_vs_out(tmax = 1e2)
 
 ```julia
 in_vs_out(tmax = 1e3)
-```
-
-```julia
-in_vs_out(tmax = 1e4)
-```
-
-```julia
-in_vs_out(tmax = 5e4)
 ```
 
 As we see from the above comparisons, the `StaticArray` versions are significantly faster and use less memory.

--- a/benchmarks/DynamicalODE/Quadrupole_boson_Hamiltonian_energy_conservation_benchmark.jmd
+++ b/benchmarks/DynamicalODE/Quadrupole_boson_Hamiltonian_energy_conservation_benchmark.jmd
@@ -114,24 +114,33 @@ function compare(mode = :inplace, all = true, plt = nothing; tmax = 1e2)
     prob_taylor = ODEProblem{true, SciMLBase.FullSpecialize}(
         hamilton_iip!, vcat(iip_p0, iip_q0), (0.0, tmax))
 
+    # Cap saved points so energy-error plots stay CI-friendly. Default
+    # save_everystep+dense at long tmax stores millions of states per
+    # symplectic solve; TaylorMethod(50) alone allocated ~32 GiB at tmax=2e4
+    # in the previous published run. See CI run 30654781033.
+    nsave = clamp(Int(round(tmax)) + 1, 101, 1001)
+    saveat = range(0.0, tmax; length = nsave)
+    common = (; dense = false, saveat)
+
     GC.gc()
     (mode == :inplace && all) &&
-        @time sol1 = solve(prob, Vern9(), callback = cb, abstol = 1e-14, reltol = 1e-14)
+        @time sol1 = solve(prob, Vern9(), callback = cb, abstol = 1e-14, reltol = 1e-14;
+            common...)
     GC.gc()
-    @time sol2 = solve(prob, KahanLi8(), dt = 1e-2, maxiters = 1e10)
+    @time sol2 = solve(prob, KahanLi8(), dt = 1e-2, maxiters = 1e7; common...)
     GC.gc()
-    @time sol3 = solve(prob, SofSpa10(), dt = 1e-2, maxiters = 1e8)
+    @time sol3 = solve(prob, SofSpa10(), dt = 1e-2, maxiters = 1e7; common...)
     GC.gc()
-    @time sol4 = solve(prob, Vern9(), abstol = 1e-14, reltol = 1e-14)
+    @time sol4 = solve(prob, Vern9(), abstol = 1e-14, reltol = 1e-14; common...)
     GC.gc()
-    @time sol5 = solve(prob, DPRKN12(), abstol = 1e-14, reltol = 1e-14)
+    @time sol5 = solve(prob, DPRKN12(), abstol = 1e-14, reltol = 1e-14; common...)
     GC.gc()
     (mode == :inplace && all) &&
-        @time sol6 = solve(prob_linear, TaylorMethod(50), abstol = 1e-20)
+        @time sol6 = solve(prob_linear, TaylorMethod(50), abstol = 1e-20; common...)
     GC.gc()
     (mode == :inplace && all) &&
         @time sol7 = solve(prob_taylor, ExplicitTaylor(order = Val(8)),
-            abstol = 1e-14, reltol = 1e-14)
+            abstol = 1e-14, reltol = 1e-14; common...)
 
     (mode == :inplace && all) && println("Vern9 + ManifoldProjection max energy error:\t" *
             "$(maximum(abs_energy_err(sol1)))\tin\t$(length(sol1.u))\tsteps.")
@@ -185,11 +194,9 @@ compare(tmax = 1e3)
 ```
 
 ```julia
-compare(tmax = 1e4)
-```
-
-```julia
-compare(tmax = 2e4)
+# Long-horizon comparison without Taylor / ExplicitTaylor / ManifoldProjection.
+# TaylorMethod(50) alone allocated ~32 GiB at tmax=2e4 in the previous publish.
+compare(:inplace, false; tmax = 1e4)
 ```
 
 As we can see from the above plots, we can achieve a very low energy error for long time simulation by manifold projection and with very high order Taylor methods. In comparison with the Hénon-Heiles system we see that as the Hamiltonian got more complex, the energy error for the other integration methods increased significantly.
@@ -205,10 +212,11 @@ function in_vs_out(; all = false, tmax = 1e2)
 end
 ```
 
-First, here is a summary of all the available methods for `tmax = 1e3`:
+First, here is a summary of all the available methods for `tmax = 1e2`
+(kept short so Taylor / ExplicitTaylor stay in the CI budget):
 
 ```julia
-in_vs_out(all = true, tmax = 1e3)
+in_vs_out(all = true, tmax = 1e2)
 ```
 
 Now we will compare the in place and the out of place versions, but only for the integrators that are compatible with `StaticArrays`
@@ -219,14 +227,6 @@ in_vs_out(tmax = 1e2)
 
 ```julia
 in_vs_out(tmax = 1e3)
-```
-
-```julia
-in_vs_out(tmax = 1e4)
-```
-
-```julia
-in_vs_out(tmax = 2e4)
 ```
 
 As we see from the above comparisons, the `StaticArray` versions are significantly faster and use less memory. The speedup provided for the out of place version is more proeminent at larger values for `tmax`.

--- a/benchmarks/DynamicalODE/benchmark_config.toml
+++ b/benchmarks/DynamicalODE/benchmark_config.toml
@@ -1,0 +1,6 @@
+# DynamicalODE energy-conservation notebooks are long-running (fixed-step
+# symplectic sweeps + Taylor methods + multi-series plots). Cap wall time so a
+# regression cannot monopolize the self-hosted benchmark runner for days.
+# Observed: run 30654781033 job DynamicalODE held amdci1-1 for ~4.5+ days under
+# the previous problem size with the default 12000-minute timeout.
+timeout = 180


### PR DESCRIPTION
## Summary

`Run: benchmarks/DynamicalODE` from the master push that merged #1581/#1570 has been monopolizing `amdci1-1` for **4.5+ days** (still in progress as of investigation):

https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/30654781033
job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/30654781033/job/91401731960

PR #1570 fixed liquid_argon; the multi-day runaway is **DynamicalODE**, pulled into the same cumulative detect-changes matrix because #1581 refreshed its Manifest and last publish of DynamicalODE was 2025-12-30.

### Why it downs the machine

From the notebooks + last published output (pre-ExplicitTaylor):

1. **Multi-million-step saved trajectories.** `KahanLi8`/`SofSpa10` use `dt=1e-2` with default `save_everystep=true` + `dense=true`. At `tmax=5e4` that is **5e6 saved states per solve**. Across Henon + Quadrupole and the repeated `compare` / `in_vs_out` sweeps this is tens of millions of fixed steps, all retained for plotting.

2. **Plots.jl of multi-million-point series.** Each long run does `plot!(sol.t, energy_err(sol), ...)` over every saved step (worst case ~35M points across 7 series in one figure). That is far more expensive than the integrates themselves and is not `@time`d in the published output.

3. **Taylor paths at long horizon.** `TaylorMethod(50)` on Quadrupole at `tmax=2e4` allocated **~32 GiB** in the last published run. `ExplicitTaylor(order=Val(8))` (added in #1479, never successfully published) runs at every `all=true` horizon including the longest ones, with Symbolics jet construction + dense Taylor coefficient storage.

4. **Redundant work.** Full long-horizon solves are repeated in both the `compare(tmax=...)` ladder and the `in_vs_out` ladder (iip + oop).

5. **Timeout is 200 hours.** `.github/benchmark_defaults.toml` sets `timeout = 12000` minutes. A bad DynamicalODE job is allowed to hold the exclusive self-hosted runner for ~8 days before GHA kills it. There was no per-folder override.

6. **Serial self-hosted runner.** Jobs queue on `amdci1-1`; this one blocks the entire SciMLBenchmarks queue (other Benchmarks runs have been queued for days behind it).

Historical published *solve* times for one Henon `compare(tmax=5e4)` were ~45s total — the suite was never meant to be multi-day. The combination of full history + huge plots + Taylor at long tmax + 200h timeout is what turns a regression into a machine-killer.

### What this PR changes

**`Henon-Heiles_energy_conservation_benchmark.jmd` and `Quadrupole_boson_...jmd`:**
- All solves use `dense=false` and `saveat` capped at 1001 points (energy-error plots stay informative, memory/plot cost collapses).
- Drop `tmax=5e4` / `2e4`. Keep one long `compare(:inplace, false; tmax=1e4)` without Taylor/MP/ExplicitTaylor.
- Taylor / ExplicitTaylor / ManifoldProjection only at short horizons (`tmax ≤ 1e3`, and `in_vs_out(all=true)` only at `1e2`).
- Drop redundant long `in_vs_out` horizons (`1e4`/`5e4`/`2e4`).
- `maxiters` `1e10`/`1e8` → `1e7`.

**`benchmarks/DynamicalODE/benchmark_config.toml`:**
- `timeout = 180` (3 hours) so a future regression cannot hold the runner for days.

`single_pendulums.jmd` left alone (already short).

### Work reduction (order of magnitude)

- Fixed-step symplectic total steps: ~18.5M → ~1.4M for Henon (~13×).
- Plot points per series: up to 5e6 → ≤1001 (~5000×).
- Taylor/ExplicitTaylor long-horizon runs: removed.
- Hard wall: 200h → 3h for this folder.

### Immediate ops (needs admin)

This agent cannot cancel the runaway (`gh run cancel` → 403). **Please cancel** run https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/30654781033 so `amdci1-1` is freed for the queue. Merging this PR alone does not stop the already-running job.

### Verification

- Config resolution checked: `get_benchmark_config benchmarks/DynamicalODE` → `timeout=180`, julia=1.11.
- Published SciMLBenchmarksOutput timings used to quantify pre-fix cost (Henon tmax=5e4 SofSpa10 ~20s / 2.8 GiB GC-heavy; Quadrupole TaylorMethod tmax=2e4 ~27s / **32 GiB** alloc).
- Full local weave of the revised suite was **not** completed here: the shared machine is under heavy Julia precompile contention (403 GiB/503 GiB RAM in use, many stuck precompile workers). CI on the self-hosted runner after cancel+merge is the real validation; the 180-minute timeout is the backstop.

### Note for review

Please ignore until reviewed by @ChrisRackauckas.