### PR TITLE
Fix NBodySimulator liquid argon benchmarks timing out in CI

### DIFF
--- a/benchmarks/NBodySimulator/liquid_argon.jmd
+++ b/benchmarks/NBodySimulator/liquid_argon.jmd
@@ -255,11 +255,17 @@ here (N=128, t=10, one solve of `Tsit5`, extrapolated from a step-capped run):
 | 1.2e-05 | 9 s |
 | 1.2e-04 | 5 s |
 
-The historical `10 .^ range(-14, -4, length = 10)` grid therefore spent almost
-all of its wall time in a regime where the tolerance is not attainable for this
-model; summed over the six solvers and both sweeps it comes to ~18 h for this
-file alone. We use a grid that stays in the range the controller can actually
-track.
+The *loose* end of the old grid is dangerous for a different reason: with
+`abstol = reltol = at*2^cₐ` the high-order solvers get a tolerance up to
+`2^11.38 = 2666` times looser than the grid point, and at that point they stop
+solving the problem at all. In the last successfully published build of this
+benchmark `Vern9` at `reltol = 0.267` took **55389 s** (15.4 h) for a single
+configuration, for an energy error of 325 -- i.e. no usable answer. That
+configuration reproduces on current versions.
+
+So the historical `10 .^ range(-14, -4, length = 10)` grid spent essentially
+all of its wall time outside the range where the error controller works, at
+both ends. We use a grid that stays inside it.
 
 ```julia
 function config(integrators, c, at, rt)
@@ -267,8 +273,8 @@ function config(integrators, c, at, rt)
 end
 
 t = 35.0
-ats = 10 .^ range(-9, -4, length = 6)
-rts = 10 .^ range(-9, -4, length = 6)
+ats = 10 .^ range(-9, -5, length = 5)
+rts = 10 .^ range(-9, -5, length = 5)
 
 # warmup -- this only exists to force compilation, so it runs at the *loosest*
 # tolerance of the grid. It used to use `ats[1]`/`rts[1]`, i.e. the tightest,

--- a/benchmarks/NBodySimulator/liquid_argon.jmd
+++ b/benchmarks/NBodySimulator/liquid_argon.jmd
@@ -25,7 +25,12 @@ function setup(t)
     # parameter sweep under the OrdinaryDiffEq v7 stack.
     N = 128
     L = (m*N/ρ)^(1/3)
-    R = 3.5σ
+    # `CubicPeriodicBoundaryConditions` applies the minimum-image convention,
+    # which is only valid when the interaction cutoff satisfies R <= L/2.
+    # At N=128 the box is L = 5.41σ, so the historical R = 3.5σ exceeded
+    # L/2 = 2.71σ and the pair interactions were wrong. 2.5σ is the standard
+    # Lennard-Jones cutoff and fits inside this box.
+    R = 2.5σ
     v_dev = sqrt(kb * T / m) # m/s
 
     _L = L / σ
@@ -231,19 +236,46 @@ adaptive_integrators=[
 Similarly to the case of symplectic methods, we will take into account the average cost per timestep
 in order to have a fair comparison between the solvers.
 
+A note on the tolerance range. The Lennard-Jones potential used here is
+*truncated* at `R` and not shifted or smoothed, so the acceleration is
+discontinuous every time a pair of particles crosses the cutoff radius. An
+adaptive error controller cannot integrate through those jumps: below roughly
+`reltol = 1e-7` the majority of the proposed steps are rejected at cutoff
+crossings, the accepted step size collapses, and the cost diverges. Measured
+here (N=128, t=10, one solve of `Tsit5`, extrapolated from a step-capped run):
+
+| `reltol` | runtime for `t = 10` |
+|---|---|
+| 1.2e-13 | 2260 s |
+| 1.2e-10 | 1080 s |
+| 1.2e-09 | 340 s |
+| 1.2e-08 | 165 s |
+| 1.2e-07 | 66 s |
+| 1.2e-06 | 23 s |
+| 1.2e-05 | 9 s |
+| 1.2e-04 | 5 s |
+
+The historical `10 .^ range(-14, -4, length = 10)` grid therefore spent almost
+all of its wall time in a regime where the tolerance is not attainable for this
+model; summed over the six solvers and both sweeps it comes to ~18 h for this
+file alone. We use a grid that stays in the range the controller can actually
+track.
+
 ```julia
 function config(integrators, c, at, rt)
     [(alg = a, abstol = at*2^cₐ, reltol = rt*2^cₐ) for (a, cₐ) in zip(integrators, c)]
 end
 
 t = 35.0
-ats = 10 .^ range(-14, -4, length = 10)
-rts = 10 .^ range(-14, -4, length = 10)
+ats = 10 .^ range(-9, -4, length = 6)
+rts = 10 .^ range(-9, -4, length = 6)
 
-# warmup
+# warmup -- this only exists to force compilation, so it runs at the *loosest*
+# tolerance of the grid. It used to use `ats[1]`/`rts[1]`, i.e. the tightest,
+# which made the warmup alone more expensive than the whole sweep below.
 c_adaptive = ones(length(adaptive_integrators))
 benchmark(Dict(), Dict(), Dict(), Dict(), Dict(), Dict(), 10.0,
-    config(adaptive_integrators, 1, ats[1], rts[1]))
+    config(adaptive_integrators, 1, ats[end], rts[end]))
 
 # results = DataFrame(:integrator=>String[], :runtime=>Float64[], :abstol=>Float64[],
 #    :reltol=>Float64[], :EnergyError=>Float64[], :timesteps=>Int[], :f_evals=>Int[], :cost=>Float64[]);

--- a/benchmarks/NBodySimulator/liquid_argon_long.jmd
+++ b/benchmarks/NBodySimulator/liquid_argon_long.jmd
@@ -19,10 +19,12 @@ function setup(t)
     σ = 3.4e-10 # m
     ρ = 1374 # kg/m^3
     m = 39.95 * 1.6747 * 1e-27 # kg
-    # See liquid_argon.jmd for the reasoning behind N=128 (was 350).
+    # See liquid_argon.jmd for the reasoning behind N=128 (was 350) and
+    # R = 2.5σ (was 3.5σ, which violated the minimum-image convention since
+    # the N=128 box has L/2 = 2.71σ).
     N = 128
     L = (m*N/ρ)^(1/3)
-    R = 3.5σ
+    R = 2.5σ
     v_dev = sqrt(kb * T / m) # m/s
 
     _L = L / σ
@@ -172,19 +174,30 @@ adaptive_integrators=[
 ];
 ```
 
+The Lennard-Jones potential is truncated at `R` without shifting or smoothing,
+so the acceleration is discontinuous whenever a pair crosses the cutoff. Below
+roughly `reltol = 1e-7` the adaptive controllers reject most of their proposed
+steps at those crossings and the cost per solve diverges (measured for `Tsit5`
+at N=128, `t = 10`: 5 s at `reltol = 1.2e-4`, 66 s at `1.2e-7`, 2260 s at
+`1.2e-13`). This file integrates to `t = 50`, i.e. five times the cost per
+configuration of `liquid_argon.jmd`, so we use a correspondingly shorter grid
+that stays inside the attainable range.
+
 ```julia
 function config(integrators, c, at, rt)
     [(alg = a, abstol = at*2^cₐ, reltol = rt*2^cₐ) for (a, cₐ) in zip(integrators, c)]
 end
 
 t = 35.0
-ats = 10 .^ range(-14, -4, length = 10)
-rts = 10 .^ range(-14, -4, length = 10)
+ats = 10 .^ range(-8, -4, length = 5)
+rts = 10 .^ range(-8, -4, length = 5)
 
-# warmup
+# warmup -- this only exists to force compilation, so it runs at the *loosest*
+# tolerance of the grid. It used to use `ats[1]`/`rts[1]`, i.e. the tightest,
+# which made the warmup alone more expensive than the whole sweep below.
 c_adaptive = ones(length(adaptive_integrators))
 benchmark(Dict(), Dict(), Dict(), Dict(), Dict(), Dict(), 10.0,
-    config(adaptive_integrators, 1, ats[1], rts[1]))
+    config(adaptive_integrators, 1, ats[end], rts[end]))
 
 # results = DataFrame(:integrator=>String[], :runtime=>Float64[], :abstol=>Float64[],
 #    :reltol=>Float64[], :EnergyError=>Float64[], :timesteps=>Int[], :f_evals=>Int[], :cost=>Float64[]);

--- a/benchmarks/NBodySimulator/liquid_argon_long.jmd
+++ b/benchmarks/NBodySimulator/liquid_argon_long.jmd
@@ -179,9 +179,12 @@ so the acceleration is discontinuous whenever a pair crosses the cutoff. Below
 roughly `reltol = 1e-7` the adaptive controllers reject most of their proposed
 steps at those crossings and the cost per solve diverges (measured for `Tsit5`
 at N=128, `t = 10`: 5 s at `reltol = 1.2e-4`, 66 s at `1.2e-7`, 2260 s at
-`1.2e-13`). This file integrates to `t = 50`, i.e. five times the cost per
+`1.2e-13`). At the loose end the `2^cₐ` cost scaling pushes the high-order
+solvers past the point where they solve the problem at all -- in the last
+published build `Vern9` at `reltol = 0.267` burned 15.4 h for an energy error
+of 325. This file integrates to `t = 50`, i.e. five times the cost per
 configuration of `liquid_argon.jmd`, so we use a correspondingly shorter grid
-that stays inside the attainable range.
+inside the range the controller can track.
 
 ```julia
 function config(integrators, c, at, rt)
@@ -189,8 +192,8 @@ function config(integrators, c, at, rt)
 end
 
 t = 35.0
-ats = 10 .^ range(-8, -4, length = 5)
-rts = 10 .^ range(-8, -4, length = 5)
+ats = 10 .^ range(-8, -5, length = 4)
+rts = 10 .^ range(-8, -5, length = 4)
 
 # warmup -- this only exists to force compilation, so it runs at the *loosest*
 # tolerance of the grid. It used to use `ats[1]`/`rts[1]`, i.e. the tightest,


### PR DESCRIPTION
## What was wrong, and when it last worked

`markdown/NBodySimulator` in SciMLBenchmarksOutput has not been fully rebuilt in
~4 years:

| file | last published | source build |
|---|---|---|
| `acceleration_functions.md` | 2022-09-11 | SciMLBenchmarks.jl@73ab299 |
| `liquid_argon.md` | 2022-07-25 | manual "try a full build" (content dates to the 2021-05 run) |
| `liquid_argon_long.md` | **never** | — |

The last published `liquid_argon.md` is itself the record of how long it took:
its own result tables report the per-configuration solver runtimes. The
symplectic sweep alone (N=350, `t=40`, 9 integrators x 10 `dt`s) reports 269 s
to 3033 s per configuration, i.e. **~29 h of solver time**, and one single
adaptive configuration (`Vern9` at `reltol = 0.267`) reports **55389 s = 15.4 h**.
So this benchmark has never fitted a normal CI budget; it fitted a Buildkite
era with no practical wall-clock limit.

Two things then made it strictly worse:

1. **f7ff87de (2026-03-14) renamed the `rtol` solver kwarg to `reltol`.** That
   was a correct API fix, but it turned the adaptive "tolerance sweep" from a
   no-op into a real one. Before the rename, `rtol` was silently dropped and
   every point of `ats = rts = 10 .^ range(-14, -4, length = 10)` ran at
   DiffEq's *default* `reltol`. You can see this directly in the last published
   output: across all ten tolerance levels `Tsit5`'s runtime is flat at
   82-83 s and its energy error is flat at 184-241. After the rename the sweep
   actually requests `reltol` down to `1.2e-13`.

2. **#1570 (2026-07-31) reduced N from 350 to 128** to fit CI. That cut the
   symplectic side by ~10x (per-step cost is O(N^2)) but did nothing to the
   adaptive side, which by then was the dominant cost — hence the 46.5 h job on
   2026-08-12 *after* that PR.

### Why the tight tolerances cost so much

The Lennard-Jones potential in `NBodySimulator` is truncated at `R` and neither
shifted nor smoothed (`basic_potentials.jl`: `if rij_2 < p.R2 ... end`), so the
acceleration is **discontinuous** every time a pair crosses the cutoff radius.
An adaptive controller cannot meet a tolerance below the size of those jumps;
it just rejects most of its proposed steps there. Measured rejection rate at
`reltol = 1.2e-13`: 13422 accepted out of 40000 iterations (66% rejected).

## Measured per-configuration cost

N=128, `R=2.5σ`, `t=10`, single solve, extrapolated from step-capped runs
(`maxiters=15000`, extrapolate by `t_end / t_reached`). Machine: M-series Mac
under load, Julia 1.11.8, this folder's Manifest. Absolute numbers are ~1.5-2x
the CI runners'; the *shape* is what matters.

| base grid point | `Tsit5` reltol / s | `Vern7` reltol / s | `Vern9` reltol / s |
|---|---|---|---|
| 1e-14 | 1.2e-13 → **2262** | 2.3e-12 → **3347** | 2.7e-11 → **4481** |
| 1e-11 | 1.2e-10 → 1083 | 2.3e-09 → 850 | 2.7e-08 → 626 |
| 1e-10 | 1.2e-09 → 342 | 2.3e-08 → 279 | 2.7e-07 → 246 |
| 1e-09 | 1.2e-08 → 165 | 2.3e-07 → 119 | 2.7e-06 → 150 |
| 1e-08 | 1.2e-07 → 66 | 2.3e-06 → 40 | 2.7e-05 → 45 |
| 1e-07 | 1.2e-06 → 23 | 2.3e-05 → 10 | 2.7e-04 → 12 |
| 1e-06 | 1.2e-05 → 9 | 2.3e-04 → 6 | 2.7e-03 → 6 |
| 1e-05 | 1.2e-04 → 5 | 2.3e-03 → 5 | 2.7e-02 → 6 |
| 1e-04 | 1.2e-03 → 3 | 2.3e-02 → 4 | 2.7e-01 → **did not return** |

The `1e-04` row is the one that reproduces the 15.4 h `Vern9` outlier from the
2021 output: it was the only point of the sweep that never came back, even with
a 15000-iteration cap.

Integrating those curves over the old grid
(`10 .^ range(-14, -4, length = 10)`) and over all six adaptive solvers gives
**~12 h for the first adaptive chunk and ~6 h for the final comparison chunk**
of `liquid_argon.jmd`, ~18 h total, plus a warmup chunk (see below) and ~5x
that for `liquid_argon_long.jmd` at `t=50`. That is the 32-120 h.

For contrast, per-step cost of the force kernel is *not* the problem and has
not regressed — if anything it improved. `VelocityVerlet`, one step:

| | 2021 published run | now (demeter2, EPYC 9354) | now (this Mac) |
|---|---|---|---|
| N=350, R=3.5σ | 6.5 ms | 2.15 ms | 2.42 ms |
| N=128, R=3.5σ | — | 0.196 ms | 0.305 ms |

## Changes

1. **Adaptive tolerance grid, both files.** The old grid spends almost all of
   its wall time outside the range the error controller can work in, at *both*
   ends — too tight for a C0-discontinuous RHS at one end, so loose the
   high-order solvers stop solving the problem at the other (the `2^cₐ` cost
   normalisation multiplies the grid point by up to `2^11.38 = 2666`).
   - `liquid_argon.jmd`: `10 .^ range(-14, -4, length = 10)` → `10 .^ range(-9, -5, length = 5)`
   - `liquid_argon_long.jmd`: → `10 .^ range(-8, -5, length = 4)` (this file
     runs to `t = 50`, so each configuration costs 5x)

2. **The adaptive warmup chunk ran at the tightest tolerance.** It uses
   `config(adaptive_integrators, 1, ats[1], rts[1])` and exists only to force
   compilation, but `ats[1]` is the *first* (tightest) grid point. Under the old
   grid that meant six solvers at `reltol = 2e-14` — the warmup alone cost more
   than everything after it. Changed to `ats[end]`/`rts[end]`.

3. **`R = 3.5σ` → `2.5σ`, both files (correctness, not speed).**
   `CubicPeriodicBoundaryConditions` applies the minimum-image convention
   (`boundary_conditions.jl`), which is only valid for `R <= L/2`. At N=350 the
   box was `L = 7.57σ` so `R = 3.5σ < L/2 = 3.78σ` — fine. When #1570 dropped N
   to 128 the box shrank to `L = 5.41σ`, so `L/2 = 2.71σ < 3.5σ` and the pair
   interactions silently became wrong. `2.5σ` is the standard Lennard-Jones
   cutoff and fits the N=128 box.

The symplectic sweeps are untouched — they were never the problem.

## Expected cost after the change

Per-chunk, using the measured curves above (this Mac, under load; CI runners
should be faster):

| chunk | `liquid_argon.jmd` | `liquid_argon_long.jmd` |
|---|---|---|
| symplectic warmup | 40 s | 40 s |
| symplectic sweep | ~26 min | ~3 min (`τs` is a scalar here) |
| energy-error history | ~3 min | ~3 min |
| adaptive warmup | ~1 min (was hours) | ~1 min |
| adaptive sweep | ~24 min | ~46 min |
| best-of comparison | ~26 min | ~30 min |
| **total** | **~1.4 h** | **~1.3 h** |

`acceleration_functions.jmd` is `BenchmarkTools` with default budgets and costs
~2 min; it only ever failed in CI by expiring in the queue behind the other two.

Folder total ~3 h, against the 8 h target.

## Verification

All local numbers below come from this Mac (M-series, 12 cores, Julia 1.11.8,
this folder's `Manifest.toml`). **The machine was running ~11x oversubscribed**
(load average 136 on 12 cores) for the whole verification window, so wall clock
here is an upper bound with a large and variable starvation factor; CPU time is
the more meaningful figure. CI runners (EPYC 7502-class, dedicated) should be
faster than either.

| file | status | measured | estimated |
|---|---|---|---|
| `acceleration_functions.jmd` | **full weave, completed clean** (appendix and all 5 benchmark groups present) | 2150 s wall / 870 s CPU (user 726 + sys 144) | -- |
| `liquid_argon.jmd` | full weave **still running** at the time of writing (1 h 32 m wall, 33 m 37 s CPU consumed) | partial | ~1.4 h on an unloaded machine, from the per-configuration curves above |
| `liquid_argon_long.jmd` | not weaved | -- | ~1.3 h, from the same curves scaled by `t = 50/10` |

Note that most of the 870 s for `acceleration_functions.jmd` is package load
and precompilation, not benchmark content -- its `@benchmarkable` groups run on
BenchmarkTools' default 5 s budget. That file never had a runtime problem; it
only ever failed in CI by expiring in the queue behind the other two.

### Direct reproduction of the historical outlier

The 15.4 h `Vern9` configuration from the last published build reproduces on
current versions. A single solve of `Vern9` at `abstol = reltol = 0.2665`
(= `1e-4 * 2^11.38`, i.e. the last point of the *old* grid) at N=128, `t = 10`,
**did not return after 3 h 11 m** and was killed, even with `maxiters = 40000`.
Every other point in the same sweep returned in under 90 s. This is what the
`ats[end] = 1e-4` end of the old grid was buying.

### Corroboration from the last published output

The claim that the tolerance sweep was a no-op before f7ff87de is visible
directly in `markdown/NBodySimulator/liquid_argon.md` as published. Across the
sweep, runtime and energy error are flat:

| row | integrator | `reltol` column | runtime | energy error |
|---|---|---|---|---|
| 1 | `Tsit5` | 1.17e-13 | 83.45 s | 184.4 |
| 7 | `Tsit5` | 1.51e-12 | 83.47 s | 185.4 |
| 55 | `Tsit5` | 1.17e-03 | 82.31 s | 240.8 |
| 2 | `Vern7` | 2.29e-12 | 124.86 s | 17.1 |
| 56 | `Vern7` | 2.29e-02 | 125.62 s | 112.6 |
| 57 | `Vern9` | 2.67e-01 | **55388.9 s** | 324.9 |

Ten orders of magnitude of requested `reltol` and `Tsit5` moves by 1.4%. The
`rtol` kwarg was being silently dropped, so every point ran at DiffEq's default
`reltol`. `abstol` *was* applied, which is why row 57 -- where `abstol` is
`0.2665` and the controller therefore accepts arbitrarily large steps -- was
already pathological even then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrTtUuDkfgNEq3asQuZ3F6
