### PR TITLE
SimpleHandwrittenPDE: unbreak the reference solves and cap the regressed KenCarp sweeps

### DIFF
--- a/benchmarks/SimpleHandwrittenPDE/allen_cahn_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/allen_cahn_fdm_wpd.jmd
@@ -261,8 +261,20 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 Dense/banded linear solvers.
 
 ```julia
-abstols = 0.1 .^ (7:13)
-reltols = 0.1 .^ (4:10)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
+# KenCarp* with the default (dense) linsolve became dramatically slower below
+# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
+# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
+#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
+#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
+#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
+#                          235.0 s, 148 accepted steps, nf = 149389
+# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
+# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
+# sweep now stops there. Restore the old range once the upstream regression is
+# fixed.
+abstols = 0.1 .^ (7:9)
+reltols = 0.1 .^ (4:6)
 setups = [
     Dict(:alg => KenCarp3()),
     Dict(:alg => KenCarp4()),
@@ -288,8 +300,10 @@ plot(wp, label=labels, markershape=:auto, title="IMEX Methods, Band Linsolve, Lo
 
 Krylov linear solvers.
 ```julia
-abstols = 0.1 .^ (7:13)
-reltols = 0.1 .^ (4:10)
+# 2026-08: tightest three decades dropped -- they cost hours under the current
+# OrdinaryDiffEq v7 stack (see the dense-linsolve block above).
+abstols = 0.1 .^ (7:10)
+reltols = 0.1 .^ (4:7)
 setups = [
     Dict(:alg => KenCarp3(linsolve=KrylovJL_GMRES())),
     Dict(:alg => KenCarp4(linsolve=KrylovJL_GMRES())),
@@ -356,8 +370,11 @@ w_diag = WeightedDiagonalPreconBuilder(w = 0.9)
 amg = algebraicmultigrid
 amg2 = algebraicmultigrid2
 
-abstols = 0.1 .^ (8:13)
-reltols = 0.1 .^ (5:10)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget;
+# see the note on the low-tolerance IMEX block above. Measured cost of this
+# block before the trim: 682 s (allen_cahn_fdm) / 964 s (burgers_fdm).
+abstols = 0.1 .^ (8:10)
+reltols = 0.1 .^ (5:7)
 N = length(abstols)
 setups = [
     # Dict(:alg => KenCarp3(linsolve=KrylovJL_GMRES(), :dts => 1e-2 * ones(N), :adaptive => true),

--- a/benchmarks/SimpleHandwrittenPDE/allen_cahn_spectral_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/allen_cahn_spectral_wpd.jmd
@@ -183,8 +183,20 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 Dense/banded linear solvers.
 
 ```julia
-abstols = 0.1 .^ (7:13)
-reltols = 0.1 .^ (4:10)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
+# KenCarp* with the default (dense) linsolve became dramatically slower below
+# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
+# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
+#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
+#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
+#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
+#                          235.0 s, 148 accepted steps, nf = 149389
+# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
+# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
+# sweep now stops there. Restore the old range once the upstream regression is
+# fixed.
+abstols = 0.1 .^ (7:9)
+reltols = 0.1 .^ (4:6)
 setups = [
     Dict(:alg => KenCarp3()),
     Dict(:alg => KenCarp4()),
@@ -210,8 +222,10 @@ plot(wp, label=labels, markershape=:auto, title="IMEX Methods, Band Linsolve, Lo
 
 Krylov linear solvers.
 ```julia
-abstols = 0.1 .^ (7:13)
-reltols = 0.1 .^ (4:10)
+# 2026-08: tightest three decades dropped -- they cost hours under the current
+# OrdinaryDiffEq v7 stack (see the dense-linsolve block above).
+abstols = 0.1 .^ (7:10)
+reltols = 0.1 .^ (4:7)
 setups = [
     Dict(:alg => KenCarp3(linsolve=KrylovJL_GMRES())),
     Dict(:alg => KenCarp4(linsolve=KrylovJL_GMRES())),

--- a/benchmarks/SimpleHandwrittenPDE/burgers_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/burgers_fdm_wpd.jmd
@@ -277,8 +277,20 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 Dense/banded linear solvers.
 
 ```julia
-abstols = 0.1 .^ (7:13)
-reltols = 0.1 .^ (4:10)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
+# KenCarp* with the default (dense) linsolve became dramatically slower below
+# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
+# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
+#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
+#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
+#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
+#                          235.0 s, 148 accepted steps, nf = 149389
+# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
+# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
+# sweep now stops there. Restore the old range once the upstream regression is
+# fixed.
+abstols = 0.1 .^ (7:9)
+reltols = 0.1 .^ (4:6)
 setups = [
     Dict(:alg => KenCarp3()),
     Dict(:alg => KenCarp4()),
@@ -304,8 +316,10 @@ plot(wp, label=labels, markershape=:auto, title="IMEX Methods, Band Linsolve, Lo
 
 Krylov linear solvers.
 ```julia
-abstols = 0.1 .^ (7:13)
-reltols = 0.1 .^ (4:10)
+# 2026-08: tightest three decades dropped -- they cost hours under the current
+# OrdinaryDiffEq v7 stack (see the dense-linsolve block above).
+abstols = 0.1 .^ (7:10)
+reltols = 0.1 .^ (4:7)
 setups = [
     Dict(:alg => KenCarp3(linsolve=KrylovJL_GMRES())),
     Dict(:alg => KenCarp4(linsolve=KrylovJL_GMRES())),
@@ -374,8 +388,11 @@ w_diag = WeightedDiagonalPreconBuilder(w = 0.9)
 amg = algebraicmultigrid
 amg2 = algebraicmultigrid2
 
-abstols = 0.1 .^ (8:13)
-reltols = 0.1 .^ (5:10)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget;
+# see the note on the low-tolerance IMEX block above. Measured cost of this
+# block before the trim: 682 s (allen_cahn_fdm) / 964 s (burgers_fdm).
+abstols = 0.1 .^ (8:10)
+reltols = 0.1 .^ (5:7)
 N = length(abstols)
 setups = [
     # Dict(:alg => KenCarp3(linsolve=KrylovJL_GMRES(), :dts => 1e-2 * ones(N), :adaptive => true),

--- a/benchmarks/SimpleHandwrittenPDE/burgers_spectral_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/burgers_spectral_wpd.jmd
@@ -177,8 +177,20 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 Dense/banded linear solvers.
 
 ```julia
-abstols = 0.1 .^ (7:13)
-reltols = 0.1 .^ (4:10)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
+# KenCarp* with the default (dense) linsolve became dramatically slower below
+# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
+# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
+#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
+#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
+#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
+#                          235.0 s, 148 accepted steps, nf = 149389
+# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
+# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
+# sweep now stops there. Restore the old range once the upstream regression is
+# fixed.
+abstols = 0.1 .^ (7:9)
+reltols = 0.1 .^ (4:6)
 setups = [
     Dict(:alg => KenCarp3()),
     Dict(:alg => KenCarp4()),
@@ -204,8 +216,10 @@ plot(wp, label=labels, markershape=:auto, title="IMEX Methods, Band Linsolve, Lo
 
 Krylov linear solvers.
 ```julia
-abstols = 0.1 .^ (7:13)
-reltols = 0.1 .^ (4:10)
+# 2026-08: tightest three decades dropped -- they cost hours under the current
+# OrdinaryDiffEq v7 stack (see the dense-linsolve block above).
+abstols = 0.1 .^ (7:10)
+reltols = 0.1 .^ (4:7)
 setups = [
     Dict(:alg => KenCarp3(linsolve=KrylovJL_GMRES())),
     Dict(:alg => KenCarp4(linsolve=KrylovJL_GMRES())),

--- a/benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd
@@ -26,7 +26,7 @@ The spatial derivative operators are represented via finite difference approxima
 
 ```julia
 using OrdinaryDiffEq
-using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
 using DiffEqDevTools
 using SciMLOperators
 using LinearSolve
@@ -73,7 +73,16 @@ L = 16.0  # Domain length
 alpha = 5.0 # Time scaling factor
 xs, prob = kortwrieg_de_vries(N, L, alpha)
 
-@time sol = solve(prob, AutoVern7(RadauIIA5(autodiff=AutoFiniteDiff())); 
+# 2026-08: this reference solve used `AutoVern7(RadauIIA5(...))`, which now
+# throws `type CompositeCache has no field iter` and takes the whole file down
+# with it (every later chunk then fails on an undefined `test_sol`).
+# `stepsize_controller!` in OrdinaryDiffEqCore v4
+# (src/integrators/controllers.jl) does `if isfirk(alg); (; iter) =
+# integrator.cache`, but under an AutoSwitch wrapper `integrator.cache` is a
+# CompositeCache, which has no `iter` field. Rodas5P is not FIRK, so it takes
+# the `fac_default_gamma` path instead and works; measured against the same
+# `dt`/tolerances it costs 21-57 s on these problems.
+@time sol = solve(prob, AutoVern7(Rodas5P(autodiff=AutoFiniteDiff())); 
                   dt = 1e-4, abstol = 1e-14, reltol = 1e-14);
 
 test_sol = TestSolution(sol) # Reference solution for error estimation
@@ -172,8 +181,20 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 
 Dense and Krylov linear solvers.
 ```julia
-abstols = 0.1 .^ (8:12)
-reltols = 0.1 .^ (5:9)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
+# KenCarp* with the default (dense) linsolve became dramatically slower below
+# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
+# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
+#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
+#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
+#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
+#                          235.0 s, 148 accepted steps, nf = 149389
+# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
+# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
+# sweep now stops there. Restore the old range once the upstream regression is
+# fixed.
+abstols = 0.1 .^ (7:9)
+reltols = 0.1 .^ (4:6)
 setups = [
     Dict(:alg => KenCarp3()),
     Dict(:alg => KenCarp4()),

--- a/benchmarks/SimpleHandwrittenPDE/kdv_spectral_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/kdv_spectral_wpd.jmd
@@ -5,7 +5,7 @@ author: Arjit Seth
 
 ```julia
 using OrdinaryDiffEq
-using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
 using DiffEqDevTools
 using SciMLOperators
 using LinearSolve
@@ -69,7 +69,16 @@ n = 128 # Number of Chebyshev points
 alpha = 5.0 # Time scaling factor
 xs, prob = korteweg_de_vries(n, L, alpha)
 
-@time sol = solve(prob, AutoVern7(RadauIIA5(autodiff=AutoFiniteDiff())); 
+# 2026-08: this reference solve used `AutoVern7(RadauIIA5(...))`, which now
+# throws `type CompositeCache has no field iter` and takes the whole file down
+# with it (every later chunk then fails on an undefined `test_sol`).
+# `stepsize_controller!` in OrdinaryDiffEqCore v4
+# (src/integrators/controllers.jl) does `if isfirk(alg); (; iter) =
+# integrator.cache`, but under an AutoSwitch wrapper `integrator.cache` is a
+# CompositeCache, which has no `iter` field. Rodas5P is not FIRK, so it takes
+# the `fac_default_gamma` path instead and works; measured against the same
+# `dt`/tolerances it costs 21-57 s on these problems.
+@time sol = solve(prob, AutoVern7(Rodas5P(autodiff=AutoFiniteDiff())); 
                   dt = 1e-4, reltol = 1e-12, abstol = 1e-12);
 
 test_sol = TestSolution(sol) # Reference solution for error estimation
@@ -167,8 +176,20 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 
 
 ```julia
-abstols = 0.1 .^ (8:10)
-reltols = 0.1 .^ (5:7)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
+# KenCarp* with the default (dense) linsolve became dramatically slower below
+# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
+# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
+#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
+#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
+#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
+#                          235.0 s, 148 accepted steps, nf = 149389
+# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
+# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
+# sweep now stops there. Restore the old range once the upstream regression is
+# fixed.
+abstols = 0.1 .^ (7:9)
+reltols = 0.1 .^ (4:6)
 setups = [
     Dict(:alg => KenCarp3()),
     Dict(:alg => KenCarp4()),

--- a/benchmarks/SimpleHandwrittenPDE/ks_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/ks_fdm_wpd.jmd
@@ -377,8 +377,20 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 
 Dense and Krylov linear solvers.
 ```julia
-abstols = 0.1 .^ (7:11)
-reltols = 0.1 .^ (7:11)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
+# KenCarp* with the default (dense) linsolve became dramatically slower below
+# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
+# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
+#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
+#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
+#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
+#                          235.0 s, 148 accepted steps, nf = 149389
+# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
+# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
+# sweep now stops there. Restore the old range once the upstream regression is
+# fixed.
+abstols = 0.1 .^ (7:9)
+reltols = 0.1 .^ (4:6)
 setups = [
     Dict(:alg => KenCarp3()),
     Dict(:alg => KenCarp4()),
@@ -411,8 +423,12 @@ plot(wp, label=labels, markershape=:auto, title="IMEX Methods, Low Tolerances")
 #### Exponential Integrators
 
 ```julia
+# 2026-08: reltols restored to 0.1^(4:8), the range that last published
+# (2025-08-29). #1629 tightened them to 0.1^(7:11) without touching
+# abstols; these are all fixed-dt setups, so that only shifted where the
+# points land on the plot.
 abstols = 0.1 .^ (7:11) # all fixed dt methods so these don't matter much
-reltols = 0.1 .^ (7:11)
+reltols = 0.1 .^ (4:8)
 multipliers = 0.5 .^ (0:4)
 setups = [
     Dict(:alg => ETDRK3(), :dts => 1e-4 * multipliers),
@@ -434,8 +450,12 @@ plot(wp, label=labels, markershape=:auto, title="ExpRK Methods, Low Tolerances")
 #### Comparisons Between Families
 
 ```julia
+# 2026-08: reltols restored to 0.1^(4:8), the range that last published
+# (2025-08-29). #1629 tightened them to 0.1^(7:11) without touching
+# abstols; these are all fixed-dt setups, so that only shifted where the
+# points land on the plot.
 abstols = 0.1 .^ (7:11)
-reltols = 0.1 .^ (7:11)
+reltols = 0.1 .^ (4:8)
 multipliers = 0.5 .^ (0:4)
 setups = [
     Dict(:alg => ARKODE(Sundials.Implicit(), order=5, linear_solver=:GMRES)),

--- a/benchmarks/SimpleHandwrittenPDE/ks_spectral_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/ks_spectral_wpd.jmd
@@ -166,8 +166,20 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 #### Implicit-Explicit Methods
 
 ```julia
-abstols = 0.1 .^ (7:10)
-reltols = 0.1 .^ (4:7)
+# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
+# KenCarp* with the default (dense) linsolve became dramatically slower below
+# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
+# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
+#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
+#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
+#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
+#                          235.0 s, 148 accepted steps, nf = 149389
+# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
+# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
+# sweep now stops there. Restore the old range once the upstream regression is
+# fixed.
+abstols = 0.1 .^ (7:9)
+reltols = 0.1 .^ (4:6)
 setups = [
     Dict(:alg => KenCarp3()),
     Dict(:alg => KenCarp4()),

--- a/benchmarks/SimpleHandwrittenPDE/nls_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/nls_fdm_wpd.jmd
@@ -98,7 +98,16 @@ L = 16.0  # Domain half-length
 alpha = 5.0 # Dispersive coefficient
 xs, prob = nonlinear_schrodinger(N, L, alpha)
 
-@time sol = solve(prob, AutoVern7(RadauIIA5(autodiff=AutoFiniteDiff()));
+# 2026-08: this reference solve used `AutoVern7(RadauIIA5(...))`, which now
+# throws `type CompositeCache has no field iter` and takes the whole file down
+# with it (every later chunk then fails on an undefined `test_sol`).
+# `stepsize_controller!` in OrdinaryDiffEqCore v4
+# (src/integrators/controllers.jl) does `if isfirk(alg); (; iter) =
+# integrator.cache`, but under an AutoSwitch wrapper `integrator.cache` is a
+# CompositeCache, which has no `iter` field. Rodas5P is not FIRK, so it takes
+# the `fac_default_gamma` path instead and works; measured against the same
+# `dt`/tolerances it costs 21-57 s on these problems.
+@time sol = solve(prob, AutoVern7(Rodas5P(autodiff=AutoFiniteDiff()));
                   dt = 1e-4, abstol = 1e-14, reltol = 1e-14);
 
 test_sol = TestSolution(sol) # Reference solution for error estimation

--- a/benchmarks/SimpleHandwrittenPDE/nls_spectral_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/nls_spectral_wpd.jmd
@@ -5,7 +5,7 @@ author: Chris Rackauckas
 
 ```julia
 using OrdinaryDiffEq
-using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqHighOrderRK, OrdinaryDiffEqIMEXMultistep
+using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqHighOrderRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqRosenbrock
 using DiffEqDevTools
 using SciMLOperators
 using LinearSolve
@@ -86,7 +86,16 @@ n = 256 # Number of grid points
 alpha = 5.0 # Dispersive coefficient
 xs, prob = nonlinear_schrodinger(n, L, alpha)
 
-@time sol = solve(prob, AutoVern7(RadauIIA5(autodiff=AutoFiniteDiff()));
+# 2026-08: this reference solve used `AutoVern7(RadauIIA5(...))`, which now
+# throws `type CompositeCache has no field iter` and takes the whole file down
+# with it (every later chunk then fails on an undefined `test_sol`).
+# `stepsize_controller!` in OrdinaryDiffEqCore v4
+# (src/integrators/controllers.jl) does `if isfirk(alg); (; iter) =
+# integrator.cache`, but under an AutoSwitch wrapper `integrator.cache` is a
+# CompositeCache, which has no `iter` field. Rodas5P is not FIRK, so it takes
+# the `fac_default_gamma` path instead and works; measured against the same
+# `dt`/tolerances it costs 21-57 s on these problems.
+@time sol = solve(prob, AutoVern7(Rodas5P(autodiff=AutoFiniteDiff()));
                   dt = 1e-4, reltol = 1e-12, abstol = 1e-12);
 
 test_sol = TestSolution(sol) # Reference solution for error estimation


### PR DESCRIPTION
## What broke, and when it last worked

`benchmarks/SimpleHandwrittenPDE` last published on **2025-08-29**, from source commit
`747d591e` (all eight `.md` files in `SciMLBenchmarksOutput/markdown/SimpleHandwrittenPDE`
carry that build). Summing the `@time` lines in that published output, the eight files
cost **≈3.2 h of solver time** then:

| file | `@time` total, 2025-08-29 build |
|---|---|
| allen_cahn_fdm_wpd | 709 s |
| allen_cahn_spectral_wpd | 3393 s |
| burgers_fdm_wpd | 896 s |
| burgers_spectral_wpd | 2212 s |
| kdv_fdm_wpd | 775 s |
| kdv_spectral_wpd | 1395 s |
| ks_fdm_wpd | 1140 s |
| ks_spectral_wpd | 928 s |

`nls_fdm_wpd.jmd` and `nls_spectral_wpd.jmd` were added in 2026-03 (`11be1dcd`, `cec58e3c`,
`836a86fe`) and **have never published** — there is no `nls_*.md` in the Output repo at all.

Since the move to GitHub Actions the whole-folder job has been cancelled at the 5-day limit
on 2026-06-18, 07-02, 07-07, 07-20 and 08-15, and at 63.3 h on 08-11. That predates the
08-13 NordsieckBDF addition (#1646), so #1646 is not the cause.

The cause is the **2026-05-04 OrdinaryDiffEq v7 migration** (`fb9a3b66`..`cbafe70c`), which
took the folder from OrdinaryDiffEq 6.101 / LinearSolve 3.26 to 7.0.0 / 3.87. The `.jmd`
tolerance settings themselves are unchanged since the last good build in seven of the eight
files — only `ks_fdm_wpd.jmd` was restructured (by #1629, 2026-08-11).

## Measured root causes

**1. Four of the ten files abort at their reference solve.**
`AutoVern7(RadauIIA5(...))` throws `type CompositeCache has no field iter` under
OrdinaryDiffEqCore v4. In `OrdinaryDiffEqCore/src/integrators/controllers.jl`,
`stepsize_controller!` does

```julia
if isfirk(alg)
    (; iter) = integrator.cache
```

but under an `AutoSwitch` wrapper `integrator.cache` is a `CompositeCache`, which has no
`iter` field. It fires as soon as the switch to the FIRK member happens. Every later chunk
then dies on an undefined `test_sol`, so the file produces nothing:

| file | pre-fix result |
|---|---|
| kdv_fdm_wpd | chunk 3 `CompositeCache has no field iter`, chunks 4-9 `UndefVarError: test_sol` |
| kdv_spectral_wpd | same |
| nls_fdm_wpd | same (chunk 4, then 5-13) |
| nls_spectral_wpd | same (chunk 3, then 4-10) |

Note this combination *worked* at the last good build, where the call was
`AutoVern7(RadauIIA5(autodiff=false))`; the v7 migration rewrote it to
`autodiff=AutoFiniteDiff()` and the OrdinaryDiffEqCore v4 controller broke it.

**2. KenCarp\* with the default (dense) linsolve regressed 10-90x below abstol 1e-9.**
Back-to-back on the same machine, same problem (KS spectral, N = 128), one solve:

| alg | abstol / reltol | 6.101 + LinearSolve 3.26 | 7.0.0 + LinearSolve 3.87 |
|---|---|---|---|
| KenCarp3 | 1e-9 / 1e-6 | 7.4 s | 48.7 s |
| KenCarp3 | 1e-10 / 1e-7 | 10.6 s | 89.1 s |
| KenCarp4 | 1e-9 / 1e-6 | 1.8 s | 16.7 s |
| KenCarp4 | 1e-10 / 1e-7 | 2.6 s | **235.0 s** |

Accepted steps are identical (148 vs 149 for the KenCarp4 1e-10 case); what explodes is the
work per step — `nf` 15598 → 149389, `nsolve` 15761 → 149552. At abstol 1e-7 and 1e-8 the
two stacks are bit-for-bit identical in step and function counts, so the knee sits between
1e-9 and 1e-10.

Per-chunk wall times for the affected blocks, measured on the parent commit (a
chunk-by-chunk driver, one thread per file):

| file | chunk | pre-fix cost |
|---|---|---|
| ks_fdm_wpd | dense/Krylov IMEX, low tol | KenCarp3 alone **3690 s**, killed during KenCarp4 |
| burgers_spectral_wpd | IMEX, low tol | KenCarp3 alone **3457 s**, killed during KenCarp4 |
| allen_cahn_spectral_wpd | IMEX, low tol | KenCarp3 3138 s, KenCarp4 1536 s, killed in KenCarp5 |
| ks_spectral_wpd | IMEX, low tol | KenCarp3 1903 s, KenCarp4 928 s, killed in KenCarp5 |
| burgers_fdm_wpd | IMEX dense/banded, low tol | **1939 s** (KenCarp3 1541 s of it) |
| burgers_fdm_wpd | preconditioner sweep | 964 s |
| allen_cahn_fdm_wpd | preconditioner sweep | 682 s |

## The fix

* Reference solves switched from `AutoVern7(RadauIIA5(...))` to `AutoVern7(Rodas5P(...))`
  in the four broken files. Rodas5P is not FIRK, so it takes the `fac_default_gamma` path
  and never touches the missing field. Measured against the same `dt`/tolerances it costs
  21-57 s on these problems, against 9-41 s for a bare `RadauIIA5` — no meaningful change
  in reference cost, and the same tolerance is reached.
* The low-tolerance KenCarp sweeps now stop at **abstol 1e-9 / reltol 1e-6**, the last point
  before the regression bites. The measured old-vs-new numbers are recorded inline in each
  file so the range can be restored once the upstream regression is fixed.
* The Krylov and preconditioner sweeps lose their tightest 3 decades for the same reason.
* `ks_fdm_wpd.jmd`: the two ExpRK/ARKODE `reltols` ranges are restored to the `0.1^(4:8)`
  that last published. #1629 tightened them to `0.1^(7:11)` without touching `abstols`;
  those are fixed-`dt` setups, so it only moved where the points land on the plot.

No solver, problem size, `numruns` or scientific content is changed.

## Verification

**Measured**, end-to-end `SciMLBenchmarks.weave_file` on this branch's files, current
Manifest (OrdinaryDiffEq 7.0.0, Julia 1.10):

| file | wall time |
|---|---|
| `ks_spectral_wpd.jmd` | **2287 s** (38 min), all 10 chunks, `.md` + figures produced |
| `nls_fdm_wpd.jmd` | **1684 s** (28 min), all 14 chunks, `.md` + figures produced |

`nls_fdm_wpd.jmd` had produced *zero* results before this change.

**Caveat on those numbers:** they were measured on a 12-core laptop that was carrying a
load average of 50-180 from unrelated jobs, so they are loose upper bounds. The
old-vs-new solver comparisons above are the reliable signal, because both halves were run
back-to-back under the same contention.

**Estimated** for the remaining eight files: the pre-fix per-chunk table above accounts for
essentially all the excess, and the trims remove the tolerance points that produced it
(e.g. burgers_fdm's 1939 s block keeps only its 1e-7..1e-9 points, which cost seconds each
in the probe). Scaling the last-good 3.2 h by the two new files and the trimmed ranges puts
the folder at roughly **4-6 h**, comfortably inside the 12 h target, with no single file
near the multi-hour mark. This is an estimate, not a measurement — the honest test is the
CI run on this PR.

## Follow-ups not done here

* The KenCarp/dense-linsolve regression is upstream, in the OrdinaryDiffEq v7 or LinearSolve
  3.8x stack, and deserves its own issue with the reproducer above. This PR only routes
  around it.
* `AutoVern7(RadauIIA5(...))` is a plain bug in OrdinaryDiffEqCore v4's `stepsize_controller!`
  and should be fixed there rather than avoided in benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrTtUuDkfgNEq3asQuZ3F6
