### PR TITLE
Use Reactant as the Lux path in NeuralNetworks

### DIFF
--- a/benchmarks/NeuralNetworks/simple_networks.jmd
+++ b/benchmarks/NeuralNetworks/simple_networks.jmd
@@ -7,21 +7,20 @@ This benchmark compares Julia and Python deep learning frameworks on common neur
 network workloads. We compare:
 
 **Julia Frameworks:**
-1. [Lux.jl](https://github.com/LuxDL/Lux.jl)
-2. [Flux.jl](https://github.com/FluxML/Flux.jl)
+1. [Lux.jl](https://github.com/LuxDL/Lux.jl) compiled with [Reactant.jl](https://github.com/EnzymeAD/Reactant.jl) (`@compile` / `Training.single_train_step!(AutoEnzyme(), …)`)
+2. [Flux.jl](https://github.com/FluxML/Flux.jl) (eager CUDA + Zygote)
 3. [SimpleChains.jl](https://github.com/PumasAI/SimpleChains.jl) (via Lux.jl wrapper, CPU-optimized small networks)
-4. [Reactant.jl](https://github.com/EnzymeAD/Reactant.jl) (XLA-compiled Lux models)
 
 **Python Frameworks (via PythonCall):**
-5. [JAX](https://github.com/google/jax)
-6. [PyTorch](https://github.com/pytorch/pytorch)
+4. [JAX](https://github.com/google/jax)
+5. [PyTorch](https://github.com/pytorch/pytorch)
 
 !!! note
 
     Not all benchmarks include all frameworks. SimpleChains.jl does not support
     batch normalization or convolutions with certain configurations and stays on
-    CPU (it is a CPU-small-net library). Lux, Flux, Reactant, JAX, and PyTorch
-    all run on the GPU exclusive runner. Python timing is done entirely in
+    CPU (it is a CPU-small-net library). Lux+Reactant, Flux, JAX, and PyTorch
+    run on the GPU exclusive runner. Python timing is done entirely in
     Python to avoid Julia-to-Python call overhead.
 
 # Setup
@@ -93,6 +92,26 @@ function to_nchw(x::AbstractArray{T, 4}) where T
     # Julia WHCN -> Python NCHW (host numpy; caller puts it on the GPU)
     np.array(permutedims(Array(x), (4, 3, 1, 2)))
 end
+
+function time_lux_reactant_infer(model, ps, st, x_host)
+    x_ra = x_host |> xdev
+    compiled = @compile model(x_ra, ps, st)
+    compiled(x_ra, ps, st)
+    return median((@benchmark $compiled($x_ra, $ps, $st)).time) / 1e9
+end
+
+function time_lux_reactant_train(model, ps, st, x_host, y_host)
+    x_ra = x_host |> xdev
+    y_ra = y_host |> xdev
+    ts = Training.TrainState(model, ps, st, Adam(1.0f-3))
+    function step(ts, x, y)
+        _, loss, _, ts_new = Training.single_train_step!(
+            AutoEnzyme(), MSELoss(), (x, y), ts)
+        ts_new, loss
+    end
+    step(ts, x_ra, y_ra)
+    return median((@benchmark $step($ts, $x_ra, $y_ra)).time) / 1e9
+end
 ```
 
 ## Shared Plotting Functions
@@ -104,15 +123,13 @@ const HEIGHT = round(Int, WIDTH * ASPECT_RATIO)
 const STROKEWIDTH = 2.5
 
 const FRAMEWORK_COLORS = Dict(
-    "Lux" => :royalblue, "Flux" => :orange, "SimpleChains" => :green,
-    "Reactant" => :purple, "JAX" => :red, "PyTorch" => :brown,
-    "Lux+Zygote" => :royalblue, "Flux+Zygote" => :orange,
+    "Lux+Reactant" => :royalblue, "Flux" => :orange, "SimpleChains" => :green,
+    "JAX" => :red, "PyTorch" => :brown, "Flux+Zygote" => :orange,
 )
 
 const FRAMEWORK_STYLES = Dict(
-    "Lux" => :solid, "Flux" => :dash, "SimpleChains" => :dot,
-    "Reactant" => :dashdot, "JAX" => :dashdotdot, "PyTorch" => :solid,
-    "Lux+Zygote" => :solid, "Flux+Zygote" => :dash,
+    "Lux+Reactant" => :solid, "Flux" => :dash, "SimpleChains" => :dot,
+    "JAX" => :dashdotdot, "PyTorch" => :solid, "Flux+Zygote" => :dash,
 )
 
 function plot_results(results, batch_sizes, name)
@@ -149,7 +166,9 @@ end
 lux_mlp_relu = Chain(
     Dense(32, 256, relu), [Dense(256, 256, relu) for _ in 1:5]..., Dense(256, 10))
 ps_lux, st_lux = Lux.setup(rng, lux_mlp_relu)
-ps_lux_gpu, st_lux_gpu = ps_lux |> gpud, st_lux |> gpud
+ps_lux_ra = ps_lux |> xdev
+st_lux_ra = st_lux |> xdev
+st_lux_ra_test = Lux.testmode(st_lux) |> xdev
 
 flux_mlp_relu = Flux.Chain(
     Flux.Dense(32, 256, relu), [Flux.Dense(256, 256, relu) for _ in 1:5]..., Flux.Dense(256, 10)) |> gpud
@@ -164,11 +183,7 @@ batch_sizes = [2, 8, 32, 128, 512, 2048]
 ## Inference
 
 ```julia
-st_lux_test = Lux.testmode(st_lux_gpu)
 Flux.testmode!(flux_mlp_relu)
-
-ps_ra = ps_lux |> xdev
-st_ra = Lux.testmode(st_lux) |> xdev
 
 results = Dict{String, NamedTuple}()
 
@@ -176,9 +191,8 @@ for bs in batch_sizes
     x_host = randn(Float32, 32, bs)
     x_gpu = x_host |> gpud
 
-    # Lux
-    t = @benchmark CUDA.@sync($lux_mlp_relu($x_gpu, $ps_lux_gpu, $st_lux_test))
-    append_timing!(results, "Lux", median(t).time / 1e9)
+    append_timing!(results, "Lux+Reactant",
+        time_lux_reactant_infer(lux_mlp_relu, ps_lux_ra, st_lux_ra_test, x_host))
 
     # Flux
     t = @benchmark CUDA.@sync($flux_mlp_relu($x_gpu))
@@ -189,12 +203,6 @@ for bs in batch_sizes
     ps_sc, st_sc = Lux.setup(rng, sc_model)
     t = @benchmark $sc_model($x_host, $ps_sc, $st_sc)
     append_timing!(results, "SimpleChains", median(t).time / 1e9)
-
-    # Reactant
-    x_ra = Reactant.ConcreteRArray(x_host)
-    compiled_fn = @compile lux_mlp_relu(x_ra, ps_ra, st_ra)
-    t = @benchmark $compiled_fn($x_ra, $ps_ra, $st_ra)
-    append_timing!(results, "Reactant", median(t).time / 1e9)
 
     # JAX (timed in Python)
     x_py = nn_utils.to_jax_gpu(to_row_major(x_host))
@@ -228,20 +236,8 @@ for bs in train_batch_sizes
     x_gpu = x_host |> gpud
     y_gpu = y_host |> gpud
 
-    # Lux + Zygote
-    opt_state = Optimisers.setup(Adam(1.0f-3), ps_lux_gpu)
-    function lux_zygote_step(model, ps, st, opt_state, x, y)
-        (loss, st_new), back = Zygote.pullback(p -> begin
-            ypred, st_ = model(x, p, st)
-            sum(abs2, ypred .- y), st_
-        end, ps)
-        gs = back((one(loss), nothing))[1]
-        opt_state_new, ps_new = Optimisers.update(opt_state, ps, gs)
-        ps_new, st_new, opt_state_new, loss
-    end
-    lux_zygote_step(lux_mlp_relu, ps_lux_gpu, st_lux_gpu, opt_state, x_gpu, y_gpu)
-    t = @benchmark CUDA.@sync($lux_zygote_step($lux_mlp_relu, $ps_lux_gpu, $st_lux_gpu, $opt_state, $x_gpu, $y_gpu))
-    append_timing!(train_results, "Lux+Zygote", median(t).time / 1e9)
+    append_timing!(train_results, "Lux+Reactant",
+        time_lux_reactant_train(lux_mlp_relu, ps_lux_ra, st_lux_ra, x_host, y_host))
 
     # Flux + Zygote
     flux_opt = Flux.setup(Adam(1.0f-3), flux_mlp_relu)
@@ -254,18 +250,6 @@ for bs in train_batch_sizes
     flux_step(flux_mlp_relu, flux_opt, x_gpu, y_gpu)
     t = @benchmark CUDA.@sync($flux_step($flux_mlp_relu, $flux_opt, $x_gpu, $y_gpu))
     append_timing!(train_results, "Flux+Zygote", median(t).time / 1e9)
-
-    # Reactant
-    x_ra = Reactant.ConcreteRArray(x_host)
-    y_ra = Reactant.ConcreteRArray(y_host)
-    ts = Training.TrainState(lux_mlp_relu, ps_ra, st_ra, Adam(1.0f-3))
-    function reactant_step(ts, x, y)
-        _, loss, _, ts_new = Training.single_train_step!(AutoEnzyme(), MSELoss(), (x, y), ts)
-        ts_new, loss
-    end
-    reactant_step(ts, x_ra, y_ra)
-    t = @benchmark $reactant_step($ts, $x_ra, $y_ra)
-    append_timing!(train_results, "Reactant", median(t).time / 1e9)
 
     # JAX
     x_py = nn_utils.to_jax_gpu(to_row_major(x_host))
@@ -298,7 +282,9 @@ plot_results(train_results, train_batch_sizes, "Training Step: 7 Layer MLP (relu
 lux_mlp_gelu = Chain(
     Dense(32, 256, gelu), [Dense(256, 256, gelu) for _ in 1:5]..., Dense(256, 10))
 ps_gelu, st_gelu = Lux.setup(rng, lux_mlp_gelu)
-ps_gelu_gpu, st_gelu_gpu = ps_gelu |> gpud, st_gelu |> gpud
+ps_gelu_ra = ps_gelu |> xdev
+st_gelu_ra = st_gelu |> xdev
+st_gelu_ra_test = Lux.testmode(st_gelu) |> xdev
 
 flux_mlp_gelu = Flux.Chain(
     Flux.Dense(32, 256, gelu), [Flux.Dense(256, 256, gelu) for _ in 1:5]..., Flux.Dense(256, 10)) |> gpud
@@ -310,10 +296,7 @@ torch_mlp_gelu = nn_utils.cuda_model(nn_utils.TorchMLP("gelu"))
 ## Inference
 
 ```julia
-st_gelu_test = Lux.testmode(st_gelu_gpu)
 Flux.testmode!(flux_mlp_gelu)
-ps_gelu_ra = ps_gelu |> xdev
-st_gelu_ra = Lux.testmode(st_gelu) |> xdev
 
 gelu_results = Dict{String, NamedTuple}()
 
@@ -321,8 +304,8 @@ for bs in batch_sizes
     x_host = randn(Float32, 32, bs)
     x_gpu = x_host |> gpud
 
-    t = @benchmark CUDA.@sync($lux_mlp_gelu($x_gpu, $ps_gelu_gpu, $st_gelu_test))
-    append_timing!(gelu_results, "Lux", median(t).time / 1e9)
+    append_timing!(gelu_results, "Lux+Reactant",
+        time_lux_reactant_infer(lux_mlp_gelu, ps_gelu_ra, st_gelu_ra_test, x_host))
 
     t = @benchmark CUDA.@sync($flux_mlp_gelu($x_gpu))
     append_timing!(gelu_results, "Flux", median(t).time / 1e9)
@@ -331,11 +314,6 @@ for bs in batch_sizes
     ps_sc, st_sc = Lux.setup(rng, sc_model)
     t = @benchmark $sc_model($x_host, $ps_sc, $st_sc)
     append_timing!(gelu_results, "SimpleChains", median(t).time / 1e9)
-
-    x_ra = Reactant.ConcreteRArray(x_host)
-    compiled_fn = @compile lux_mlp_gelu(x_ra, ps_gelu_ra, st_gelu_ra)
-    t = @benchmark $compiled_fn($x_ra, $ps_gelu_ra, $st_gelu_ra)
-    append_timing!(gelu_results, "Reactant", median(t).time / 1e9)
 
     x_py = nn_utils.to_jax_gpu(to_row_major(x_host))
     jax_time = pyconvert(Float64, nn_utils.time_jax_inference(nn_utils.jax_mlp_gelu_forward, jax_mlp_gelu_params, x_py))
@@ -364,19 +342,8 @@ for bs in train_batch_sizes
     x_gpu = x_host |> gpud
     y_gpu = y_host |> gpud
 
-    opt_state = Optimisers.setup(Adam(1.0f-3), ps_gelu_gpu)
-    function lux_gelu_step(model, ps, st, opt_state, x, y)
-        (loss, st_new), back = Zygote.pullback(p -> begin
-            ypred, st_ = model(x, p, st)
-            sum(abs2, ypred .- y), st_
-        end, ps)
-        gs = back((one(loss), nothing))[1]
-        opt_state_new, ps_new = Optimisers.update(opt_state, ps, gs)
-        ps_new, st_new, opt_state_new, loss
-    end
-    lux_gelu_step(lux_mlp_gelu, ps_gelu_gpu, st_gelu_gpu, opt_state, x_gpu, y_gpu)
-    t = @benchmark CUDA.@sync($lux_gelu_step($lux_mlp_gelu, $ps_gelu_gpu, $st_gelu_gpu, $opt_state, $x_gpu, $y_gpu))
-    append_timing!(gelu_train_results, "Lux+Zygote", median(t).time / 1e9)
+    append_timing!(gelu_train_results, "Lux+Reactant",
+        time_lux_reactant_train(lux_mlp_gelu, ps_gelu_ra, st_gelu_ra, x_host, y_host))
 
     flux_opt = Flux.setup(Adam(1.0f-3), flux_mlp_gelu)
     Flux.trainmode!(flux_mlp_gelu)
@@ -388,17 +355,6 @@ for bs in train_batch_sizes
     flux_gelu_step(flux_mlp_gelu, flux_opt, x_gpu, y_gpu)
     t = @benchmark CUDA.@sync($flux_gelu_step($flux_mlp_gelu, $flux_opt, $x_gpu, $y_gpu))
     append_timing!(gelu_train_results, "Flux+Zygote", median(t).time / 1e9)
-
-    x_ra = Reactant.ConcreteRArray(x_host)
-    y_ra = Reactant.ConcreteRArray(y_host)
-    ts_gelu = Training.TrainState(lux_mlp_gelu, ps_gelu_ra, st_gelu_ra, Adam(1.0f-3))
-    function reactant_gelu_step(ts, x, y)
-        _, loss, _, ts_new = Training.single_train_step!(AutoEnzyme(), MSELoss(), (x, y), ts)
-        ts_new, loss
-    end
-    reactant_gelu_step(ts_gelu, x_ra, y_ra)
-    t = @benchmark $reactant_gelu_step($ts_gelu, $x_ra, $y_ra)
-    append_timing!(gelu_train_results, "Reactant", median(t).time / 1e9)
 
     x_py = nn_utils.to_jax_gpu(to_row_major(x_host))
     y_py = nn_utils.to_jax_gpu(to_row_major(y_host))
@@ -431,7 +387,9 @@ lux_mlp_bn = Chain(
     [Chain(Dense(256, 256), BatchNorm(256, relu)) for _ in 1:5]...,
     Dense(256, 10))
 ps_bn, st_bn = Lux.setup(rng, lux_mlp_bn)
-ps_bn_gpu, st_bn_gpu = ps_bn |> gpud, st_bn |> gpud
+ps_bn_ra = ps_bn |> xdev
+st_bn_ra = st_bn |> xdev
+st_bn_ra_test = Lux.testmode(st_bn) |> xdev
 
 flux_mlp_bn = Flux.Chain(
     Flux.Dense(32, 256), Flux.BatchNorm(256, relu),
@@ -444,10 +402,7 @@ torch_mlp_bn = nn_utils.cuda_model(nn_utils.TorchMLPBN())
 ## Inference
 
 ```julia
-st_bn_test = Lux.testmode(st_bn_gpu)
 Flux.testmode!(flux_mlp_bn)
-ps_bn_ra = ps_bn |> xdev
-st_bn_ra = Lux.testmode(st_bn) |> xdev
 
 bn_batch_sizes = [2, 8, 32, 128, 512, 2048]
 bn_results = Dict{String, NamedTuple}()
@@ -456,16 +411,11 @@ for bs in bn_batch_sizes
     x_host = randn(Float32, 32, bs)
     x_gpu = x_host |> gpud
 
-    t = @benchmark CUDA.@sync($lux_mlp_bn($x_gpu, $ps_bn_gpu, $st_bn_test))
-    append_timing!(bn_results, "Lux", median(t).time / 1e9)
+    append_timing!(bn_results, "Lux+Reactant",
+        time_lux_reactant_infer(lux_mlp_bn, ps_bn_ra, st_bn_ra_test, x_host))
 
     t = @benchmark CUDA.@sync($flux_mlp_bn($x_gpu))
     append_timing!(bn_results, "Flux", median(t).time / 1e9)
-
-    x_ra = Reactant.ConcreteRArray(x_host)
-    compiled_fn = @compile lux_mlp_bn(x_ra, ps_bn_ra, st_bn_ra)
-    t = @benchmark $compiled_fn($x_ra, $ps_bn_ra, $st_bn_ra)
-    append_timing!(bn_results, "Reactant", median(t).time / 1e9)
 
     # PyTorch (JAX lacks a simple functional BatchNorm)
     x_torch = nn_utils.to_torch_gpu(to_row_major(x_host))
@@ -489,19 +439,8 @@ for bs in train_batch_sizes
     x_gpu = x_host |> gpud
     y_gpu = y_host |> gpud
 
-    opt_state = Optimisers.setup(Adam(1.0f-3), ps_bn_gpu)
-    function lux_bn_step(model, ps, st, opt_state, x, y)
-        (loss, st_new), back = Zygote.pullback(p -> begin
-            ypred, st_ = model(x, p, st)
-            sum(abs2, ypred .- y), st_
-        end, ps)
-        gs = back((one(loss), nothing))[1]
-        opt_state_new, ps_new = Optimisers.update(opt_state, ps, gs)
-        ps_new, st_new, opt_state_new, loss
-    end
-    lux_bn_step(lux_mlp_bn, ps_bn_gpu, st_bn_gpu, opt_state, x_gpu, y_gpu)
-    t = @benchmark CUDA.@sync($lux_bn_step($lux_mlp_bn, $ps_bn_gpu, $st_bn_gpu, $opt_state, $x_gpu, $y_gpu))
-    append_timing!(bn_train_results, "Lux+Zygote", median(t).time / 1e9)
+    append_timing!(bn_train_results, "Lux+Reactant",
+        time_lux_reactant_train(lux_mlp_bn, ps_bn_ra, st_bn_ra, x_host, y_host))
 
     flux_opt = Flux.setup(Adam(1.0f-3), flux_mlp_bn)
     Flux.trainmode!(flux_mlp_bn)
@@ -513,17 +452,6 @@ for bs in train_batch_sizes
     flux_bn_step(flux_mlp_bn, flux_opt, x_gpu, y_gpu)
     t = @benchmark CUDA.@sync($flux_bn_step($flux_mlp_bn, $flux_opt, $x_gpu, $y_gpu))
     append_timing!(bn_train_results, "Flux+Zygote", median(t).time / 1e9)
-
-    x_ra = Reactant.ConcreteRArray(x_host)
-    y_ra = Reactant.ConcreteRArray(y_host)
-    ts_bn = Training.TrainState(lux_mlp_bn, ps_bn_ra, st_bn_ra, Adam(1.0f-3))
-    function reactant_bn_step(ts, x, y)
-        _, loss, _, ts_new = Training.single_train_step!(AutoEnzyme(), MSELoss(), (x, y), ts)
-        ts_new, loss
-    end
-    reactant_bn_step(ts_bn, x_ra, y_ra)
-    t = @benchmark $reactant_bn_step($ts_bn, $x_ra, $y_ra)
-    append_timing!(bn_train_results, "Reactant", median(t).time / 1e9)
 
     # PyTorch
     torch_bn_model = nn_utils.cuda_model(nn_utils.TorchMLPBN())
@@ -551,7 +479,9 @@ lux_lenet = Chain(
     Conv((5, 5), 6 => 16, relu), MaxPool((2, 2)),
     FlattenLayer(), Dense(256, 120, relu), Dense(120, 84, relu), Dense(84, 10))
 ps_lenet, st_lenet = Lux.setup(rng, lux_lenet)
-ps_lenet_gpu, st_lenet_gpu = ps_lenet |> gpud, st_lenet |> gpud
+ps_lenet_ra = ps_lenet |> xdev
+st_lenet_ra = st_lenet |> xdev
+st_lenet_ra_test = Lux.testmode(st_lenet) |> xdev
 
 flux_lenet = Flux.Chain(
     Flux.Conv((5, 5), 1 => 6, relu), Flux.MaxPool((2, 2)),
@@ -567,10 +497,7 @@ lenet_batch_sizes = [2, 8, 32, 128]
 ## Inference
 
 ```julia
-st_lenet_test = Lux.testmode(st_lenet_gpu)
 Flux.testmode!(flux_lenet)
-ps_lenet_ra = ps_lenet |> xdev
-st_lenet_ra = Lux.testmode(st_lenet) |> xdev
 
 lenet_results = Dict{String, NamedTuple}()
 
@@ -578,16 +505,11 @@ for bs in lenet_batch_sizes
     x_host = randn(Float32, 28, 28, 1, bs)  # WHCN
     x_gpu = x_host |> gpud
 
-    t = @benchmark CUDA.@sync($lux_lenet($x_gpu, $ps_lenet_gpu, $st_lenet_test))
-    append_timing!(lenet_results, "Lux", median(t).time / 1e9)
+    append_timing!(lenet_results, "Lux+Reactant",
+        time_lux_reactant_infer(lux_lenet, ps_lenet_ra, st_lenet_ra_test, x_host))
 
     t = @benchmark CUDA.@sync($flux_lenet($x_gpu))
     append_timing!(lenet_results, "Flux", median(t).time / 1e9)
-
-    x_ra = Reactant.ConcreteRArray(x_host)
-    compiled_fn = @compile lux_lenet(x_ra, ps_lenet_ra, st_lenet_ra)
-    t = @benchmark $compiled_fn($x_ra, $ps_lenet_ra, $st_lenet_ra)
-    append_timing!(lenet_results, "Reactant", median(t).time / 1e9)
 
     # JAX/PyTorch use NCHW
     x_py = to_nchw(x_host)
@@ -618,19 +540,8 @@ for bs in lenet_train_batch_sizes
     x_gpu = x_host |> gpud
     y_gpu = y_host |> gpud
 
-    opt_state = Optimisers.setup(Adam(1.0f-3), ps_lenet_gpu)
-    function lux_lenet_step(model, ps, st, opt_state, x, y)
-        (loss, st_new), back = Zygote.pullback(p -> begin
-            ypred, st_ = model(x, p, st)
-            sum(abs2, ypred .- y), st_
-        end, ps)
-        gs = back((one(loss), nothing))[1]
-        opt_state_new, ps_new = Optimisers.update(opt_state, ps, gs)
-        ps_new, st_new, opt_state_new, loss
-    end
-    lux_lenet_step(lux_lenet, ps_lenet_gpu, st_lenet_gpu, opt_state, x_gpu, y_gpu)
-    t = @benchmark CUDA.@sync($lux_lenet_step($lux_lenet, $ps_lenet_gpu, $st_lenet_gpu, $opt_state, $x_gpu, $y_gpu))
-    append_timing!(lenet_train_results, "Lux+Zygote", median(t).time / 1e9)
+    append_timing!(lenet_train_results, "Lux+Reactant",
+        time_lux_reactant_train(lux_lenet, ps_lenet_ra, st_lenet_ra, x_host, y_host))
 
     flux_opt = Flux.setup(Adam(1.0f-3), flux_lenet)
     Flux.trainmode!(flux_lenet)
@@ -642,17 +553,6 @@ for bs in lenet_train_batch_sizes
     flux_lenet_step(flux_lenet, flux_opt, x_gpu, y_gpu)
     t = @benchmark CUDA.@sync($flux_lenet_step($flux_lenet, $flux_opt, $x_gpu, $y_gpu))
     append_timing!(lenet_train_results, "Flux+Zygote", median(t).time / 1e9)
-
-    x_ra = Reactant.ConcreteRArray(x_host)
-    y_ra = Reactant.ConcreteRArray(y_host)
-    ts_lenet = Training.TrainState(lux_lenet, ps_lenet_ra, st_lenet_ra, Adam(1.0f-3))
-    function reactant_lenet_step(ts, x, y)
-        _, loss, _, ts_new = Training.single_train_step!(AutoEnzyme(), MSELoss(), (x, y), ts)
-        ts_new, loss
-    end
-    reactant_lenet_step(ts_lenet, x_ra, y_ra)
-    t = @benchmark $reactant_lenet_step($ts_lenet, $x_ra, $y_ra)
-    append_timing!(lenet_train_results, "Reactant", median(t).time / 1e9)
 
     x_py = to_nchw(x_host)
     x_jnp = nn_utils.to_jax_gpu(x_py)
@@ -697,7 +597,9 @@ lux_resnet = Chain(
     Conv((3, 3), 128 => 128; pad=1, use_bias=false), BatchNorm(128),
     GlobalMeanPool(), FlattenLayer(), Dense(128, 10))
 ps_resnet, st_resnet = Lux.setup(rng, lux_resnet)
-ps_resnet_gpu, st_resnet_gpu = ps_resnet |> gpud, st_resnet |> gpud
+ps_resnet_ra = ps_resnet |> xdev
+st_resnet_ra = st_resnet |> xdev
+st_resnet_ra_test = Lux.testmode(st_resnet) |> xdev
 
 torch_resnet = nn_utils.cuda_model(nn_utils.TorchSmallResNet())
 
@@ -707,23 +609,13 @@ resnet_batch_sizes = [2, 8, 32]
 ## Inference
 
 ```julia
-st_resnet_test = Lux.testmode(st_resnet_gpu)
-ps_resnet_ra = ps_resnet |> xdev
-st_resnet_ra = Lux.testmode(st_resnet) |> xdev
-
 resnet_results = Dict{String, NamedTuple}()
 
 for bs in resnet_batch_sizes
     x_host = randn(Float32, 32, 32, 3, bs)  # WHCN
-    x_gpu = x_host |> gpud
 
-    t = @benchmark CUDA.@sync($lux_resnet($x_gpu, $ps_resnet_gpu, $st_resnet_test))
-    append_timing!(resnet_results, "Lux", median(t).time / 1e9)
-
-    x_ra = Reactant.ConcreteRArray(x_host)
-    compiled_fn = @compile lux_resnet(x_ra, ps_resnet_ra, st_resnet_ra)
-    t = @benchmark $compiled_fn($x_ra, $ps_resnet_ra, $st_resnet_ra)
-    append_timing!(resnet_results, "Reactant", median(t).time / 1e9)
+    append_timing!(resnet_results, "Lux+Reactant",
+        time_lux_reactant_infer(lux_resnet, ps_resnet_ra, st_resnet_ra_test, x_host))
 
     x_py = to_nchw(x_host)
     x_torch = nn_utils.to_torch_gpu(x_py)
@@ -745,33 +637,9 @@ resnet_train_batch_sizes = [8, 32]
 for bs in resnet_train_batch_sizes
     x_host = randn(Float32, 32, 32, 3, bs)
     y_host = randn(Float32, 10, bs)
-    x_gpu = x_host |> gpud
-    y_gpu = y_host |> gpud
 
-    opt_state = Optimisers.setup(Adam(1.0f-3), ps_resnet_gpu)
-    function lux_resnet_step(model, ps, st, opt_state, x, y)
-        (loss, st_new), back = Zygote.pullback(p -> begin
-            ypred, st_ = model(x, p, st)
-            sum(abs2, ypred .- y), st_
-        end, ps)
-        gs = back((one(loss), nothing))[1]
-        opt_state_new, ps_new = Optimisers.update(opt_state, ps, gs)
-        ps_new, st_new, opt_state_new, loss
-    end
-    lux_resnet_step(lux_resnet, ps_resnet_gpu, st_resnet_gpu, opt_state, x_gpu, y_gpu)
-    t = @benchmark CUDA.@sync($lux_resnet_step($lux_resnet, $ps_resnet_gpu, $st_resnet_gpu, $opt_state, $x_gpu, $y_gpu))
-    append_timing!(resnet_train_results, "Lux+Zygote", median(t).time / 1e9)
-
-    x_ra = Reactant.ConcreteRArray(x_host)
-    y_ra = Reactant.ConcreteRArray(y_host)
-    ts_resnet = Training.TrainState(lux_resnet, ps_resnet_ra, st_resnet_ra, Adam(1.0f-3))
-    function reactant_resnet_step(ts, x, y)
-        _, loss, _, ts_new = Training.single_train_step!(AutoEnzyme(), MSELoss(), (x, y), ts)
-        ts_new, loss
-    end
-    reactant_resnet_step(ts_resnet, x_ra, y_ra)
-    t = @benchmark $reactant_resnet_step($ts_resnet, $x_ra, $y_ra)
-    append_timing!(resnet_train_results, "Reactant", median(t).time / 1e9)
+    append_timing!(resnet_train_results, "Lux+Reactant",
+        time_lux_reactant_train(lux_resnet, ps_resnet_ra, st_resnet_ra, x_host, y_host))
 
     torch_rn = nn_utils.cuda_model(nn_utils.TorchSmallResNet())
     torch_opt = torch.optim.Adam(torch_rn.parameters(); lr=1e-3)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

After https://github.com/SciML/SciMLBenchmarks.jl/pull/1656 the NeuralNetworks weave was on the GPU runner, but Lux still ran eager `CuArray` + Zygote. Reactant was only a side series (`ConcreteRArray` + `@compile`). This makes compiled Reactant the Lux path, matching the [Lux Reactant tutorial](https://lux.csail.mit.edu/stable/manual/compiling_lux_models).

## What changed

- **Lux inference:** `x |> reactant_device()` then `@compile model(x, ps, st)`
- **Lux training:** `Training.TrainState` + `Training.single_train_step!(AutoEnzyme(), MSELoss(), …)`
- Train-mode states for training (the old Reactant series reused `testmode` states, which is wrong for BatchNorm)
- Removed eager Lux and `Lux+Zygote` timings (they were the same model as the Reactant series)
- Flux stays eager CUDA + Zygote; SimpleChains stays CPU; JAX/PyTorch unchanged

## Verification

No NVIDIA driver on this machine, so no compiled GPU run. The weave is a mechanical swap onto the documented Lux API. Full `simple_networks` weave not run.

cc @ChrisRackauckas
