### PR TITLE
Fix QA failures from non-public qualified accesses

### DIFF
--- a/src/SciMLBenchmarks.jl
+++ b/src/SciMLBenchmarks.jl
@@ -10,9 +10,24 @@ repo_directory = joinpath(@__DIR__, "..")
 
 macro subprocess(ex, wait = true)
     return quote
-        local project = Pkg.project().path
-        local ex_str = $(esc(sprint(Base.show_unquoted, ex)))
+        local project = Base.active_project()
+        local ex_str = $(string(ex))
         run(`$(Base.julia_cmd()) --project=$(project) -e "$(ex_str)"`; wait = $(wait))
+    end
+end
+
+function _benchmark_priority(path)
+    return open(path) do io
+        eof(io) && return 0
+        strip(readline(io)) == "---" || return 0
+        for line in eachline(io)
+            strip(line) == "---" && return 0
+            key_value = split(line, ':'; limit = 2)
+            if length(key_value) == 2 && strip(first(key_value)) == "priority"
+                return parse(Int, strip(last(key_value)))
+            end
+        end
+        return 0
     end
 end
 
@@ -83,8 +98,7 @@ function weave_folder(folder, build_list = (:script, :github))
         # Skip non-`.jmd` files
         endswith(file, ".jmd") || continue
         push!(weave_files, file)
-        weave_doc = Weave.WeaveDoc(joinpath(folder, file))
-        push!(priorities, get(weave_doc.header, "priority", 0))
+        push!(priorities, _benchmark_priority(joinpath(folder, file)))
     end
 
     weave_files = weave_files[sortperm(priorities; rev = true)]
@@ -118,27 +132,25 @@ function bench_footer(folder = nothing, file = nothing)
     )
     if folder !== nothing && file !== nothing
         display(
-            Markdown.parse(
-                """
-                To locally run this benchmark, do the following commands:
-                ```
-                using SciMLBenchmarks
-                SciMLBenchmarks.weave_file("$folder","$file")
-                ```
-                """
-            )
+            "text/markdown",
+            """
+            To locally run this benchmark, do the following commands:
+            ```
+            using SciMLBenchmarks
+            SciMLBenchmarks.weave_file("$folder","$file")
+            ```
+            """,
         )
     end
     display(md"Computer Information:")
     vinfo = sprint(InteractiveUtils.versioninfo)
     display(
-        Markdown.parse(
-            """
-            ```
-            $(vinfo)
-            ```
-            """
-        )
+        "text/markdown",
+        """
+        ```
+        $(vinfo)
+        ```
+        """,
     )
 
     display(
@@ -161,7 +173,7 @@ function bench_footer(folder = nothing, file = nothing)
     $(chomp(mani))
     ```
     """
-    return display(Markdown.parse(md))
+    return display("text/markdown", md)
 end
 
 """
@@ -186,15 +198,13 @@ end
         This is a test markdown string.
         """
 
-        # Precompile Markdown.parse which is called in bench_footer
-        parsed_md = Markdown.parse(
-            """
-            Test markdown content
-            ```
-            code block
-            ```
-            """
-        )
+        markdown_text = """
+        Test markdown content
+        ```
+        code block
+        ```
+        """
+        repr("text/markdown", markdown_text)
 
         # Precompile sprint with versioninfo (used in bench_footer)
         vinfo = sprint(InteractiveUtils.versioninfo)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,9 +1,32 @@
 using SciMLBenchmarks
 using Test
 
+@testset "benchmark priority" begin
+    mktempdir() do directory
+        prioritized = joinpath(directory, "prioritized.jmd")
+        write(prioritized, "---\ntitle: Prioritized\npriority: 42\n---\n")
+        @test SciMLBenchmarks._benchmark_priority(prioritized) == 42
+
+        unprioritized = joinpath(directory, "unprioritized.jmd")
+        write(unprioritized, "---\ntitle: Unprioritized\n---\n")
+        @test SciMLBenchmarks._benchmark_priority(unprioritized) == 0
+
+        no_header = joinpath(directory, "no_header.jmd")
+        write(no_header, "# No front matter\n")
+        @test SciMLBenchmarks._benchmark_priority(no_header) == 0
+    end
+end
+
+@testset "subprocess" begin
+    process = SciMLBenchmarks.@subprocess exit()
+    @test success(process)
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")
 
-    @test isfile(joinpath(dirname(@__DIR__), "markdown", "Testing", "test.md"))
+    output = joinpath(dirname(@__DIR__), "markdown", "Testing", "test.md")
+    @test isfile(output)
+    @test occursin("To locally run this benchmark", read(output, String))
 end


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Strict QA on Julia 1.11 reports four qualified accesses through modules that do not declare those names public. This replaces them with public APIs: `Base.active_project` and `string` for subprocess construction, MIME-aware `display` for dynamic Markdown, and a small local reader for the benchmark-specific `priority` frontmatter field instead of Weave's internal `WeaveDoc` type.

Core regression coverage now checks priority parsing, subprocess execution, and that the woven test benchmark still contains the dynamic footer. This adds no dependency or public API.

The accesses predate strict QA; the stricter gate was introduced by https://github.com/SciML/SciMLBenchmarks.jl/commit/74805e7d3472dc785d9e9a44c36bebe6ca2ef1db. Julia 1.10 runs four ExplicitImports checks and does not run `all_qualified_accesses_are_public`; Julia 1.11 runs all six, which is why this became visible there.

## Verification

Failing before on clean `upstream/master` (`2c211845c143d28e0f3cd2340035098f7bdfd2f7`):

```console
$ TMPDIR=/home/crackauc/tmp JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260825_180339_53321/qa-public-depot JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA /home/crackauc/.juliaup/bin/julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
NonPublicQualifiedAccessException
- `WeaveDoc` is not public in `Weave`
- `parse` is not public in `Markdown`
- `project` is not public in `Pkg`
- `show_unquoted` is not public in `Base`
Test Summary: | Pass  Fail  Error  Total
QA            |   17     3      1     21
ExplicitImports: 5 passed, 1 errored
```

Passing after for the discriminating QA check on this exact branch:

```console
$ TMPDIR=/home/crackauc/tmp JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260825_180339_53321/qa-public-depot JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA /home/crackauc/.juliaup/bin/julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:       | Pass  Fail  Total
QA                  |   18     3     21
ExplicitImports     |    6             6
```

The remaining three failures are unchanged `master` failures (stale dependencies and missing stdlib/Test compat entries) addressed by https://github.com/SciML/SciMLBenchmarks.jl/pull/1683. The IJulia extension precompile warning is separately addressed by https://github.com/SciML/SciMLBenchmarks.jl/pull/1684.

Stacked locally on those two fixes, the full QA group passes:

```console
$ TMPDIR=/home/crackauc/tmp JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260825_180339_53321/qa-public-depot JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA /home/crackauc/.juliaup/bin/julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  2m01.9s
Testing SciMLBenchmarks tests passed
```

The relevant Core group passes on this exact branch:

```console
$ TMPDIR=/home/crackauc/tmp JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260825_180339_53321/qa-public-depot JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=Core /home/crackauc/.juliaup/bin/julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
Core          |    6      6  4m16.7s
Testing SciMLBenchmarks tests passed
```

Formatting, spelling, and diff checks:

```console
$ /home/crackauc/.local/bin/julia --startup-file=no -m Runic --check --diff src/SciMLBenchmarks.jl test/core.jl
$ typos --format brief src/SciMLBenchmarks.jl test/core.jl
$ git diff --check
```

All three exited 0 with no output. A docs build was not run because this changes no documentation, docstring, or public API. No GPU or downstream jobs were run because the change is confined to the benchmark harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
