### PR TITLE
docs: enable strict benchmark documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ makedocs(
     sitename = "The SciML Benchmarks",
     authors = "Chris Rackauckas",
     modules = [SciMLBenchmarksOutput],
-    clean = true, doctest = false, warnonly = [:footnote],
+    clean = true,
     format = Documenter.HTML(#analytics = "UA-90474609-3",
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/SciMLBenchmarksOutput/stable/",


### PR DESCRIPTION
## Summary

Remove the repository-specific `doctest = false` and `warnonly = [:footnote]` settings from the benchmark documentation configuration. The generated `SciMLBenchmarksOutput` docs are now built with Documenter defaults, so documentation examples and errors are not silently skipped.

## Verification

- The source checkout cannot build standalone because `docs/pages.jl` expects generated `markdown/` benchmark output; this is the documented publish pipeline.
- Reproduced the same `docs/make.jl` in a clean checkout of `SciMLBenchmarksOutput`, with the strict settings applied: `julia --startup-file=no --project=docs docs/make.jl` completed successfully with doctests enabled and no `warnonly` setting.
- `julia --startup-file=no --project=@runic -m Runic --check docs/make.jl`: passed.
- `typos --isolated --format brief docs/make.jl`: passed.
- `git diff --check`: passed.

Please ignore this draft PR until reviewed by @ChrisRackauckas.