### PR TITLE
CI: run Publish Results on ubuntu-latest, not the benchmark runners

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -131,7 +131,12 @@ jobs:
     # that were actually uploaded (only successful builds upload), and
     # publish_benchmark_output.sh is a no-op when there's nothing new.
     if: always() && github.ref == 'refs/heads/master' && (needs.benchmark.result == 'success' || needs.benchmark.result == 'failure')
-    runs-on: [self-hosted, benchmark]
+    # Hosted runner on purpose: publishing only needs git + ssh + the small
+    # markdown/notebook/pdf/script artifacts. On the self-hosted benchmark
+    # runners this 1-minute job queues behind multi-hour (sometimes multi-day)
+    # benchmark jobs, so finished results sit unpublished for hours even though
+    # their benchmark job succeeded.
+    runs-on: ubuntu-latest
     # No concurrency group here on purpose. A job-level group has the same
     # one-running + one-pending semantics as above, so with several master runs
     # finishing close together the middle run's publish job would be cancelled


### PR DESCRIPTION
Follow-up to #1666.

`Publish Results` only needs git + ssh + the small `markdown/notebook/pdf/script` artifacts, but it ran on `[self-hosted, benchmark]`, so this ~1-minute job queues behind multi-hour benchmark jobs.

Observed today after #1666 merged: the five dispatched master runs (LinearSolveGPU, AstroChem, LinearSolve, DynamicalODE, NonlinearProblem) all **succeeded** between 12:39 and 14:42 UTC, but only LinearSolveGPU's publish ran; the other four publish jobs sat queued for hours because amdci3-1 is held by SimpleHandwrittenPDE (since Aug 19) and amdci1-1/amdci8-1 were taken by two `Bio/*.jmd` per-file PR jobs (BCR alone is ~14 h). Results weren't lost (artifacts are retained) but weren't reaching SciMLBenchmarksOutput either.

Change: `runs-on: ubuntu-latest` for `publish`. The SciMLBenchmarksOutput clone is `--depth 1` since #1666, so the ~1 GB history isn't pulled on the hosted runner. The deploy key is a repo secret and available there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrTtUuDkfgNEq3asQuZ3F6
