### PR TITLE
Bound KdV KenCarp step sizes

### DIFF
--- a/benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd
@@ -179,34 +179,23 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 
 #### Implicit-Explicit Methods
 
-Dense and Krylov linear solvers.
+Adaptive KenCarp and ARKODE configurations. The KenCarp steps are capped before
+they reach a Newton/Krylov stall near $t = 0.32$.
 ```julia
-# 2026-08: tolerance range trimmed to keep this folder inside the CI budget.
-# KenCarp* with the default (dense) linsolve became dramatically slower below
-# abstol 1e-9 in the OrdinaryDiffEq v7 stack. Measured on the KS spectral
-# problem (N = 128), one KenCarp4 solve at abstol=1e-10, reltol=1e-7:
-#   OrdinaryDiffEq 6.101 + LinearSolve 3.26 (the stack that last published this
-#     folder, 2025-08-29):   2.6 s, 149 accepted steps, nf = 15598
-#   OrdinaryDiffEq 7.0.0 + LinearSolve 3.87 (current):
-#                          235.0 s, 148 accepted steps, nf = 149389
-# i.e. the same steps but ~10x the f evaluations and linear solves; KenCarp3
-# goes 10.6 s -> 89 s the same way. abstol 1e-7..1e-9 is unaffected, so the
-# sweep now stops there. Restore the old range once the upstream regression is
-# fixed.
 abstols = 0.1 .^ (7:9)
 reltols = 0.1 .^ (4:6)
 setups = [
-    Dict(:alg => KenCarp3()),
-    Dict(:alg => KenCarp4()),
-    Dict(:alg => KenCarp5()),
+    Dict(:alg => KenCarp3(), :dtmax => 0.015),
+    Dict(:alg => KenCarp4(), :dtmax => 0.03),
+    Dict(:alg => KenCarp5(), :dtmax => 0.00875),
     Dict(:alg => ARKODE(Sundials.Implicit(), order=3, linear_solver=:GMRES)),
     Dict(:alg => ARKODE(Sundials.Implicit(), order=4, linear_solver=:GMRES)),
     Dict(:alg => ARKODE(Sundials.Implicit(), order=5, linear_solver=:GMRES)),
 ]
 labels = hcat(
-    "KenCarp3 (dense)",
-    "KenCarp4 (dense)",
-    "KenCarp5 (dense)",
+    "KenCarp3",
+    "KenCarp4",
+    "KenCarp5",
     "ARKODE3 (Krylov)",
     "ARKODE4 (Krylov)",
     "ARKODE5 (Krylov)",


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

This is a one-commit patch stacked on https://github.com/SciML/SciMLBenchmarks.jl/pull/1672. Merge it into `fix/simplehandwrittenpde-runtime` before merging that PR.

## What changed and why

The KdV `SplitODEProblem` lets the adaptive KenCarp methods enter a Newton solve whose default matrix-free GMRES path does not return. This is the reason the remaining `kdv_fdm_wpd.jmd` CI job has run for more than 41 hours.

Cap each KenCarp method at the largest locally verified stable step size: 0.015 for KenCarp3, 0.03 for KenCarp4, and 0.00875 for KenCarp5. These caps preserve tolerance-dependent work counts. The labels no longer call the default linear solver “dense”; the observed default path is Krylov GMRES.

## Verification

### Failing before

A minimized solve using the benchmark's exact `SplitODEProblem`, `KenCarp3()`, `abstol=1e-7`, and `reltol=1e-4` did not return in the deliberately short immediate-hang check:

```text
$ timeout 60 julia +1.10 --project=benchmarks/SimpleHandwrittenPDE scratch/kdv_fdm_probe.jl default
starting mode=default
[1150676] signal (15): Terminated
...
gmres! at Krylov/src/gmres.jl:121
compute_step! at OrdinaryDiffEqNonlinearSolve/src/newton.jl:323
Allocations: 31282594 ...
exit status: 124
```

The temporary probe was removed before committing.

### Passing after

The same problem with the final caps returned `Success` at every benchmark tolerance:

```text
KenCarp3 dtmax=0.015:   accepted steps 69, 126, 280
KenCarp4 dtmax=0.03:    accepted steps 59, 117, 184
KenCarp5 dtmax=0.00875: accepted steps 115, 115, 155
9/9 solves: Success
```

Nearby larger coarse-tolerance caps reproduced the hang: KenCarp3 at 0.02, KenCarp4 at 0.04, and the uncapped KenCarp5 path. This is why the values are method-specific.

The exact final benchmark file completed locally:

```text
$ timeout 3600 .github/scripts/build_benchmark.sh benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd
...
KenCarp3
KenCarp4
KenCarp5
ARKODE3 (Krylov)
ARKODE4 (Krylov)
ARKODE5 (Krylov)
 97.842728 seconds (...)
...
[ Info: Weaved all chunks
└   progress = 1
[ Info: Weaved to .../markdown/SimpleHandwrittenPDE/kdv_fdm_wpd.md
exit status: 0
```

The unchanged final ARKODE comparison emitted one `Instability detected` warning and still generated its plot. The full folder was not run; only the CI target changed here was weaved.

Formatting and spelling checks completed with no output and exit status 0:

```text
git ls-files -z -- '*.jl' | xargs -0 --no-run-if-empty julia +1.12 --startup-file=no -m Runic --check --diff
typos benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd
git diff --check
```

Root QA reproduced the known base-branch metadata failures and no others:

```text
$ GROUP=QA julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
QA | 16 passed, 3 failed, 19 total
```

The failures are stale root dependencies and missing stdlib/Test compat entries. They reproduce on master and are fixed separately by https://github.com/SciML/SciMLBenchmarks.jl/pull/1683 (19/19 locally). Direct `docs/make.jl` is inapplicable in this source checkout; docs are copied to and built from `SciMLBenchmarksOutput`. No GPU or downstream jobs were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
