### PR TITLE
CI: scope master change detection to each push

### DIFF
--- a/.github/scripts/detect-changed-benchmarks.sh
+++ b/.github/scripts/detect-changed-benchmarks.sh
@@ -29,45 +29,18 @@ if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
         # yields exactly the PR's changes without requiring a merge base.
         CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD -- 'benchmarks/' 2>/dev/null || true)
     fi
-else
-    # Push event: compare against the last commit that was successfully published
-    # to SciMLBenchmarksOutput. This makes change detection cumulative — if a
-    # previous master push run was cancelled (because rapid merges queue and
-    # GHA cancels queued runs), this run still picks up its changes.
-    #
-    # The output repo's build commits have format "build based on <SHA>" or
-    # "Published by build of: SciML/SciMLBenchmarks.jl@<SHA>". We fetch the
-    # most recent one and diff against that SHA.
-    LAST_BUILT_SHA=""
-    if command -v curl >/dev/null 2>&1; then
-        # Use GITHUB_TOKEN when available to bypass the 60-req/hour anonymous
-        # rate limit (the unauth limit is shared per IP across all GHA runners
-        # and gets hit easily — when it does, the API returns a JSON error,
-        # the SciMLBenchmarks.jl@<sha> grep finds nothing, pipefail trips, and
-        # `set -e` aborts the script before fallback can kick in).
-        AUTH_HEADER=()
-        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-            AUTH_HEADER=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
-        fi
-        # Wrap in `|| true` so a non-matching grep (e.g. rate limited, network
-        # blip, or output repo briefly empty) cleanly falls through to the
-        # HEAD~1 fallback rather than aborting the whole workflow.
-        LAST_BUILT_SHA=$( { curl -s "${AUTH_HEADER[@]}" -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/SciML/SciMLBenchmarksOutput/commits?per_page=20" 2>/dev/null \
-            | grep -oE '"message":[^"]*"[^"]*"' \
-            | grep -oE 'SciMLBenchmarks\.jl@[a-f0-9]{40}' \
-            | head -1 \
-            | sed 's/SciMLBenchmarks\.jl@//'; } || true)
-    fi
-
-    if [[ -n "${LAST_BUILT_SHA}" ]] && git cat-file -e "${LAST_BUILT_SHA}^{commit}" 2>/dev/null; then
-        echo "Diffing against last published SHA: ${LAST_BUILT_SHA}" >&2
-        CHANGED_FILES=$(git diff --name-only "${LAST_BUILT_SHA}" HEAD -- 'benchmarks/' 2>/dev/null || true)
+elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+    if [[ -n "${PUSH_BASE_SHA:-}" ]] \
+        && [[ ! "${PUSH_BASE_SHA}" =~ ^0+$ ]] \
+        && git cat-file -e "${PUSH_BASE_SHA}^{commit}" 2>/dev/null; then
+        echo "Diffing against push event base SHA: ${PUSH_BASE_SHA}" >&2
+        CHANGED_FILES=$(git diff --name-only "${PUSH_BASE_SHA}" HEAD -- 'benchmarks/' 2>/dev/null || true)
     else
-        # Fallback: compare with parent commit (original behavior)
-        echo "Last published SHA not available; falling back to HEAD~1 diff" >&2
+        echo "Push event base SHA not available; falling back to HEAD~1 diff" >&2
         CHANGED_FILES=$(git diff --name-only HEAD~1 -- 'benchmarks/' 2>/dev/null || true)
     fi
+else
+    CHANGED_FILES=$(git diff --name-only HEAD~1 -- 'benchmarks/' 2>/dev/null || true)
 fi
 
 declare -A FILES     # .jmd file -> its project directory

--- a/.github/scripts/test-detect-changed-benchmarks.sh
+++ b/.github/scripts/test-detect-changed-benchmarks.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/detect-changed-benchmarks.XXXXXX")
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+FIXTURE="${TEST_ROOT}/fixture"
+mkdir -p "${FIXTURE}/.github/scripts" "${FIXTURE}/benchmarks/Alpha" \
+    "${FIXTURE}/benchmarks/Beta" "${TEST_ROOT}/bin"
+cp "${REPO_ROOT}/.github/scripts/detect-changed-benchmarks.sh" \
+    "${REPO_ROOT}/.github/scripts/read-benchmark-config.sh" "${FIXTURE}/.github/scripts/"
+cp "${REPO_ROOT}/.github/benchmark_defaults.toml" "${FIXTURE}/.github/"
+
+printf '[deps]\n' > "${FIXTURE}/benchmarks/Alpha/Project.toml"
+printf 'julia_version = "1.11.9"\n' > "${FIXTURE}/benchmarks/Alpha/Manifest.toml"
+printf '[deps]\n' > "${FIXTURE}/benchmarks/Beta/Project.toml"
+printf 'julia_version = "1.11.9"\n' > "${FIXTURE}/benchmarks/Beta/Manifest.toml"
+
+git -C "${FIXTURE}" init -q -b master
+git -C "${FIXTURE}" config user.name "Detector Test"
+git -C "${FIXTURE}" config user.email "detector-test@example.com"
+git -C "${FIXTURE}" add .
+git -C "${FIXTURE}" commit -qm "Initial fixture"
+INITIAL_SHA=$(git -C "${FIXTURE}" rev-parse HEAD)
+
+printf 'version = "0.1.0"\n' >> "${FIXTURE}/benchmarks/Alpha/Project.toml"
+git -C "${FIXTURE}" add benchmarks/Alpha/Project.toml
+git -C "${FIXTURE}" commit -qm "Update Alpha"
+PUSH_BASE_SHA=$(git -C "${FIXTURE}" rev-parse HEAD)
+
+printf 'version = "0.1.0"\n' >> "${FIXTURE}/benchmarks/Beta/Project.toml"
+git -C "${FIXTURE}" add benchmarks/Beta/Project.toml
+git -C "${FIXTURE}" commit -qm "Update Beta"
+
+printf '#!/bin/sh\nprintf '\''[{"commit":{"message":"Published by build of: SciML/SciMLBenchmarks.jl@%%s"}}]\\n'\'' "%s"\n' \
+    "${INITIAL_SHA}" > "${TEST_ROOT}/bin/curl"
+chmod +x "${TEST_ROOT}/bin/curl"
+
+OUTPUT_FILE="${TEST_ROOT}/github-output"
+(
+    cd "${FIXTURE}"
+    GITHUB_EVENT_NAME=push \
+        PUSH_BASE_SHA="${PUSH_BASE_SHA}" \
+        GITHUB_OUTPUT="${OUTPUT_FILE}" \
+        PATH="${TEST_ROOT}/bin:${PATH}" \
+        .github/scripts/detect-changed-benchmarks.sh
+)
+
+TARGETS=$(sed -n 's/^matrix=//p' "${OUTPUT_FILE}" \
+    | grep -o '"target":"[^"]*"' \
+    | cut -d'"' -f4 \
+    | sort)
+
+if [[ "${TARGETS}" != "benchmarks/Beta" ]]; then
+    printf 'Expected only benchmarks/Beta for the second push, got:\n%s\n' "${TARGETS}" >&2
+    exit 1
+fi
+
+echo "Push detection selected only changes since the event's before SHA."

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,9 +5,19 @@ on:
     branches: [master]
     paths:
       - 'benchmarks/**'
+      - '.github/benchmark_defaults.toml'
+      - '.github/scripts/detect-changed-benchmarks.sh'
+      - '.github/scripts/read-benchmark-config.sh'
+      - '.github/scripts/test-detect-changed-benchmarks.sh'
+      - '.github/workflows/benchmarks.yml'
   pull_request:
     paths:
       - 'benchmarks/**'
+      - '.github/benchmark_defaults.toml'
+      - '.github/scripts/detect-changed-benchmarks.sh'
+      - '.github/scripts/read-benchmark-config.sh'
+      - '.github/scripts/test-detect-changed-benchmarks.sh'
+      - '.github/workflows/benchmarks.yml'
   workflow_dispatch:
     inputs:
       benchmark_target:
@@ -44,11 +54,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      - name: Test changed benchmark detection
+        run: bash .github/scripts/test-detect-changed-benchmarks.sh
       - name: Detect changed benchmarks
         id: detect
         run: .github/scripts/detect-changed-benchmarks.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
 
   # When manually triggered with a specific target
   manual-matrix:


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Master change detection currently diffs against the last commit published to SciMLBenchmarksOutput. Once independent master runs stopped cancelling each other, that made every later merge repeatedly enqueue every benchmark changed since an older unpublished commit. This changes push detection to use the push event's `before` SHA and adds a fixture that proves consecutive pushes remain isolated.

## Failing before

On unmodified master at `5b6b8689`, I added only the regression fixture and ran:

```text
$ bash .github/scripts/test-detect-changed-benchmarks.sh
Diffing against last published SHA: 91aa6dc10801b588e5f108c30b01c3dac69f048d
Detected benchmark targets:
  benchmarks/Alpha
  benchmarks/Beta
Expected only benchmarks/Beta for the second push, got:
benchmarks/Alpha
benchmarks/Beta
exit_status=1
```

## Passing after

The same test with this change selects only the second push:

```text
$ bash .github/scripts/test-detect-changed-benchmarks.sh
Diffing against push event base SHA: bb5867ceff636267b9530be0ed00abaed595ee02
Detected benchmark targets:
  benchmarks/Beta -> runner=["self-hosted", "benchmark"] timeout=12000 julia=1.11
Push detection selected only changes since the event's before SHA.
```

Additional local gates:

```text
$ GROUP=QA julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m56.4s
Testing SciMLBenchmarks tests passed

$ shellcheck -x -P .github/scripts .github/scripts/detect-changed-benchmarks.sh .github/scripts/test-detect-changed-benchmarks.sh
$ actionlint .github/workflows/benchmarks.yml
$ git diff upstream/master...HEAD -- .github | typos -
$ git diff --check upstream/master...HEAD
```

Runic is not applicable to the changed Bash/YAML files. No benchmark weave or documentation build was run because this PR changes only workflow selection logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
