### PR TITLE
CI: per-run concurrency groups on master; make publish safe under concurrency

### DIFF
--- a/.github/scripts/publish_benchmark_output.sh
+++ b/.github/scripts/publish_benchmark_output.sh
@@ -15,28 +15,74 @@ ssh-add "${DEPLOY_KEY_FILE}"
 git config --global user.email "github-actions@sciml.ai"
 git config --global user.name "SciML Benchmarks CI"
 
-# Clone SciMLBenchmarksOutput to temporary directory
-temp_dir=$(mktemp -d)
-git -C "${temp_dir}" clone git@github.com:SciML/SciMLBenchmarksOutput .
-
-# Copy output artifacts into it
+# Nothing to do if no benchmark job uploaded artifacts (download-artifact is
+# continue-on-error, so this script still runs).
+have_output=false
 for d in docs html notebook pdf script markdown; do
     if [[ -d "${d}" ]]; then
-        cp -vRa "${d}/" "${temp_dir}"
+        have_output=true
     fi
 done
-
-# Commit and push
-set -e
-git -C "${temp_dir}" add .
-if git -C "${temp_dir}" diff --cached --quiet; then
-    echo "No changes to publish."
-else
-    git -C "${temp_dir}" commit -m "Automatic build
-Published by build of: ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
-    git -C "${temp_dir}" push
+if [[ "${have_output}" != true ]]; then
+    echo "No benchmark output directories found; nothing to publish."
+    rm -f "${DEPLOY_KEY_FILE}"
+    exit 0
 fi
+
+# Publish jobs from different master runs are not serialized by a concurrency
+# group (that would let a newly queued publish cancel a pending one and lose
+# its results). Instead, tolerate concurrent publishes: if the push is
+# rejected because another run pushed first, re-clone and try again. Each
+# attempt copies the same files on top of the newest SciMLBenchmarksOutput, so
+# retrying is safe; there is nothing to merge.
+MAX_ATTEMPTS=${PUBLISH_MAX_ATTEMPTS:-6}
+OUTPUT_REPO=${PUBLISH_OUTPUT_REPO:-git@github.com:SciML/SciMLBenchmarksOutput}
+# Optional hook run after the clone, before the push (used by the local test to
+# inject a concurrent push). Unset in CI.
+PUBLISH_PRE_PUSH_HOOK=${PUBLISH_PRE_PUSH_HOOK:-}
+attempt=1
+while true; do
+    temp_dir=$(mktemp -d)
+    git -C "${temp_dir}" clone --depth 1 "${OUTPUT_REPO}" .
+
+    # Copy output artifacts into it
+    for d in docs html notebook pdf script markdown; do
+        if [[ -d "${d}" ]]; then
+            cp -vRa "${d}/" "${temp_dir}"
+        fi
+    done
+
+    git -C "${temp_dir}" add .
+    if git -C "${temp_dir}" diff --cached --quiet; then
+        echo "No changes to publish."
+        rm -rf "${temp_dir}"
+        break
+    fi
+
+    git -C "${temp_dir}" commit -q -m "Automatic build
+Published by build of: ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+
+    if [[ -n "${PUBLISH_PRE_PUSH_HOOK}" ]]; then
+        "${PUBLISH_PRE_PUSH_HOOK}" "${attempt}"
+    fi
+
+    if git -C "${temp_dir}" push; then
+        echo "Published on attempt ${attempt}."
+        rm -rf "${temp_dir}"
+        break
+    fi
+
+    rm -rf "${temp_dir}"
+    if [[ "${attempt}" -ge "${MAX_ATTEMPTS}" ]]; then
+        echo "::error::Failed to push to SciMLBenchmarksOutput after ${attempt} attempts."
+        rm -f "${DEPLOY_KEY_FILE}"
+        exit 1
+    fi
+    # Jitter so two publishers that collided don't retry in lock-step.
+    sleep $((10 + RANDOM % 20))
+    attempt=$((attempt + 1))
+    echo "Push rejected (another publish likely landed first); retrying (attempt ${attempt}/${MAX_ATTEMPTS})..."
+done
 
 # Clean up
 rm -f "${DEPLOY_KEY_FILE}"
-rm -rf "${temp_dir}"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,9 +15,20 @@ on:
         required: false
         type: string
 
-# Cancel in-progress PR runs (but not master — benchmarks are long-running)
+# PR runs: one group per ref, newer pushes cancel the in-progress run.
+#
+# master runs (push and workflow_dispatch): one group PER RUN, so they never
+# queue behind or evict each other. GitHub allows only one running + one
+# pending run per group; a newly queued run CANCELS the pending one. With a
+# single shared master group, a multi-day folder (e.g. SimpleHandwrittenPDE)
+# held the group for days while every later master push was first parked as
+# pending and then silently cancelled by the next push — its benchmark jobs
+# never ran and nothing reached SciMLBenchmarksOutput, even though other
+# self-hosted runners sat idle. Per-run groups let the matrix jobs spread over
+# all available runners; the only thing that must be serialized is the push
+# to SciMLBenchmarksOutput, which publish_benchmark_output.sh handles itself.
 concurrency:
-  group: benchmarks-${{ github.ref }}
+  group: benchmarks-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
@@ -121,9 +132,12 @@ jobs:
     # publish_benchmark_output.sh is a no-op when there's nothing new.
     if: always() && github.ref == 'refs/heads/master' && (needs.benchmark.result == 'success' || needs.benchmark.result == 'failure')
     runs-on: [self-hosted, benchmark]
-    concurrency:
-      group: scimlbenchmarks-deploy
-      cancel-in-progress: false
+    # No concurrency group here on purpose. A job-level group has the same
+    # one-running + one-pending semantics as above, so with several master runs
+    # finishing close together the middle run's publish job would be cancelled
+    # and its results lost. Concurrent publishes are instead made safe by
+    # publish_benchmark_output.sh, which re-clones and retries when the push to
+    # SciMLBenchmarksOutput is rejected as non-fast-forward.
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Problem

`benchmarks.yml` uses one concurrency group for every master run (`benchmarks-refs/heads/master`). GitHub allows one running + one pending run per group, and a newly queued run **cancels** the pending one. Effects observed this week:

- Run [32024671720](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32024671720) (#1651) has held the group since Aug 19 because its `SimpleHandwrittenPDE` job is multi-day (timeout 200 h). LinearSolve (last published **2025-01-29**), ComplicatedPDE, AstroChem and LinearSolveGPU all succeeded in that run but can't publish until it ends — while amdci1-1 sits idle.
- Run [32389171706](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32389171706) (#1663, NonStiffSDE) was parked pending, then cancelled at `2026-08-21T19:27:27Z` — the exact second run [32518558085](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32518558085) (#1641) was queued. Its benchmark jobs never ran. 32518558085 is itself still `pending` with zero jobs.
- Run [31479805309](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/31479805309) (#1629): DynamicalODE, NonlinearProblem, LinearSolveDistributed, PSOGlobalOptimization succeeded, but queued siblings expired (>24 h) so the run was marked cancelled and `Publish Results` was skipped — those results were discarded. SciMLBenchmarksOutput still shows DynamicalODE at 2025-12-30 and NonlinearProblem at 2026-03-04.

Any `workflow_dispatch` on master right now would also evict the pending #1641 run and then wait behind SimpleHandwrittenPDE.

## Changes

- **Per-run concurrency group on master** (push + workflow_dispatch): `group: benchmarks-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}`. Master runs now spread across all self-hosted runners and never evict each other. PR runs keep the per-ref cancel-in-progress behaviour.
- **Remove the job-level `scimlbenchmarks-deploy` group on Publish Results.** It has the same one-pending semantics, so with several master runs finishing close together the middle run's publish would be cancelled and its results lost.
- **Make `publish_benchmark_output.sh` safe under concurrent publishers instead**: clone → copy → commit → push in a retry loop; on a non-fast-forward rejection it re-clones and retries (default 6 attempts, jittered). Every attempt lays the same artifact files over the newest output, so there's nothing to merge. Also: early exit when no artifact dirs were downloaded, `--depth 1` clone, and `PUBLISH_OUTPUT_REPO` / `PUBLISH_PRE_PUSH_HOOK` env overrides for testing.

## Testing

- YAML parses; expression semantics checked against GitHub's concurrency docs (one running + one pending per group).
- Local two-publisher test of the script against a bare repo (hook injects a competing push between clone and push on attempt 1): push rejected → re-cloned → published on attempt 2, with both publishers' files present in the final tree.

## Not in this PR (follow-ups)

- `SimpleHandwrittenPDE` and `StiffODE` now run >119 h per folder (both got cancelled at that point on Aug 19); a per-folder timeout or per-file targets are needed so one folder can't hold a runner for a week. Being looked at separately.
- The Weekly Update job is broken (never commits Manifest-only bumps because of `> 1`; crashed on `git checkout GlobalOptimization`; OrdinaryDiffEqBDF/SciMLBase `AutoDespecialize` resolve failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrTtUuDkfgNEq3asQuZ3F6
