### PR TITLE
Revert "docs: enable strict benchmark documentation" (#1664)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ makedocs(
     sitename = "The SciML Benchmarks",
     authors = "Chris Rackauckas",
     modules = [SciMLBenchmarksOutput],
-    clean = true,
+    clean = true, doctest = false, warnonly = [:footnote],
     format = Documenter.HTML(#analytics = "UA-90474609-3",
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/SciMLBenchmarksOutput/stable/",


### PR DESCRIPTION
Reverts #1664, which I merged during a bot-PR sweep before noticing that SciMLBenchmarks is on the standing do-not-auto-merge list.

The one-line diff removed `doctest = false, warnonly = [:footnote]` from `docs/make.jl`. Documenter defaults `doctest` to `true`, so that turns doctests on across every benchmark page, and drops the footnote warning allowance. The PR CI matrix here does not build the docs, so the change came back CLEAN without ever exercising what it changed.

Restoring the previous settings. If strict benchmark docs are actually wanted, it should land with a docs build that proves it passes.