### PR TITLE
Fix weekly benchmark dependency updates

### DIFF
--- a/.github/workflows/update.jl
+++ b/.github/workflows/update.jl
@@ -1,64 +1,114 @@
 using Pkg
-Pkg.add(["Git", "GitHub", "Dates"])
-using Git, GitHub, Dates
 
-gh_token = ARGS[1]
-myauth = GitHub.authenticate(gh_token)
+Pkg.activate(; temp = true)
+Pkg.add("GitHub")
 
-(@isdefined myauth) ? @info("Authentication token is found...") :
-    @info("Coudn't find the authentication token")
+using Dates, GitHub
 
-const git = Git.git()
-date = Dates.format(now(), "yyyy-mm-dd")
-benchpath = joinpath(@__DIR__, "..", "..", "benchmarks")
+include("update_helpers.jl")
+using .WeeklyUpdateHelpers
 
-# Get all the open PRs and their number
-gh_prs = GitHub.pull_requests("SciML/SciMLBenchmarks.jl"; auth = myauth)
-prs = Dict{String, Int64}()
-for i in 1:length(gh_prs[1])
-    prs[gh_prs[1][i].head.ref] = gh_prs[1][i].number
-end
+const REPOSITORY = "SciML/SciMLBenchmarks.jl"
+const BASE_BRANCH = "master"
+const SESSION_URL = "https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512"
 
-# Get all the branches from the repo
-gh_branches = GitHub.branches("SciML/SciMLBenchmarks.jl"; auth = myauth)
-branches = [gh_branches[1][i].name for i in 1:length(gh_branches[1])]
+gh_token = only(ARGS)
+auth = GitHub.authenticate(gh_token)
+repo = normpath(joinpath(@__DIR__, "..", ".."))
+benchpath = joinpath(repo, "benchmarks")
+date = Dates.format(now(UTC), "yyyy-mm-dd")
+run_id = get(ENV, "GITHUB_RUN_ID", string(getpid()))
+scratch_parent = get(ENV, "RUNNER_TEMP", get(ENV, "TMPDIR", repo))
 
-@info("PRs and branches", prs, branches)
+open_prs, _ = GitHub.pull_requests(
+    REPOSITORY;
+    auth,
+    params = Dict("state" => "open", "per_page" => 100),
+)
+filter!(pr -> startswith(something(pr.head.label, ""), "SciML:"), open_prs)
 
+failures = String[]
 for dir in readdir(benchpath)
     model_dir = joinpath(benchpath, dir)
     isdir(model_dir) || continue
     println("--- Inspecting $dir ---")
-    cd(model_dir)
-    Pkg.activate(".") do
-        Pkg.update()
+
+    existing_pr = WeeklyUpdateHelpers.find_update_pull_request(open_prs, dir)
+    branch = if existing_pr === nothing
+        WeeklyUpdateHelpers.update_branch_name(dir, date, run_id)
+    else
+        existing_pr.head.ref
     end
-    manpath = (joinpath(benchpath, "Manifest.toml"))
-    if length(readlines(`git status . --porcelain`)) > 1
-        if dir ∉ branches
-            run(`git checkout -b $(dir) master`)
-            run(`$git add -A . :!$(manpath)`)
-            run(`$git commit -m "Updated $(dir) on $(date)"`)
-            run(`$git push --set-upstream origin $(dir)`)
-        else
-            run(`$git fetch origin`)
-            run(`$git checkout $(dir)`)
-            run(`$git pull -Xours`)
-            run(`$git add -A . :!$(manpath)`)
-            run(`$git commit -m "Updated $(dir) on $(date)"`)
-            run(`$git push`)
-        end
-        if dir ∉ keys(prs)
-            params = Dict(
-                "title" => "Updated $(dir) for benchmarks",
-                "head" => "$(dir)",
-                "base" => "master"
+
+    mktempdir(scratch_parent) do scratch
+        worktree = joinpath(scratch, "repo")
+        try
+            WeeklyUpdateHelpers.add_update_worktree(
+                repo, worktree, branch;
+                base_branch = BASE_BRANCH,
+                remote_branch = existing_pr !== nothing,
             )
-            @info("Creating a pull request from head: ", dir)
-            GitHub.create_pull_request("SciML/SciMLBenchmarks.jl"; params = params, auth = myauth)
-        else
-            @info("Updating the pull request numbered: ", prs[dir])
-            GitHub.update_pull_request("SciML/SciMLBenchmarks.jl", prs[dir]; auth = myauth)
+
+            model_path = joinpath(worktree, "benchmarks", dir)
+            Pkg.activate(model_path) do
+                Pkg.update()
+                Pkg.precompile(; strict = true)
+            end
+
+            relative_model_path = joinpath("benchmarks", dir)
+            changed = WeeklyUpdateHelpers.has_changes(worktree, relative_model_path)
+            if changed
+                run(WeeklyUpdateHelpers.git_cmd(worktree, "add", "-A", "--", relative_model_path))
+                commit_message = """Updated $dir on $date
+
+                Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>
+                Co-Authored-By: Claude <noreply@anthropic.com>
+                Claude-Session: $SESSION_URL"""
+                run(WeeklyUpdateHelpers.git_cmd(worktree, "commit", "-m", commit_message))
+            end
+
+            remote_head = existing_pr === nothing ? nothing : readchomp(
+                    WeeklyUpdateHelpers.git_cmd(worktree, "rev-parse", "origin/$branch")
+                )
+            local_head = readchomp(WeeklyUpdateHelpers.git_cmd(worktree, "rev-parse", "HEAD"))
+            should_push = changed || (remote_head !== nothing && local_head != remote_head)
+            if should_push
+                if existing_pr === nothing
+                    run(WeeklyUpdateHelpers.git_cmd(worktree, "push", "--set-upstream", "origin", branch))
+                    body = """This automated dependency refresh should be ignored until reviewed by @ChrisRackauckas.
+
+                    Verification:
+
+                    - `Pkg.update()` completed for `benchmarks/$dir`.
+                    - `Pkg.precompile(; strict = true)` completed for the updated environment.
+
+                    🤖 Generated with [Claude Code](https://claude.com/claude-code)
+                    $SESSION_URL"""
+                    params = Dict(
+                        "title" => "Updated $dir for benchmarks",
+                        "head" => branch,
+                        "base" => BASE_BRANCH,
+                        "body" => body,
+                        "draft" => true,
+                    )
+                    created_pr = GitHub.create_pull_request(REPOSITORY; params, auth)
+                    @info "Created draft pull request" dir branch url = created_pr.html_url
+                else
+                    run(WeeklyUpdateHelpers.git_cmd(worktree, "push", "origin", branch))
+                    @info "Updated pull request" dir branch number = existing_pr.number
+                end
+            end
+        catch error
+            push!(failures, dir)
+            @error "Failed to update benchmark environment" dir branch exception = (
+                error, catch_backtrace(),
+            )
+        finally
+            isdir(worktree) && run(
+                WeeklyUpdateHelpers.git_cmd(repo, "worktree", "remove", "--force", worktree)
+            )
         end
     end
 end
+
+isempty(failures) || error("Failed to update: $(join(failures, ", "))")

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,9 +8,14 @@ on:
 jobs:
   update_weekly:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: update step
         uses: julia-actions/setup-julia@v3
         with:
@@ -20,4 +25,5 @@ jobs:
               git config --local user.email "$(git log --format='%ae' HEAD^!)"
               git config --local user.name "$(git log --format='%an' HEAD^!)"
 
+              julia .github/workflows/update_tests.jl
               julia -e 'include(".github/workflows/update.jl")' ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_helpers.jl
+++ b/.github/workflows/update_helpers.jl
@@ -1,0 +1,38 @@
+module WeeklyUpdateHelpers
+
+function git_cmd(repo::AbstractString, args::AbstractString...)
+    return Cmd(Cmd(["git", args...]); dir = repo)
+end
+
+function has_changes(repo::AbstractString, path::AbstractString)
+    return !isempty(readlines(git_cmd(repo, "status", "--porcelain", "--", path)))
+end
+
+function update_branch_name(dir::AbstractString, date::AbstractString, run_id::AbstractString)
+    return "update/$dir/$date-$run_id"
+end
+
+function find_update_pull_request(prs, dir::AbstractString)
+    legacy = findfirst(pr -> pr.head.ref == dir, prs)
+    legacy !== nothing && return prs[legacy]
+
+    prefix = "update/$dir/"
+    current = findfirst(pr -> startswith(pr.head.ref, prefix), prs)
+    return current === nothing ? nothing : prs[current]
+end
+
+function add_update_worktree(
+        repo::AbstractString, worktree::AbstractString, branch::AbstractString;
+        base_branch::AbstractString = "master", remote_branch::Bool = false
+    )
+    if remote_branch
+        run(git_cmd(repo, "fetch", "origin", branch))
+        run(git_cmd(repo, "worktree", "add", "-B", branch, worktree, "origin/$branch"))
+        run(git_cmd(worktree, "merge", "--no-edit", base_branch))
+    else
+        run(git_cmd(repo, "worktree", "add", "-b", branch, worktree, base_branch))
+    end
+    return nothing
+end
+
+end

--- a/.github/workflows/update_tests.jl
+++ b/.github/workflows/update_tests.jl
@@ -1,0 +1,77 @@
+using Test
+
+include("update_helpers.jl")
+using .WeeklyUpdateHelpers
+
+function git(repo, args...)
+    return run(WeeklyUpdateHelpers.git_cmd(repo, args...))
+end
+
+@testset "weekly update helpers" begin
+    @test WeeklyUpdateHelpers.update_branch_name("Example", "2026-08-25", "123") ==
+        "update/Example/2026-08-25-123"
+
+    prs = [
+        (head = (ref = "unrelated",), number = 1),
+        (head = (ref = "update/Example/2026-08-18-99",), number = 2),
+    ]
+    @test WeeklyUpdateHelpers.find_update_pull_request(prs, "Example").number == 2
+    @test isnothing(WeeklyUpdateHelpers.find_update_pull_request(prs, "Other"))
+    legacy_prs = [(head = (ref = "Example",), number = 3)]
+    @test WeeklyUpdateHelpers.find_update_pull_request(legacy_prs, "Example").number == 3
+
+    scratch_parent = get(ENV, "TMPDIR", tempdir())
+    mktempdir(scratch_parent) do scratch
+        repo = joinpath(scratch, "repo")
+        remote = joinpath(scratch, "remote.git")
+        worktree = joinpath(scratch, "worktree")
+        mkpath(joinpath(repo, "benchmarks", "Example"))
+        git(repo, "init", "-b", "master")
+        git(repo, "config", "user.name", "Weekly Update Test")
+        git(repo, "config", "user.email", "weekly-update@example.com")
+        write(joinpath(repo, "benchmarks", "Example", "Manifest.toml"), "version = 1\n")
+        git(repo, "add", ".")
+        git(repo, "commit", "-m", "Initial state")
+        git(scratch, "init", "--bare", remote)
+        git(repo, "remote", "add", "origin", remote)
+        git(repo, "push", "-u", "origin", "master")
+
+        try
+            WeeklyUpdateHelpers.add_update_worktree(
+                repo, worktree, "update/Example/2026-08-25-123";
+                base_branch = "master"
+            )
+            manifest = joinpath(worktree, "benchmarks", "Example", "Manifest.toml")
+            @test !WeeklyUpdateHelpers.has_changes(worktree, "benchmarks/Example")
+            write(manifest, "version = 2\n")
+            @test WeeklyUpdateHelpers.has_changes(worktree, "benchmarks/Example")
+            @test !WeeklyUpdateHelpers.has_changes(repo, "benchmarks/Example")
+        finally
+            isdir(worktree) && git(repo, "worktree", "remove", "--force", worktree)
+        end
+
+        git(repo, "switch", "-c", "Example")
+        write(joinpath(repo, "branch.txt"), "existing update\n")
+        git(repo, "add", "branch.txt")
+        git(repo, "commit", "-m", "Existing update")
+        git(repo, "push", "-u", "origin", "Example")
+        git(repo, "switch", "master")
+        write(joinpath(repo, "base.txt"), "new base\n")
+        git(repo, "add", "base.txt")
+        git(repo, "commit", "-m", "Advance base")
+
+        existing_worktree = joinpath(scratch, "existing-worktree")
+        try
+            WeeklyUpdateHelpers.add_update_worktree(
+                repo, existing_worktree, "Example";
+                base_branch = "master", remote_branch = true
+            )
+            @test isfile(joinpath(existing_worktree, "branch.txt"))
+            @test isfile(joinpath(existing_worktree, "base.txt"))
+            @test !WeeklyUpdateHelpers.has_changes(repo, ".")
+        finally
+            isdir(existing_worktree) &&
+                git(repo, "worktree", "remove", "--force", existing_worktree)
+        end
+    end
+end


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The weekly dependency updater currently loses Manifest-only refreshes and accumulates dirty files across benchmark folders. When it eventually encounters an existing update branch, `git checkout` fails because switching branches would overwrite those accumulated edits. The latest scheduled failure at https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32555916878 reached `GlobalOptimization` with changes from nine earlier folders still in the worktree.

This runs each folder refresh in its own linked worktree. Existing open updater branches are fetched and merged with master before package operations; new updates receive run-specific branch names. Only the current benchmark folder can be committed, a one-file Manifest change is sufficient to trigger an update, and one broken environment no longer prevents later folders from being inspected. Failed folders are reported together at the end.

The workflow now requires strict precompilation before publishing an update, opens every generated PR as a draft with the review hold, grants only the required write permissions, and fetches full history for branch merging.

## Verification

### Failing before

The old change predicate rejects the exact Manifest-only case:

```console
$ julia -e 'using Test; status_lines = [" M benchmarks/Example/Manifest.toml"]; @test length(status_lines) > 1'
Test Failed at none:1
  Expression: length(status_lines) > 1
   Evaluated: 1 > 1

ERROR: There was an error during testing
```

The production stale-branch failure is visible in the August 22 workflow log:

```console
error: Your local changes to the following files would be overwritten by checkout:
        benchmarks/AstroChem/Manifest.toml
        benchmarks/AutomaticDifferentiation/Manifest.toml
        benchmarks/AutomaticDifferentiationTuring/Manifest.toml
        benchmarks/Bio/Manifest.toml
        benchmarks/ComplicatedPDE/Manifest.toml
        benchmarks/DAE/Manifest.toml
        benchmarks/DiffEqGPU/Manifest.toml
        benchmarks/DynamicalODE/Manifest.toml
        benchmarks/GlobalOptimization/Manifest.toml
Please commit your changes or stash them before you switch branches.
```

### Passing after

The new helper test creates local and bare Git repositories, verifies that a single Manifest edit is detected only in its isolated worktree, and verifies that an existing remote update branch merges an advanced master before any edit occurs:

```console
$ TMPDIR=/home/crackauc/tmp /home/crackauc/.juliaup/bin/julia +1.12 .github/workflows/update_tests.jl
Test Summary:         | Pass  Total  Time
weekly update helpers |   10     10  0.9s
```

Additional local checks:

```console
$ /home/crackauc/.juliaup/bin/julia +1.12 --project=@v1.12 -m Runic --check --diff .github/workflows/update.jl .github/workflows/update_helpers.jl .github/workflows/update_tests.jl
# exit 0, no output

$ typos .github/workflows/update.jl .github/workflows/update_helpers.jl .github/workflows/update_tests.jl .github/workflows/update.yml
# exit 0, no output

$ actionlint .github/workflows/update.yml
# exit 0, no output

$ git diff --check upstream/master...HEAD
# exit 0, no output
```

## Known root QA failure

The exact branch reproduces master's existing root-project QA failures:

```console
Test Summary: | Pass  Fail  Total     Time
QA            |   16     3     19  1m12.1s
```

Those failures are the 19 stale root dependencies and missing compat declarations already isolated in https://github.com/SciML/SciMLBenchmarks.jl/pull/1683. On that focused QA branch, the same group passes 19/19. This PR does not touch the root project.

## Scope and review notes

- No package dependency is added to SciMLBenchmarks. `GitHub.jl`, already used by the updater, is now installed in a temporary workflow environment instead of mutating the runner's global Julia environment.
- No public API or documentation is changed.
- The full workflow was not dispatched from this branch because doing so is write-bearing: it would push dependency branches and open PRs for every changed benchmark environment. The isolated git regression suite exercises the branch and worktree mechanics without external mutations.
- Generated commits and PR bodies include the repository-required attribution and review hold.
- GPU jobs, downstream packages, `GROUP=Everything`, and documentation builds were not run; this is a workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
