### PR TITLE
Bio: unbreak Bidkhori2012 and bring the folder back under a CI-sized budget

### DIFF
--- a/benchmarks/Bio/BCR.jmd
+++ b/benchmarks/Bio/BCR.jmd
@@ -160,55 +160,42 @@ catch e
 end
 ```
 
-## Work-Precision Diagrams (competitive CVODE / lsoda)
+## Work-Precision Diagrams (competitive solvers)
 
-Main suite: methods that remain competitive on this large sparse stiff system.
-Dense Lapack and bare GMRES (no preconditioner) are timed only in the loser
-section below.
+Main suites: methods that remain competitive on this large sparse stiff system.
+Everything else is timed once, in isolation, in the loser section below.
+
+`lsoda` and the default dense `CVODE_BDF` used to be swept across this whole
+tolerance grid. Measured on CI (2026-07-27 build, per point): `lsoda` 500-1200 s
+and `CVODE_BDF` 210-370 s, against 9-22 s for `CVODE_BDF` with GMRES +
+incomplete LU. That one panel alone cost 2 h 44 min of the document's 7 h 57 min,
+so both were moved to the isolation section. `TRBDF2` (880 s / 975 s summed over
+the grid for the GMRES+iLU and KLU variants) and `KenCarp4` with GMRES+iLU
+(870 s) were removed from the Julia panels for the same reason - roughly 7x
+`QNDF`/`FBDF` in the same configuration.
+
+#### GMRES + incomplete LU
 
 ```julia
 setups = [
-    Dict(:alg=>lsoda(), :prob_choice => 1),
-    Dict(:alg=>CVODE_BDF(), :prob_choice => 1),
     Dict(
         :alg=>CVODE_BDF(linear_solver = :GMRES, prec = precilu, psetup = psetupilu, prec_side = 1),
-        :prob_choice => 2)
+        :prob_choice => 2),
+    Dict(:alg=>QNDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true),
+        :prob_choice => 3),
+    Dict(:alg=>FBDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true),
+        :prob_choice => 3),
+    Dict(:alg=>NordsieckBDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true),
+        :prob_choice => 3)
 ];
 ```
 
 ```julia
 wp = WorkPrecisionSet(
     [oprob, oprob_sparse, sparsejacprob], abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = [test_sol, test_sol, test_sol], maxiters = Int(1e6), numruns = 1)
+    saveat = tf/1000.0, appxsol = [test_sol, test_sol, test_sol], maxiters = Int(1e6), numruns = 1)
 
-names = ["lsoda" "CVODE_BDF" "CVODE_BDF (GMRES, iLU)"]
-plot(wp; label = names)
-```
-
-## Work-Precision Diagrams (competitive Julia solvers)
-
-Only preconditioned GMRES and sparse KLU variants; default dense factorizations
-and unpreconditioned GMRES are in the loser section.
-
-#### GMRES + incomplete LU
-
-```julia
-setups = [
-    Dict(:alg=>TRBDF2(
-        linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true)),
-    Dict(:alg=>QNDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true)),
-    Dict(:alg=>FBDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true)),
-    Dict(:alg=>NordsieckBDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true)),
-    Dict(:alg=>KenCarp4(
-        linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true))
-];
-```
-
-```julia
-wp = WorkPrecisionSet(sparsejacprob, abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = test_sol, maxiters = Int(1e6), numruns = 1)
-
-names = ["TRBDF2 (GMRES, iLU)" "QNDF (GMRES, iLU)" "FBDF (GMRES, iLU)" "NordsieckBDF (GMRES, iLU)" "KenCarp4 (GMRES, iLU)"]
+names = ["CVODE_BDF (GMRES, iLU)" "QNDF (GMRES, iLU)" "FBDF (GMRES, iLU)" "NordsieckBDF (GMRES, iLU)"]
 plot(wp; label = names)
 ```
 
@@ -216,7 +203,6 @@ plot(wp; label = names)
 
 ```julia
 setups = [
-    Dict(:alg=>TRBDF2(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>QNDF(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>FBDF(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>NordsieckBDF(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff())),
@@ -226,35 +212,56 @@ setups = [
 
 ```julia
 wp = WorkPrecisionSet(sparsejacprob, abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = test_sol, maxiters = Int(1e6), numruns = 1)
+    saveat = tf/1000.0, appxsol = test_sol, maxiters = Int(1e6), numruns = 1)
 
-names = ["TRBDF2 (KLU, sparse jac)" "QNDF (KLU, sparse jac)" "FBDF (KLU, sparse jac)" "NordsieckBDF (KLU, sparse jac)" "KenCarp4 (KLU, sparse jac)"]
+names = ["QNDF (KLU, sparse jac)" "FBDF (KLU, sparse jac)" "NordsieckBDF (KLU, sparse jac)" "KenCarp4 (KLU, sparse jac)"]
 plot(wp; label = names)
 ```
 
 ## Loser methods (large cost in isolation)
 
-On this ~1122-ODE sparse chemistry system, the following are not competitive:
-dense Lapack factorization, default dense Julia Newton/linear solves, and GMRES
-without a preconditioner. We do **not** fold them into the main work-precision
-suites. Instead each is timed **once**, in isolation, at a fixed tolerance, next
-to a competitive sparse reference so the wall-time gap is obvious.
+On this ~1122-ODE sparse chemistry system the following are not competitive:
+`lsoda`, dense direct CVODE (default and Lapack), default dense Julia
+Newton/linear solves, GMRES without a preconditioner, and `TRBDF2`/`KenCarp4`
+even with the good linear solvers. We do **not** fold them into the main
+work-precision suites. Instead each is timed **once**, in isolation, at a fixed
+tolerance, next to a competitive sparse reference so the wall-time gap is
+obvious.
+
+Each isolated solve is capped by wall clock. In the 2026-07-27 CI build the
+uncapped versions of the four unpreconditioned-GMRES entries alone measured
+2110 s, 3763 s, 4707 s and 7267 s - about 4.9 h for four data points, i.e. this
+"cheap isolation" section had itself become one of the most expensive parts of
+the document. A solve that hits the cap is reported as a lower bound (`>cap`),
+which is all the diagram needs in order to show the gap.
 
 ```julia
 const _loser_tol = 1e-6
 const _loser_maxiters = Int(1e6)
-_solve_kwargs = (; abstol = _loser_tol, reltol = _loser_tol, maxiters = _loser_maxiters,
-    save_everystep = false)
+const _loser_cap = 180.0   # seconds of wall clock per isolated solve
 
 loser_labels = String[]
 loser_elapsed = Float64[]
 
-function _time_loser!(label, prob, alg)
+# LSODA.jl does not support callbacks, so `lsoda` is the one entry that has to
+# run to completion; everything else is stopped by the wall-clock callback.
+function _time_loser!(label, prob, alg; cap = true)
     println("--- $label ---")
-    t = @elapsed sol = solve(prob, alg; _solve_kwargs...)
+    tstart = time()
+    kw = if cap
+        capcb = DiscreteCallback(
+            (u, t, integrator) -> time() - tstart > _loser_cap,
+            integrator -> terminate!(integrator); save_positions = (false, false))
+        (; callback = capcb)
+    else
+        (;)
+    end
+    t = @elapsed sol = solve(prob, alg; abstol = _loser_tol, reltol = _loser_tol,
+        maxiters = _loser_maxiters, save_everystep = false, kw...)
+    hit_cap = cap && t >= _loser_cap
     @show sol.retcode
-    println("elapsed = ", t, " s")
-    push!(loser_labels, label)
+    println("elapsed = ", t, " s", hit_cap ? " (hit the $(_loser_cap) s cap)" : "")
+    push!(loser_labels, hit_cap ? label * " (>cap)" : label)
     push!(loser_elapsed, t)
     return sol
 end
@@ -263,7 +270,9 @@ end
 _time_loser!("FBDF + KLU (reference)", sparsejacprob,
     FBDF(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff()))
 
-# Dense CVODE Lapack
+# Multistep dense direct solvers
+_time_loser!("lsoda", oprob, lsoda(); cap = false)
+_time_loser!("CVODE_BDF (dense)", oprob, CVODE_BDF())
 _time_loser!("CVODE_BDF LapackDense", oprob, CVODE_BDF(linear_solver = :LapackDense))
 
 # Bare CVODE GMRES (no preconditioner)
@@ -284,6 +293,16 @@ _time_loser!("FBDF GMRES (no prec)", oprob,
     FBDF(linsolve = KrylovJL_GMRES(), autodiff = AutoFiniteDiff()))
 _time_loser!("KenCarp4 GMRES (no prec)", oprob,
     KenCarp4(linsolve = KrylovJL_GMRES(), autodiff = AutoFiniteDiff()))
+
+# Slow methods with the *good* linear solvers, dropped from the panels above
+_time_loser!("TRBDF2 (GMRES, iLU)", sparsejacprob,
+    TRBDF2(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(),
+        concrete_jac = true))
+_time_loser!("KenCarp4 (GMRES, iLU)", sparsejacprob,
+    KenCarp4(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(),
+        concrete_jac = true))
+_time_loser!("TRBDF2 (KLU, sparse jac)", sparsejacprob,
+    TRBDF2(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff()))
 ```
 
 ```julia
@@ -291,7 +310,7 @@ _time_loser!("KenCarp4 GMRES (no prec)", oprob,
 ref_t = loser_elapsed[1]
 bar(loser_labels, loser_elapsed ./ ref_t; xrotation = 45, legend = false,
     ylabel = "wall time / (FBDF+KLU reference)",
-    title = "BCR loser isolation (tol=$_loser_tol, one solve each)",
+    title = "BCR loser isolation (tol=$_loser_tol, one capped solve each)",
     size = (900, 500), left_margin = 5Plots.mm, bottom_margin = 15Plots.mm)
 ```
 
@@ -331,7 +350,7 @@ For these, we generate a work-precision diagram for the selection of solvers.
 ```julia
 wp = WorkPrecisionSet(
     [oprob, oprob_sparse, sparsejacprob], abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = [test_sol, test_sol, test_sol], maxiters = Int(1e9), numruns = 200)
+    saveat = tf/1000.0, appxsol = [test_sol, test_sol, test_sol], maxiters = Int(1e9), numruns = 200)
 
 names = ["CVODE_BDF (GMRES, iLU)" "QNDF (GMRES, iLU)" "FBDF (GMRES, iLU)" "NordsieckBDF (GMRES, iLU)" "QNDF (KLU, sparse jac)" "FBDF (KLU, sparse jac)" "NordsieckBDF (KLU, sparse jac)" "KenCarp4 (KLU, sparse jac)"]
 colors = [:green :deepskyblue1 :dodgerblue2 :mediumorchid :royalblue2 :slateblue3 :orchid :lightskyblue]

--- a/benchmarks/Bio/Bidkhori2012.jmd
+++ b/benchmarks/Bio/Bidkhori2012.jmd
@@ -1444,8 +1444,9 @@ setups = [
     #Dict(:alg=>CVODE_BDF()), #Fails!
     Dict(:alg=>KenCarp4(autodiff = AutoFiniteDiff())),
     Dict(:alg=>Rodas4(autodiff = AutoFiniteDiff())),
-    Dict(:alg=>QNDF(autodiff = AutoFiniteDiff()))    #Dict(:alg=>lsoda()),
-    Dict(:alg=>NordsieckBDF(autodiff = AutoFiniteDiff()))    #Dict(:alg=>lsoda()),
+    Dict(:alg=>QNDF(autodiff = AutoFiniteDiff())),
+    Dict(:alg=>NordsieckBDF(autodiff = AutoFiniteDiff())),
+    #Dict(:alg=>lsoda()),
     #Dict(:alg=>radau()),
     #Dict(:alg=>seulex()),
     #Dict(:alg=>ImplicitEulerExtrapolation(autodiff = AutoFiniteDiff(),min_order = 8, init_order = 9,threading = OrdinaryDiffEqCore.PolyesterThreads())),
@@ -1456,8 +1457,7 @@ setups = [
     #Dict(:alg=>ImplicitHairerWannerExtrapolation(autodiff = AutoFiniteDiff(),init_order = 5, threading = false)),
 ]
 
-solnames = ["KenCarp4", "Rodas4", "QNDF", "NordsieckBDF"#"ImplEulerExtpl (threaded)", "ImplEulerExtpl (non-threaded)",    #"ImplEulerBaryExtpl (threaded)","ImplEulerBaryExtpl (non-threaded)","ImplHWExtpl (threaded)","ImplHWExtpl (non-threaded)"
-]
+solnames = ["KenCarp4", "Rodas4", "QNDF", "NordsieckBDF"]
 
 wp = WorkPrecisionSet(sparsejacprob, abstols, reltols, setups;
     names = solnames, appxsol = test_sol, save_everystep = false, maxiters = Int(1e5), numruns = 10)

--- a/benchmarks/Bio/fceri_gamma2.jmd
+++ b/benchmarks/Bio/fceri_gamma2.jmd
@@ -3,8 +3,8 @@ title: Fceri_gamma2 Work-Precision Diagrams
 author: Torkel Loman
 ---
 
-The following benchmark is of 356 ODEs with 3749 terms that describe a stiff
-chemical reaction network. This fceri_gamma2 model was used as a benchmark model in [Gupta et
+The following benchmark is of 3744 ODEs with 58276 terms that describe a stiff
+chemical reaction network - the largest network in this folder. This fceri_gamma2 model was used as a benchmark model in [Gupta et
 al.](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6013266/). It describes high-affinity human IgE receptor signalling [Faeder et
 al.](https://www.jimmunol.org/content/170/7/3769.long). We use
 [`ReactionNetworkImporters`](https://github.com/isaacsas/ReactionNetworkImporters.jl)
@@ -274,7 +274,7 @@ plot(wp; label = names)
 
 ## Methods that are not competitive (timed once, capped)
 
-On this 356-species / 3744-reaction stiff network the dense direct solves and
+On this 3744-species / 58276-reaction stiff network the dense direct solves and
 `TRBDF2` are one to two orders of magnitude off the pace of the preconditioned
 Krylov and sparse-KLU methods. Sweeping them across the whole tolerance grid
 costs multiple hours of CI time per document and dominated the runtime of this

--- a/benchmarks/Bio/fceri_gamma2.jmd
+++ b/benchmarks/Bio/fceri_gamma2.jmd
@@ -135,18 +135,32 @@ end;
 #### Sets tolerances
 
 ```julia
-abstols = 1.0 ./ 10.0 .^ (5:8)
-reltols = 1.0 ./ 10.0 .^ (5:8);
+abstols = 1.0 ./ 10.0 .^ (5:7)
+reltols = 1.0 ./ 10.0 .^ (5:7);
 ```
+
+Note on cost: this is one of the most expensive documents in the repository.
+Every work-precision point costs three solves (one for the error, one to warm
+up, one that is timed), and on this network a single stiff solve at these
+tolerances runs from a few seconds (preconditioned Krylov) to well over ten
+minutes (dense direct solves). The tolerance grid was therefore cut from four
+points (`1e-5 … 1e-8`) to three, `saveat` was relaxed from `tf/10000` to
+`tf/1000`, and the methods that are an order of magnitude off the pace are
+timed once in the isolation section below instead of being swept across every
+tolerance. See the section "Methods that are not competitive" for the measured
+numbers behind those choices.
 
 ## Work-Precision Diagrams (CVODE and lsoda solvers)
 
 #### Declare solvers.
 
+`lsoda` and the default (dense direct) `CVODE_BDF` are **not** in this suite:
+they run 700-2000 s and 300-800 s per point respectively, which is 100x the
+preconditioned-Krylov CVODE variants and by itself made this chunk take 6.5 h
+of CI time. Both are timed once in the isolation section below.
+
 ```julia
 setups = [
-    Dict(:alg=>lsoda(), :prob_choice => 1),
-    Dict(:alg=>CVODE_BDF(), :prob_choice => 1),
     Dict(:alg=>CVODE_BDF(linear_solver = :LapackDense), :prob_choice => 1),
     Dict(:alg=>CVODE_BDF(linear_solver = :GMRES), :prob_choice => 1),
     Dict(
@@ -161,9 +175,9 @@ setups = [
 ```julia
 wp = WorkPrecisionSet(
     [oprob, oprob_sparse, sparsejacprob], abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = [test_sol, test_sol, test_sol], maxiters = Int(1e9), numruns = 10)
+    saveat = tf/1000.0, appxsol = [test_sol, test_sol, test_sol], maxiters = Int(1e6), numruns = 10)
 
-names = ["lsoda" "CVODE_BDF" "CVODE_BDF (LapackDense)" "CVODE_BDF (GMRES)" "CVODE_BDF (GMRES, iLU)" "CVODE_BDF (KLU, sparse jac)"]
+names = ["CVODE_BDF (LapackDense)" "CVODE_BDF (GMRES)" "CVODE_BDF (GMRES, iLU)" "CVODE_BDF (KLU, sparse jac)"]
 plot(wp; label = names)
 ```
 
@@ -173,7 +187,6 @@ plot(wp; label = names)
 
 ```julia
 setups = [
-    Dict(:alg=>TRBDF2(autodiff = AutoFiniteDiff())),
     Dict(:alg=>QNDF(autodiff = AutoFiniteDiff())),
     Dict(:alg=>FBDF(autodiff = AutoFiniteDiff())),
     Dict(:alg=>NordsieckBDF(autodiff = AutoFiniteDiff())),
@@ -185,9 +198,9 @@ setups = [
 
 ```julia
 wp = WorkPrecisionSet(oprob, abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = test_sol, maxiters = Int(1e12), dtmin = 1e-18, numruns = 10)
+    saveat = tf/1000.0, appxsol = test_sol, maxiters = Int(1e6), numruns = 10)
 
-names = ["TRBDF2" "QNDF" "FBDF" "NordsieckBDF" "KenCarp4"]
+names = ["QNDF" "FBDF" "NordsieckBDF" "KenCarp4"]
 plot(wp; label = names)
 ```
 
@@ -195,7 +208,6 @@ plot(wp; label = names)
 
 ```julia
 setups = [
-    Dict(:alg=>TRBDF2(linsolve = KrylovJL_GMRES(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>QNDF(linsolve = KrylovJL_GMRES(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>FBDF(linsolve = KrylovJL_GMRES(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>NordsieckBDF(linsolve = KrylovJL_GMRES(), autodiff = AutoFiniteDiff())),
@@ -207,9 +219,9 @@ setups = [
 
 ```julia
 wp = WorkPrecisionSet(oprob, abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = test_sol, maxiters = Int(1e12), dtmin = 1e-18, numruns = 10)
+    saveat = tf/1000.0, appxsol = test_sol, maxiters = Int(1e6), numruns = 10)
 
-names = ["TRBDF2 (GMRES)" "QNDF (GMRES)" "FBDF (GMRES)" "NordsieckBDF (GMRES)" "KenCarp4 (GMRES)"]
+names = ["QNDF (GMRES)" "FBDF (GMRES)" "NordsieckBDF (GMRES)" "KenCarp4 (GMRES)"]
 plot(wp; label = names)
 ```
 
@@ -217,8 +229,6 @@ plot(wp; label = names)
 
 ```julia
 setups = [
-    Dict(:alg=>TRBDF2(
-        linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true)),
     Dict(:alg=>QNDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true)),
     Dict(:alg=>FBDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true)),
     Dict(:alg=>NordsieckBDF(linsolve = KrylovJL_GMRES(; precs = incompletelu), autodiff = AutoFiniteDiff(), concrete_jac = true)),
@@ -231,9 +241,9 @@ setups = [
 
 ```julia
 wp = WorkPrecisionSet(sparsejacprob, abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = test_sol, maxiters = Int(1e12), dtmin = 1e-18, numruns = 10)
+    saveat = tf/1000.0, appxsol = test_sol, maxiters = Int(1e6), numruns = 10)
 
-names = ["TRBDF2 (GMRES, iLU)" "QNDF (GMRES, iLU)" "FBDF (GMRES, iLU)" "NordsieckBDF (GMRES, iLU)" "KenCarp4 (GMRES, iLU)"]
+names = ["QNDF (GMRES, iLU)" "FBDF (GMRES, iLU)" "NordsieckBDF (GMRES, iLU)" "KenCarp4 (GMRES, iLU)"]
 plot(wp; label = names)
 ```
 
@@ -243,7 +253,6 @@ We designate the solvers we wish to use.
 
 ```julia
 setups = [
-    Dict(:alg=>TRBDF2(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>QNDF(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>FBDF(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff())),
     Dict(:alg=>NordsieckBDF(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff())),
@@ -257,10 +266,72 @@ Finally, we generate a work-precision diagram for the selection of solvers.
 
 ```julia
 wp = WorkPrecisionSet(sparsejacprob, abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = test_sol, maxiters = Int(1e12), dtmin = 1e-18, numruns = 10)
+    saveat = tf/1000.0, appxsol = test_sol, maxiters = Int(1e6), numruns = 10)
 
-names = ["TRBDF2 (KLU, sparse jac)" "QNDF (KLU, sparse jac)" "FBDF (KLU, sparse jac)" "NordsieckBDF (KLU, sparse jac)" "KenCarp4 (KLU, sparse jac)"]
+names = ["QNDF (KLU, sparse jac)" "FBDF (KLU, sparse jac)" "NordsieckBDF (KLU, sparse jac)" "KenCarp4 (KLU, sparse jac)"]
 plot(wp; label = names)
+```
+
+## Methods that are not competitive (timed once, capped)
+
+On this 356-species / 3744-reaction stiff network the dense direct solves and
+`TRBDF2` are one to two orders of magnitude off the pace of the preconditioned
+Krylov and sparse-KLU methods. Sweeping them across the whole tolerance grid
+costs multiple hours of CI time per document and dominated the runtime of this
+benchmark, so they are **not** folded into the work-precision suites above.
+Instead each is solved **once**, at a fixed tolerance, next to a competitive
+reference, under a hard wall-clock cap so that a pathological method cannot
+stall the build. A solve that hits the cap is reported as a lower bound.
+
+```julia
+const _loser_tol = 1e-6
+const _loser_cap = 300.0   # seconds of wall clock per isolated solve
+
+loser_labels = String[]
+loser_elapsed = Float64[]
+
+# LSODA.jl does not support callbacks, so `lsoda` is the one entry that has to
+# run to completion; everything else is stopped by the wall-clock callback.
+function _time_loser!(label, prob, alg; cap = true)
+    println("--- $label ---")
+    tstart = time()
+    kw = if cap
+        capcb = DiscreteCallback(
+            (u, t, integrator) -> time() - tstart > _loser_cap,
+            integrator -> terminate!(integrator); save_positions = (false, false))
+        (; callback = capcb)
+    else
+        (;)
+    end
+    t = @elapsed sol = solve(prob, alg; abstol = _loser_tol, reltol = _loser_tol,
+        maxiters = Int(1e6), save_everystep = false, kw...)
+    hit_cap = cap && t >= _loser_cap
+    @show sol.retcode
+    println("elapsed = ", t, " s", hit_cap ? " (hit the $(_loser_cap) s cap)" : "")
+    push!(loser_labels, hit_cap ? label * " (>cap)" : label)
+    push!(loser_elapsed, t)
+    return sol
+end
+
+# Competitive reference (preconditioned Krylov CVODE)
+_time_loser!("CVODE_BDF GMRES+iLU (reference)", oprob_sparse,
+    CVODE_BDF(linear_solver = :GMRES, prec = precilu, psetup = psetupilu, prec_side = 1))
+
+# Dense direct solves
+_time_loser!("lsoda", oprob, lsoda(); cap = false)
+_time_loser!("CVODE_BDF (dense)", oprob, CVODE_BDF())
+
+# TRBDF2, the slowest of the Julia BDF/SDIRK set in every linear-solver variant
+_time_loser!("TRBDF2 (KLU, sparse jac)", sparsejacprob,
+    TRBDF2(linsolve = KLUFactorization(), autodiff = AutoFiniteDiff()))
+```
+
+```julia
+ref_t = loser_elapsed[1]
+bar(loser_labels, loser_elapsed ./ ref_t; xrotation = 20, legend = false,
+    ylabel = "wall time / (CVODE_BDF GMRES+iLU reference)",
+    title = "fceri_gamma2 isolation (tol=$_loser_tol, one solve each)",
+    size = (900, 500), left_margin = 5Plots.mm, bottom_margin = 15Plots.mm)
 ```
 
 ## Explicit Work-Precision Diagram
@@ -269,7 +340,7 @@ Benchmarks for explicit solvers.
 
 #### Declare solvers
 
-We designate the solvers we wish to use, this also includes lsoda and CVODE.
+We designate the solvers we wish to use, this also includes CVODE_Adams.
 
 ```julia
 setups = [
@@ -278,19 +349,23 @@ setups = [
     Dict(:alg=>BS5()),
     Dict(:alg=>VCABM()),
     Dict(:alg=>Vern6()),
-    Dict(:alg=>Vern7()),
-    Dict(:alg=>Vern8()),
     Dict(:alg=>Vern9())
 ];
 ```
+
+`Vern7` and `Vern8` were dropped from this panel: every explicit method sits in
+a narrow 40-60 s band on this problem, so the intermediate Verner orders add
+about 15 minutes of CI time without adding information that `Vern6`/`Vern9`
+do not already carry. (The previous version of this cell also passed eight
+setups with only seven `names`, so the labels were shifted.)
 
 #### Plot Work-Precision Diagram
 
 ```julia
 wp = WorkPrecisionSet(oprob, abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = test_sol, maxiters = Int(1e9), numruns = 10)
+    saveat = tf/1000.0, appxsol = test_sol, maxiters = Int(1e6), numruns = 10)
 
-names = ["CVODE_Adams" "Tsit5" "BS5" "Vern6" "Vern7" "Vern8" "Vern9"]
+names = ["CVODE_Adams" "Tsit5" "BS5" "VCABM" "Vern6" "Vern9"]
 plot(wp; label = names)
 ```
 
@@ -328,7 +403,7 @@ For these, we generate a work-precision diagram for the selection of solvers.
 ```julia
 wp = WorkPrecisionSet(
     [oprob, oprob_sparse, sparsejacprob], abstols, reltols, setups; error_estimate = :l2,
-    saveat = tf/10000.0, appxsol = [test_sol, test_sol, test_sol], maxiters = Int(1e9), numruns = 200)
+    saveat = tf/1000.0, appxsol = [test_sol, test_sol, test_sol], maxiters = Int(1e6), numruns = 200)
 
 names = ["CVODE_BDF (GMRES)" "CVODE_BDF (GMRES, iLU)" "QNDF (GMRES, iLU)" "FBDF (GMRES, iLU)" "NordsieckBDF (GMRES, iLU)" "Tsit5"]
 colors = [:darkgreen :green :deepskyblue1 :dodgerblue2 :mediumorchid :orchid2]
@@ -341,8 +416,7 @@ plot(wp; label = names, left_margin = 10Plots.mm, right_margin = 10Plots.mm,
     markerstrokewidth = 1.5, gridalpha = 0.3, gridlinewidth = 7.5, size = (1100, 1000))
 ```
 
-```julia
-echo = false
+```julia, echo = false
 using SciMLBenchmarks
 SciMLBenchmarks.bench_footer(WEAVE_ARGS[:folder], WEAVE_ARGS[:file])
 ```


### PR DESCRIPTION
## What broke, and when it last worked

**Short version:** nothing regressed in the solver stack. The Bio benchmarks were
always enormously expensive; what changed is that CI now enforces a hard cap they
exceed, and that `Bidkhori2012.jmd` was broken outright by a missing comma.

### Last good build

`SciMLBenchmarksOutput/markdown/Bio` last had *all six* files refreshed together on
**2025-09-20**, from `SciML/SciMLBenchmarks.jl@d3c2478` (the Sundials-5 CompatHelper
bump), under the old Buildkite CI.

| file | last published | source build |
|---|---|---|
| BCR.md | 2026-07-28 | per-file job from #1623 (13 h 41 min) |
| egfr_net.md | 2026-07-28 | per-file job from #1623 (2 h 07 min) |
| multisite2.md | 2026-07-28 | per-file job from #1623 (0 h 31 min) |
| multistate.md | 2026-07-28 | per-file job from #1623 (0 h 19 min) |
| **Bidkhori2012.md** | **2025-09-20** | `d3c2478` |
| **fceri_gamma2.md** | **2025-09-20** | `d3c2478` |

So `Bidkhori2012` and `fceri_gamma2` have not completed in over eleven months.

### Why the folder job never finishes

`.github/workflows/benchmarks.yml` first ran on **2026-03-18**; there are no
`benchmarks.yml` runs before that date. Since then the whole-folder
`Run: benchmarks/Bio` job has never reached the end:

| run | started | ended | duration | conclusion |
|---|---|---|---|---|
| 25374443675 | 2026-05-05 | 2026-05-06 | 24.0 h | cancelled |
| 25374549824 | 2026-05-10 | 2026-05-11 | 24.0 h | cancelled |
| 28602995579 | 2026-07-02 | 2026-07-03 | 24.0 h | cancelled |
| 28718664799 | 2026-07-04 | 2026-07-09 | 119.9 h | cancelled |
| 29724055500 | 2026-07-20 | 2026-07-25 | 119.9 h | cancelled |
| 31719785340 | 2026-08-14 | 2026-08-15 | 22.7 h | cancelled |

The 119.9 h entries are GitHub's hard **5-day job execution limit**; the exactly-24.0 h
entries are the **24-hour job queue limit** (those jobs were waiting behind a Bio job
that was already occupying the runner for five days). The workflow's own
`timeout-minutes` for this folder is 12000 (8.3 days), i.e. above GitHub's cap, so the
cap always bites first.

### It was never fast

`BCR.jmd` alone, as a successful per-file run on **2026-03-21** (run 23339618793,
pre-v7 stack), took **31 h 44 min**. #1623 (2026-07-24) brought it to 13 h 41 min and
the v7 stack plus the faster MTK sparse-Jacobian path brought it to 7 h 57 min by
2026-08-14. The Bio folder has been on the order of a day or more for as long as the
GitHub Actions history goes back; on Buildkite that was tolerated, on GitHub Actions
it is not.

### The one true regression

`Bidkhori2012.jmd` has been dead since **2026-08-13**. #1644 inserted a `NordsieckBDF`
entry after this line:

```julia
Dict(:alg=>QNDF(autodiff = AutoFiniteDiff()))    #Dict(:alg=>lsoda()),
```

The trailing comment swallows the separating comma. That was legal only while the
entry was last in the vector; adding one after it produced

```
ERROR: ParseError:
    Dict(:alg=>QNDF(autodiff = AutoFiniteDiff()))    #Dict(:alg=>lsoda()),
    Dict(:alg=>NordsieckBDF(autodiff = AutoFiniteDiff()))    #Dict(:alg=>lsoda()),
#   └────────────────────────────────────────────────┘ ── Expected `]`
```

and the document died four minutes in. (The 2026-05-27 / 06-18 failures of this file
were a different, already-fixed problem: `OrdinaryDiffEqCore` was missing from
`benchmarks/Bio/Project.toml`, fixed by #1607.)

## Measured offenders

Chunk wall times from run 31719785340 (amdci8-1, master @ #1644, 2026-08-14):

| file | chunk | wall time |
|---|---|---|
| BCR | setup + reference solution | 21 min |
| BCR | WP: `lsoda` / `CVODE_BDF` / CVODE GMRES+iLU | **2 h 44 min** |
| BCR | WP: Julia GMRES + iLU (5 methods) | 1 h 18 min |
| BCR | WP: Julia KLU (5 methods) | 1 h 14 min |
| BCR | loser isolation (11 single solves) | 1 h 19 min |
| BCR | summary panel (8 methods) | 57 min |
| BCR | **total** | **7 h 57 min** |
| Bidkhori2012 | — | 4.5 min, ParseError |
| egfr_net | **total** | 1 h 40 min |
| fceri_gamma2 | setup (parse, ODESys, sparse jac, rhs/jac compile, reference, iLU) | 45 min |
| fceri_gamma2 | WP: `lsoda` / `CVODE_BDF` × 6 variants | **6 h 27 min** |
| fceri_gamma2 | WP: Julia default (dense) linear solver | 45 min |
| fceri_gamma2 | WP: Julia GMRES | 23 min |
| fceri_gamma2 | WP: Julia GMRES + iLU | 14 min |
| fceri_gamma2 | WP: Julia KLU | **3 h 07 min** |
| fceri_gamma2 | WP: explicit methods | ≥ 1 h 14 min (job cancelled inside it) |
| fceri_gamma2 | summary panel | not reached |
| fceri_gamma2 | **total** | **≈ 13 h 20 min** |

Folder total ≈ **24 h**, which is why it only ever ends by hitting a GitHub limit.

Per-solver seconds *per work-precision point* (read off the published diagrams; each
point costs three solves — one for the error, one to warm up, one that is timed):

**BCR** (2026-07-27 build, current stack, 1122 species / 24388 reactions)

| method | s / point |
|---|---|
| `lsoda` | 500 – 1200 |
| `CVODE_BDF` (dense) | 210 – 370 |
| `CVODE_BDF` (GMRES, iLU) | 9 – 22 |
| `TRBDF2` (GMRES, iLU) | 118 – 355 |
| `KenCarp4` (GMRES, iLU) | 126 – 295 |
| `QNDF` / `FBDF` (GMRES, iLU) | 26 – 40 |
| `TRBDF2` (KLU) | 170 – 340 |
| `QNDF` / `FBDF` / `KenCarp4` (KLU) | 63 – 135 |

and in BCR's isolation section, single solves at `tol = 1e-6`:
`TRBDF2`/`QNDF`/`FBDF`/`KenCarp4` with **unpreconditioned** GMRES measured
**3763 / 4707 / 2110 / 7267 s** — 4.9 h for four data points. The "cheap isolation"
section had itself become one of the most expensive parts of the document.

**fceri_gamma2** (2025-09-20 build; the current-stack chunk totals above are
consistent with these to within a few percent, so they have not moved)

| method | s / point |
|---|---|
| `lsoda` | 700 – 2000 |
| `CVODE_BDF` (dense) | 300 – 800 |
| `CVODE_BDF` (KLU, sparse jac) | 140 – 380 |
| `CVODE_BDF` (LapackDense) | 20 – 45 |
| `CVODE_BDF` (GMRES) | 5 – 7 |
| `CVODE_BDF` (GMRES, iLU) | 4 – 6 |
| `TRBDF2` (KLU, sparse jac) | 70 – 500 |
| `QNDF` / `FBDF` / `KenCarp4` (KLU) | 55 – 190 |
| explicit (`Tsit5` … `Vern9`) | 40 – 63 |

The pattern is the same in both: **dense direct linear algebra, and `TRBDF2`, are one
to two orders of magnitude off the pace**, and sweeping them across the whole tolerance
grid is where the days go. This is not surprising once you notice that
`fceri_gamma2`'s prose was wrong about its own size — it says "356 ODEs with 3749
terms" (those are `egfr_net`'s numbers), while `@show numspecies(rn)` prints **3744
species / 58276 reactions**. A dense 3744×3744 LU is ~1.7e10 flops per factorization.

## Changes

* **`Bidkhori2012.jmd`** — restore the swallowed comma, move the commented-out entries
  onto their own lines, and tidy the matching `solnames` line that had the same
  comment-glued-to-code problem.
* **`BCR.jmd`**
  * `lsoda` and dense `CVODE_BDF` out of the work-precision panels, into the existing
    isolation section; the surviving CVODE GMRES+iLU curve is merged into the
    GMRES+iLU panel via the multi-problem `WorkPrecisionSet` form.
  * `TRBDF2` dropped from both Julia panels, `KenCarp4` from the GMRES+iLU panel.
  * The isolation section is now **wall-clock capped** (180 s per solve, via a
    `DiscreteCallback` + `terminate!`); entries that hit the cap are labelled `>cap`
    and the bar chart reads as a lower bound, which is all it needs to show the gap.
  * `saveat = tf/10000` → `tf/1000`.
* **`fceri_gamma2.jmd`**
  * Same isolation treatment for `lsoda`, dense `CVODE_BDF` and `TRBDF2` (KLU), with a
    300 s cap and a preconditioned-Krylov CVODE reference.
  * `TRBDF2` dropped from all four Julia linear-solver panels.
  * Tolerance grid `1e-5 … 1e-8` → `1e-5 … 1e-7`, `saveat = tf/10000` → `tf/1000`.
  * `maxiters = Int(1e12), dtmin = 1e-18` → `maxiters = Int(1e6)` with the default
    `dtmin`. Those two settings let a method whose step size collapses grind
    indefinitely; DiffEqDevTools handles a failed point *cheaply* (one solve instead of
    three) as long as the solver actually returns a failure retcode.
  * Explicit panel trimmed to six methods, which also fixes a real labelling bug: it
    passed **eight** setups with **seven** `names`, so every explicit curve after
    `BS5` was mislabelled in the published diagram.
  * Corrected the problem size in the intro text, and the footer chunk whose
    `echo = false` was a code line rather than a chunk option.

`LSODA.jl` rejects callbacks (`"LSODA is not compatible with callbacks"`), so the
`lsoda` isolation entry is the one solve that cannot be capped and is run to
completion; `_time_loser!` takes `cap = false` for it.

## Verification

Two independent runs of the branch as it stands (`8b7b684f`).

### 1. CI on the benchmark runners — authoritative

This PR's own workflow run
[**32639839341**](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32639839341)
fanned the three changed files out to one **per-file** job each on the SciML
benchmark runners (`amdci1`, `amdci8` — 128-thread EPYC, the same fleet the
pre-fix numbers were measured on), so this is the apples-to-apples comparison.

| file | pre-fix | post-fix (CI, measured) | notes |
|---|---|---|---|
| `BCR.jmd` | 7 h 57 min | **3 h 56 min** weave (4 h 04 min job) | amdci1-1, ✅ success. **−51%** |
| `Bidkhori2012.jmd` | died at 4.5 min, `ParseError` | **5 min** weave (11 min job) | amdci8-1, ✅ success. Completes for the first time since 2026-08-13 |
| `fceri_gamma2.jmd` | ≈ 13 h 20 min, never finished | **still running** at 4 h 03 min; ≈ **6 h 50 min** *(estimated)* | ⏳ in progress. Estimate is the measured local 6 h 24 min scaled by the local:CI ratio this run gave for `BCR.jmd` (3 h 40 min : 3 h 56 min). The job will be updated here when it lands |

Per-chunk, from the CI `BCR.jmd` job log:

| section | pre-fix (run 31719785340, amdci8) | post-fix (run 32639839341, amdci1) |
|---|---|---|
| setup + reference solution | 21 min | 24 min |
| WP: `lsoda` / `CVODE_BDF` / CVODE GMRES+iLU | **2 h 44 min** | *panel removed* |
| WP: Julia GMRES + iLU | 1 h 18 min (5 methods) | **22 min** (4 methods, incl. the CVODE GMRES+iLU curve) |
| WP: Julia KLU | 1 h 14 min (5 methods) | **59 min** (4 methods) |
| loser isolation | 1 h 19 min (11 solves) | **48 min** (16 solves, capped) |
| summary panel | 57 min (8 methods) | 1 h 19 min (8 methods) |
| **total** | **7 h 57 min** | **3 h 56 min** |

Two things to read off that table honestly:

* The isolation section now runs **more** solves (16 vs 11) in **less** time (48 min
  vs 1 h 19 min), because the 180 s cap fires. It is doing more work than before and
  still costs 40% less.
* The summary panel is the one section that did **not** improve (57 min → 1 h 19 min).
  This PR does not change that panel apart from `saveat`, and the two measurements are
  on different runners (amdci8 vs amdci1), so this is machine-to-machine variation
  rather than anything introduced here. It is now the single largest chunk in `BCR.jmd`
  and the obvious next target if the file needs to get cheaper still.

The wall-clock cap behaves as designed. From the CI job's own
`markdown/Bio/BCR.md` artifact:

```
--- FBDF + KLU (reference) ---
sol.retcode = SciMLBase.ReturnCode.Success
elapsed = 61.068756148 s
--- lsoda ---
sol.retcode = SciMLBase.ReturnCode.Success
elapsed = 636.717073746 s
--- CVODE_BDF (dense) ---
sol.retcode = SciMLBase.ReturnCode.Terminated
elapsed = 180.0319766 s (hit the 180.0 s cap)
```

**10 of the 16** entries hit the cap, return `ReturnCode.Terminated`, and are labelled
`>cap` in the bar chart; the other 6 ran to `Success` and their times are exact
(`CVODE_BDF LapackDense` 71 s, `QNDF` dense 59 s, `FBDF` dense 68 s, `KenCarp4` dense
118 s). The 16 solves sum to **46 min 55 s**, of which uncapped `lsoda` alone is
**10 min 37 s** — `LSODA.jl` rejects callbacks, so it is the one entry that has to run
to completion, and it is by a wide margin the most expensive thing in the section.
Without the cap the same 16 entries would run for hours: the four
unpreconditioned-GMRES entries measured 2110 / 3763 / 4707 / 7267 s uncapped in the
2026-07-27 build.

### 2. Local re-weave (Apple M2 Max)

Independent confirmation on a laptop: Apple M2 Max, 12 cores, 32 GB, Julia 1.10.10,
`-t 4`, the folder `benchmarks/Bio/Manifest.toml` as committed.

| file | pre-fix | post-fix (local, measured) | notes |
|---|---|---|---|
| `BCR.jmd` | 7 h 57 min (CI) | **3 h 40 min** (13215 s) | ✅ all 21 chunks, 5 figures, no errors |
| `Bidkhori2012.jmd` | `ParseError` | **6 min 51 s** (411 s) | ✅ all 11 chunks, 5 figures, no `ParseError` |
| `fceri_gamma2.jmd` | ≈ 13 h 20 min (CI) | **6 h 24 min** (23021 s) | ✅ all 26 chunks, 9 figures, no errors. **−52%** |

**Do not read the local numbers as a speed comparison against CI.** The laptop was
running eight other benchmark weaves concurrently (1-minute load average ≈ 48 on 12
cores), so every local section time is inflated by several-fold oversubscription. The
local run is here to establish *correctness and completion*, not timing; the CI run
above is the timing.

Local `fceri_gamma2.jmd` per-section, from figure timestamps (only chunks that emit
a figure give a timestamp, so adjacent chunks are grouped):

| section | chunks | pre-fix (CI) | post-fix (local, contended) |
|---|---|---|---|
| setup + reference solution + iLU, then the `lsoda` / `CVODE_BDF` panel | 1-11 | 45 min + **6 h 27 min** = 7 h 12 min | **1 h 48 min** |
| WP: Julia default (dense) | 12-13 | 45 min | 8 min |
| WP: Julia GMRES | 14-15 | 23 min | 21 min |
| WP: Julia GMRES + iLU | 16-17 | 14 min | 13 min |
| WP: Julia KLU (sparse jac) | 18-19 | **3 h 07 min** | 41 min |
| isolation (new, capped) | 20-21 | — | 14 min |
| WP: explicit methods | 22-23 | ≥ 1 h 14 min (job cancelled inside it) | 1 h 58 min |
| summary panel | 24-25 | never reached | 60 min |

`fceri_gamma2`'s isolation section, from the regenerated `markdown/Bio/fceri_gamma2.md`:

```
--- CVODE_BDF GMRES+iLU (reference) ---   Success   elapsed =   1.40 s
--- lsoda ---                             Success   elapsed = 392.72 s
--- CVODE_BDF (dense) ---                 Success   elapsed = 259.44 s
--- TRBDF2 (KLU, sparse jac) ---          Success   elapsed = 195.14 s
```

None of the three capped entries reached the 300 s cap, so all four ratios in that bar
chart are exact and nothing is labelled `>cap` here; the cap is a ceiling, not a
routine truncation. 848 s buys the whole section — the same three methods swept across
the tolerance grid cost 6 h 27 min + 3 h 07 min pre-fix. Dense `CVODE_BDF` at 259 s
against 1.4 s for preconditioned Krylov CVODE is a **185×** gap, which is the point the
section exists to make.

Those section times sum to 6 h 23 min, matching the measured whole-file 23021 s. The
two panels the PR targeted hardest — the CVODE/`lsoda` sweep and the KLU sweep — are
where the hours came from and where they went: **6 h 27 min** and **3 h 07 min** on CI
pre-fix, against 1 h 48 min (which also absorbs all of the setup and the tol-1e-15
reference solve) and 41 min on a *four-times-oversubscribed laptop* post-fix.

### Correctness checks

* Every `setups` / `names` pair in all three files now has matching lengths
  (`fceri_gamma2`'s explicit panel was 8 setups vs 7 names before this PR; it is 6/6
  now, and all five Julia linear-solver panels are 4/4).
* `Bidkhori2012.md` regenerates with no `ParseError` and all five figures.
* `BCR.md` regenerates with all five figures and no errors in the output.
* `fceri_gamma2.md` regenerates with all nine figures and no errors, and now prints
  `numspecies(rn) = 3744` / `numreactions(rn) = 58276` next to prose that finally
  states those numbers instead of `egfr_net`'s.
* Both CI jobs uploaded complete artifacts
  (`benchmark-benchmarks-Bio-BCR-jmd`, `benchmark-benchmarks-Bio-Bidkhori2012-jmd`)
  with every figure present.

## Not touched

`egfr_net.jmd` (1 h 40 min), `multisite2.jmd` (31 min) and `multistate.jmd` (19 min)
are already within budget and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrTtUuDkfgNEq3asQuZ3F6
