### PR TITLE
Fix HighOrderWeakSDE ensemble prob_func to use ctx.sim_id

### DIFF
--- a/benchmarks/NonStiffSDE/HighOrderWeakSDEWorkPrecision.jmd
+++ b/benchmarks/NonStiffSDE/HighOrderWeakSDEWorkPrecision.jmd
@@ -58,7 +58,7 @@ Random.seed!(seed)
 seeds = rand(UInt, numtraj)
 
 function prob_func(prob, ctx)
-    remake(prob, seed = seeds[ctx.i])
+    remake(prob, seed = seeds[ctx.sim_id])
 end
 
 h2(z) = z^2
@@ -173,7 +173,7 @@ numtraj_bruss = 100
 seeds_bruss = rand(UInt, numtraj_bruss)
 
 function prob_func_bruss(prob, ctx)
-    Random.seed!(seeds_bruss[ctx.i])
+    Random.seed!(seeds_bruss[ctx.sim_id])
     W = WienerProcess(0.0, 0.0, 0.0)
     remake(prob, noise = W)
 end


### PR DESCRIPTION
The two ensemble prob_func closures still used ctx.i. Switched them to ctx.sim_id.

The two weak WorkPrecisionSet plots still error from upstream issues, tracked in #1662.