### PR TITLE
ci: fix typos in benchmark data

### DIFF
--- a/benchmarks/OptimizationFrameworks/opf_data/pglib_opf_case3_lmbd.m
+++ b/benchmarks/OptimizationFrameworks/opf_data/pglib_opf_case3_lmbd.m
@@ -33,7 +33,7 @@
 %   Licensed under the Creative Commons Attribution 4.0
 %   International license, http://creativecommons.org/licenses/by/4.0/
 %
-%   Contact M.E. Brennan (me.brennan@ieee.org) for inquries on further reuse of
+%   Contact M.E. Brennan (me.brennan@ieee.org) for inquiries on further reuse of
 %   this dataset.
 %
 function mpc = pglib_opf_case3_lmbd

--- a/benchmarks/OptimizationFrameworks/opf_data/pglib_opf_case5_pjm.m
+++ b/benchmarks/OptimizationFrameworks/opf_data/pglib_opf_case5_pjm.m
@@ -20,7 +20,7 @@
 %   Licensed under the Creative Commons Attribution 4.0
 %   International license, http://creativecommons.org/licenses/by/4.0/
 %
-%   Contact M.E. Brennan (me.brennan@ieee.org) for inquries on further reuse of
+%   Contact M.E. Brennan (me.brennan@ieee.org) for inquiries on further reuse of
 %   this dataset.
 %
 function mpc = pglib_opf_case5_pjm


### PR DESCRIPTION
## Why
This is a trivial CI hygiene cleanup in benchmark data files, fixing a misspelling caught by `typos`.

## Verification
- Before: `typos .` reported two occurrences of `inquries` in
  - `benchmarks/OptimizationFrameworks/opf_data/pglib_opf_case3_lmbd.m`
  - `benchmarks/OptimizationFrameworks/opf_data/pglib_opf_case5_pjm.m`
- After:
  - `INPUT_RUNIC_EXTENSIONS=jl INPUT_RUNIC_DOCSTRINGS=false julia --project=@runic -e 'using Runic; bad = String[]; ...' .` exits 0
  - `typos .` exits 0

Please ignore this PR until reviewed by @ChrisRackauckas.
