### PR TITLE
Repair AdaptiveSDE runtime and ensemble analysis

### DIFF
--- a/benchmarks/AdaptiveSDE/AdaptiveEfficiencyTests.jmd
+++ b/benchmarks/AdaptiveSDE/AdaptiveEfficiencyTests.jmd
@@ -146,7 +146,7 @@ end
 ```julia
 gr(fmt = :svg)
 lw=3
-leg=String["RSwM1", "RSwM2", "RSwM3"]
+leg = permutedims(String["RSwM1", "RSwM2", "RSwM3"])
 
 titleFontSize = 16
 guideFontSize = 14

--- a/benchmarks/AdaptiveSDE/AdaptiveEfficiencyTests.jmd
+++ b/benchmarks/AdaptiveSDE/AdaptiveEfficiencyTests.jmd
@@ -20,8 +20,17 @@ p3 = Vector{Any}(undef, 3)
 end
 
 using StochasticDiffEq, SDEProblemLibrary, DiffEqNoiseProcess, Plots, ParallelDataTransfer
+import Statistics
 import SDEProblemLibrary: prob_sde_additive,
                           prob_sde_linear, prob_sde_wave
+
+function final_error_stats(sim)
+    errors = [sol.errors[:final] for sol in sim.u]
+    return (;
+        elapsed_time = sim.elapsedTime, mean = Statistics.mean(errors),
+        median = Statistics.median(errors),
+    )
+end
 
 probs = Matrix{SDEProblem}(undef, 3, 3)
 ## Problem 1
@@ -84,12 +93,12 @@ for k in 1:size(probs, 1)
     println("RSwM1")
     for i in (1 + offset):(N + offset)
         tols[i - offset, 1] = 2.0^(-i-1)
-        msims[i - offset] = DiffEqBase.calculate_monte_errors(solve(monte_prob, SRIW1(),
+        msims[i - offset] = final_error_stats(solve(monte_prob, SRIW1(),
             trajectories = 1000, abstol = 2.0^(-i-1),
             reltol = 0, force_dtmin = true))
-        elapsed[i - offset, 1] = msims[i - offset].elapsedTime
-        medians[i - offset, 1] = msims[i - offset].error_medians[:final]
-        means[i - offset, 1] = msims[i - offset].error_means[:final]
+        elapsed[i - offset, 1] = msims[i - offset].elapsed_time
+        medians[i - offset, 1] = msims[i - offset].median
+        means[i - offset, 1] = msims[i - offset].mean
     end
 
     println("RSwM2")
@@ -102,12 +111,12 @@ for k in 1:size(probs, 1)
 
     for i in (1 + offset):(N + offset)
         tols[i - offset, 2] = 2.0^(-i-1)
-        msims[i - offset] = DiffEqBase.calculate_monte_errors(solve(monte_prob, SRIW1(),
+        msims[i - offset] = final_error_stats(solve(monte_prob, SRIW1(),
             trajectories = 1000, abstol = 2.0^(-i-1),
             reltol = 0, force_dtmin = true))
-        elapsed[i - offset, 2] = msims[i - offset].elapsedTime
-        medians[i - offset, 2] = msims[i - offset].error_medians[:final]
-        means[i - offset, 2] = msims[i - offset].error_means[:final]
+        elapsed[i - offset, 2] = msims[i - offset].elapsed_time
+        medians[i - offset, 2] = msims[i - offset].median
+        means[i - offset, 2] = msims[i - offset].mean
     end
 
     println("RSwM3")
@@ -119,12 +128,12 @@ for k in 1:size(probs, 1)
 
     for i in (1 + offset):(N + offset)
         tols[i - offset, 3] = 2.0^(-i-1)
-        msims[i - offset] = DiffEqBase.calculate_monte_errors(solve(monte_prob, SRIW1(),
+        msims[i - offset] = final_error_stats(solve(monte_prob, SRIW1(),
             adaptive = true, trajectories = 1000, abstol = 2.0^(-i-1),
             reltol = 0, force_dtmin = true))
-        elapsed[i - offset, 3] = msims[i - offset].elapsedTime
-        medians[i - offset, 3] = msims[i - offset].error_medians[:final]
-        means[i - offset, 3] = msims[i - offset].error_means[:final]
+        elapsed[i - offset, 3] = msims[i - offset].elapsed_time
+        medians[i - offset, 3] = msims[i - offset].median
+        means[i - offset, 3] = msims[i - offset].mean
     end
 
     fullMeans[k] = means

--- a/benchmarks/AdaptiveSDE/Manifest.toml
+++ b/benchmarks/AdaptiveSDE/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "247e18841eaddecc05ae934aa3c4942bacafc4af"
+project_hash = "3d173012f8dd9b435661299cc826a54894c8509d"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "bbc22a9a08a0ef6460041086d8a7b27940ed4ffd"

--- a/benchmarks/AdaptiveSDE/Project.toml
+++ b/benchmarks/AdaptiveSDE/Project.toml
@@ -7,6 +7,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
 SciMLBenchmarks = "31c91b34-3c75-11e9-0341-95557aab0344"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [compat]
@@ -16,4 +17,5 @@ Plots = "1.4"
 SDEProblemLibrary = "0.1, 1"
 SciMLBenchmarks = "0.1"
 SciMLLogging = "1, 2"
+Statistics = "1"
 StochasticDiffEq = "7"

--- a/benchmarks/AdaptiveSDE/qmaxDetermination.jmd
+++ b/benchmarks/AdaptiveSDE/qmaxDetermination.jmd
@@ -9,8 +9,9 @@ times = Array{Float64}(undef, length(qs), 4)
 means = Array{Float64}(undef, length(qs), 4)
 
 using StochasticDiffEq, SDEProblemLibrary, Random,
-      Plots, ParallelDataTransfer, DiffEqMonteCarlo, Distributed
+      Plots, ParallelDataTransfer, Distributed
 using SciMLLogging
+import Statistics
 Random.seed!(99)
 
 full_prob = SDEProblemLibrary.oval2ModelExample(largeFluctuations = true, useBigs = false)
@@ -50,7 +51,7 @@ end
 monte_prob = EnsembleProblem(probs[1])
 test_mc = solve(monte_prob, SRIW1(), dt = 1/2^(4), adaptive = true,
     trajectories = 1000, abstol = 2.0^(-1), reltol = 0)
-DiffEqBase.calculate_monte_errors(test_mc);
+Statistics.mean(sol.errors[:final] for sol in test_mc.u);
 ```
 
 ## qmax test on Oval2 Model
@@ -77,9 +78,8 @@ for k in eachindex(probs)
     for i in eachindex(qs)
         msim = solve(monte_prob, dt = 1/2^(4), SRIW1(), adaptive = true,
             trajectories = num_runs, abstol = 2.0^(-13), reltol = 0, qmax = qs[i])
-        test_msim = DiffEqBase.calculate_monte_errors(msim)
-        times[i, k] = test_msim.elapsedTime
-        means[i, k] = test_msim.error_means[:final]
+        times[i, k] = msim.elapsedTime
+        means[i, k] = Statistics.mean(sol.errors[:final] for sol in msim.u)
         println("for k=$k and i=$i, we get that the error was $(means[i,k]) and it took $(times[i,k]) seconds")
     end
 end

--- a/benchmarks/AdaptiveSDE/qmaxDetermination.jmd
+++ b/benchmarks/AdaptiveSDE/qmaxDetermination.jmd
@@ -43,7 +43,7 @@ println("Setup Complete")
 
 function runAdaptive(i, k)
     sol = solve(prob, SRIW1(), dt = 1/2^(8), abstol = 2.0^(-15), reltol = 2.0^(-10),
-        verbose = SciMLLogging.None(), maxIters = Int(1e12), qmax = qs[k])
+        verbose = SciMLLogging.None(), maxiters = Int(1e12), qmax = qs[k])
     Int(any(isnan, sol[end]) || sol.t[end] != 1)
 end
 

--- a/benchmarks/AdaptiveSDE/qmaxDetermination.jmd
+++ b/benchmarks/AdaptiveSDE/qmaxDetermination.jmd
@@ -73,7 +73,7 @@ for k in eachindex(probs)
     global probs, times, means, qs
     println("Problem $k")
     ## Setup
-    prob = probs[k]
+    local monte_prob = EnsembleProblem(probs[k])
 
     for i in eachindex(qs)
         msim = solve(monte_prob, dt = 1/2^(4), SRIW1(), adaptive = true,

--- a/test/core.jl
+++ b/test/core.jl
@@ -71,6 +71,19 @@ end
     end
 end
 
+@testset "AdaptiveSDE plot labels" begin
+    benchmark = joinpath(
+        dirname(@__DIR__), "benchmarks", "AdaptiveSDE", "AdaptiveEfficiencyTests.jmd"
+    )
+    assignment = only(
+        line for line in eachline(benchmark) if startswith(strip(line), "leg=") ||
+            startswith(strip(line), "leg =")
+    )
+    labels = Core.eval(@__MODULE__, Meta.parse(split(assignment, "="; limit = 2)[2]))
+    @test size(labels) == (1, 3)
+    @test vec(labels) == ["RSwM1", "RSwM2", "RSwM3"]
+end
+
 @testset "DiffEqGPU singleton parameter grids" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks", "DiffEqGPU")
 


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

This combines the AdaptiveSDE repairs into one current-master branch. Both notebooks used the retired Monte Carlo error API; `qmaxDetermination.jmd` additionally imported the absent `DiffEqMonteCarlo` package, passed the obsolete `maxIters` keyword, and accidentally reran `probs[1]` for every reported problem.

The notebooks now calculate the final-error summaries they consume from the public `EnsembleSolution` data, use `maxiters`, and construct each ensemble from the intended problem. `Statistics` is added as a direct standard-library dependency. Resolving changes no package versions and updates the Manifest only in `project_hash`.

The AdaptiveEfficiency plots also now pass a row of labels to Plots. The former label vector assigned the entire three-element vector to every series instead of assigning one scalar label per algorithm.

This supersedes the narrower keyword PR at https://github.com/SciML/SciMLBenchmarks.jl/pull/1686.

## Failing before

The old import and analysis call fail in the pinned environment:

```text
ERROR: ArgumentError: Package DiffEqMonteCarlo not found in current path.
ERROR: UndefVarError: `calculate_monte_errors` not defined
```

The old keyword independently fails before solving:

```text
ERROR: Unrecognized keyword arguments found.
Unrecognized keyword arguments: [:maxIters]
```

The prior folder CI reached these failures at https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32905717360/job/98124979423.

The exact plot-label regression test fails against the unfixed source:

```text
Test Summary:           | Pass  Fail  Total
AdaptiveSDE plot labels |    1     1      2
Expression: size(labels) == (1, 3)
 Evaluated: (3,) == (1, 3)
```

A clean-master bisect identified https://github.com/SciML/SciMLBenchmarks.jl/commit/5c24d4c2c9a9390c353b714aa99e84402ae256b7 as the first bad commit. On current master, Plots rendered each series label as the full vector `["RSwM1", "RSwM2", "RSwM3"]`.

## Passing after

The complete AdaptiveSDE folder was woven on Julia 1.11.9. Both pages reached `Weaved all chunks` and the command exited 0:

```sh
timeout 43200 julia +1.11.9 --threads=auto --project=.validation/root-env benchmark.jl benchmarks/AdaptiveSDE
```

The generated artifacts contain no benchmark exception or stack trace. `qmaxDetermination.md` contains all 24 expected rows: three problems times eight q values, with three freshly generated figures.

After rebasing onto current master, the exact full `AdaptiveEfficiencyTests.jmd` weave again completed all seven chunks and exited 0. All three generated plots were visually inspected: each series has the scalar legend entries `RSwM1`, `RSwM2`, and `RSwM3`.

The full generated qmax script was also run directly so Weave could not swallow a chunk exception. It completed all 24 rows and exited 0:

```sh
WEAVE_ARGS=Dict(:folder=>"benchmarks/AdaptiveSDE", :file=>"qmaxDetermination.jmd") \
  julia +1.11.9 --threads=auto --project=benchmarks/AdaptiveSDE \
  script/AdaptiveSDE/qmaxDetermination.jl
```

The full generated `AdaptiveEfficiencyTests.jl` script likewise completed all three algorithms for each of its three problems and exited 0.

Package and repository gates on the rebased tree:

```text
Pkg.resolve(): no changes
Pkg.precompile(strict=true): exit 0
Core | 87/87
QA   | 21/21
Runic on generated Julia scripts and test/core.jl: exit 0
typos on all changed source files: exit 0
git diff --check: exit 0
```

The corrected plot-label check passes 2/2 and independently rendered a real Plots figure with the three scalar legend entries.

## Scope

No public package API or documentation changes. No GPU, downstream, or `GROUP=Everything` jobs were run.

## Links

- This PR: https://github.com/SciML/SciMLBenchmarks.jl/pull/1687
- Superseded keyword-only PR: https://github.com/SciML/SciMLBenchmarks.jl/pull/1686
- Prior failing folder job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32905717360/job/98124979423
- First bad label commit: https://github.com/SciML/SciMLBenchmarks.jl/commit/5c24d4c2c9a9390c353b714aa99e84402ae256b7
- Good parent: https://github.com/SciML/SciMLBenchmarks.jl/commit/c411fd94e96dc5519dd983d7fe73a86b96173f6c

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
