### PR TITLE
test: add strict SciMLTesting QA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,6 @@ ADTypes = "1.22.0"
 CSV = "0.10"
 DataFrames = "1"
 DiffEqDevTools = "3.0.0"
-ExplicitImports = "1.14.0"
 Git = "1.2"
 IJulia = "1.23.2"
 LSODA = "1.0.0"
@@ -53,14 +52,17 @@ Plots = "1.41.6"
 PrecompileTools = "1"
 RecursiveFactorization = "0.2.26"
 SciMLLogging = "1.9.1"
+SciMLTesting = "2.8"
+SafeTestsets = "0.1, 1"
 Sundials = "6.1.0"
 Weave = "0.10"
 julia = "1"
 
 [extras]
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "Plots", "Test"]
+test = ["Plots", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,0 +1,9 @@
+using SciMLBenchmarks
+using Test
+
+@testset "weave_file" begin
+    benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
+    SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")
+
+    @test isfile(joinpath(dirname(@__DIR__), "markdown", "Testing", "test.md"))
+end

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,8 +1,0 @@
-using ExplicitImports
-using SciMLBenchmarks
-using Test
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(SciMLBenchmarks) === nothing
-    @test check_no_stale_explicit_imports(SciMLBenchmarks) === nothing
-end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,12 @@
+[deps]
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SciMLBenchmarks = "31c91b34-3c75-11e9-0341-95557aab0344"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+JET = "0.9, 0.10, 0.11, 0.12"
+SciMLBenchmarks = "0.1"
+SciMLTesting = "2.8"
+Test = "1"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,5 @@
+using JET
+using SciMLBenchmarks
+using SciMLTesting
+
+run_qa(SciMLBenchmarks)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,9 @@
-using SciMLBenchmarks, Test
+using SciMLTesting
 
-@testset "Explicit Imports" begin
-    include("explicit_imports.jl")
-end
-
-@testset "weave_file" begin
-    benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
-    SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")
-
-    #@test isfile(joinpath(dirname(@__DIR__), "script", "Testing", "test.jl"))
-    #@test isfile(joinpath(dirname(@__DIR__), "html", "Testing", "test.html"))
-    @test isfile(joinpath(dirname(@__DIR__), "markdown", "Testing", "test.md"))
-end
+run_tests(
+    core = joinpath(@__DIR__, "core.jl"),
+    qa = (
+        env = joinpath(@__DIR__, "qa"),
+        body = joinpath(@__DIR__, "qa", "qa.jl"),
+    ),
+)


### PR DESCRIPTION
## What changed

Move the existing benchmark smoke test into SciMLTesting's `Core` group and add an isolated `GROUP=QA` environment running `run_qa(SciMLBenchmarks)`. This replaces the standalone ExplicitImports check with the shared strict QA suite and sets the test-only SciMLTesting compat floor to `2.8`.

## Verification

- `~/.juliaup/bin/julia +1.12 --startup-file=no -m Runic --check test/core.jl test/qa/qa.jl test/runtests.jl`
- `typos --format brief` on changed Julia/Markdown files
- `git diff --check origin/master...HEAD`
- `GROUP=Core ~/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed, `1/1` in 2m16s.
- `~/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed, `1/1` in 2m17s.

## Strict QA follow-up

The new QA lane ran `21` checks: `17` passed, `3` failed, and `1` errored. It exposes existing package debt without suppressing it:

- stale direct dependencies and missing compat entries for `InteractiveUtils`, `Markdown`, `Pkg`, and `Test`;
- nonpublic imports of `Weave.WeaveDoc`, `Pkg.project`, and `Base.show_unquoted` in unchanged source code.

This harness PR intentionally does not add ignores or weaken those checks. Those source and metadata fixes should be a separate follow-up.

Docs were not built because this PR changes only test infrastructure. Julia 1.12 Core currently fails while building the pre-existing nested `benchmarks/Testing` manifest (`MbedTLS_jll` path resolution); Julia 1.10 is the validated supported test environment above.

Ignore until reviewed by @ChrisRackauckas.