### PR TITLE
Fix PDESystemLibrary benchmark output

### DIFF
--- a/benchmarks/MethodOfLinesPDE/MOLxPDESystemLibrary.jmd
+++ b/benchmarks/MethodOfLinesPDE/MOLxPDESystemLibrary.jmd
@@ -1,7 +1,7 @@
-* * *
-
-## title: PDESystemLibrary.jl Work-Precision Diagrams with Various MethodOfLines.jl Methods
+---
+title: PDESystemLibrary.jl Work-Precision Diagrams with Various MethodOfLines.jl Methods
 author: Alex Jones
+---
 
 This benchmark is for the MethodOfLines.jl package, which is an automatic PDE discretization package.
 It is concerned with comparing the performance of various discretization methods for the Burgers equation.
@@ -15,7 +15,7 @@ using PDESystemLibrary
 solver = FBDF()
 ```
 
-Next we define some functions to generate approproiate discretizations for the PDESystemLibrary systems.
+Next we define some functions to generate appropriate discretizations for the PDESystemLibrary systems.
 
 ```julia
 function center_uniform_grid(ex, ivs, N)
@@ -85,60 +85,53 @@ function discweno2(ex, ivs, t, N)
 end
 ```
 
-This script tests all systems in PDESystemLibrary against different MethodOfLines.jl discretizations.
+This script tests the Burgers systems in PDESystemLibrary against different MethodOfLines.jl discretizations.
 It then plots the work precision sets.
 
 ```julia
 N = 100
-for ex in PDESystemLibrary.all_systems
-    try
-        if ex.analytic_func === nothing
-            continue
+for ex in get_pdesys_with_tags(["Burgers"])
+    if ex.analytic_func === nothing
+        continue
+    end
+    ivs = filter(x -> !isequal(Symbol(x), :t), ex.ivs)
+    if length(ivs) == 0
+        continue
+    elseif length(ivs) == length(ex.ivs)
+        continue
+    else
+        @parameters t
+        # Create discretizations
+        # Note: Chebyshev (non-uniform) grids with UpwindScheme fail for
+        # parameterized advection terms due to a MethodOfLines pattern matching
+        # bug. Only use uniform grids for now.
+        discuu1 = uniformupwind1(ex, ivs, t, N)
+        discuu2 = uniformupwind2(ex, ivs, t, N)
+        discs = [discuu1, discuu2]
+        disc_names = ["Uniform Upwind, center_align", "Uniform Upwind, edge_align"]
+        if "Advection" in ex.metadata
+            discw1 = discweno1(ex, ivs, t, N)
+            discw2 = discweno2(ex, ivs, t, N)
+            push!(discs, discw1, discw2)
+            push!(disc_names, "Uniform WENO, center_align", "Uniform WENO, edge_align")
         end
-        ivs = filter(x -> !isequal(Symbol(x), :t), ex.ivs)
-        if length(ivs) == 0
-            continue
-        elseif length(ivs) == length(ex.ivs)
-            continue
-        else
-            @parameters t
-            # Create discretizations
-            # Note: Chebyshev (non-uniform) grids with UpwindScheme fail for
-            # parameterized advection terms due to a MethodOfLines pattern matching
-            # bug. Only use uniform grids for now.
-            advection = false
-            discuu1 = uniformupwind1(ex, ivs, t, N)
-            discuu2 = uniformupwind2(ex, ivs, t, N)
-            discs = [discuu1, discuu2]
-            disc_names = ["Uniform Upwind, center_align", "Uniform Upwind, edge_align"]
-            if "Advection" in ex.metadata
-                advection = true
-                discw1 = discweno1(ex, ivs, t, N)
-                discw2 = discweno2(ex, ivs, t, N)
-                push!(discs, discw1, discw2)
-                push!(disc_names, "Uniform WENO, center_align", "Uniform WENO, edge_align")
-            end
 
-            # Create problems
-            probs = map(discs) do disc
-                discretize(ex, disc, analytic = ex.analytic_func)
-            end
-
-            title = "Work Precision Diagram for $(ex.name), Tags: $(ex.metadata)"
-            println("Running $title")
-            dummy_appxsol = [nothing for i in 1:length(probs)]
-            abstols = 1.0 ./ 10.0 .^ (5:8)
-            reltols = 1.0 ./ 10.0 .^ (1:4);
-            setups = [Dict(:alg => solver, :prob_choice => i) for i in 1:length(probs)]
-
-            wp = WorkPrecisionSet(probs, abstols, reltols, setups; names = disc_names,
-                save_everystep = false, appxsol = dummy_appxsol, maxiters = Int(1e5),
-                numruns = 10, wrap = Val(false))
-            plot(wp, title = title)
+        # Create problems
+        probs = map(discs) do disc
+            discretize(ex, disc, analytic = ex.analytic_func)
         end
-    catch e
-        println("Failed on $(ex.name):")
-        println(e)
+
+        title = "Work Precision Diagram for $(ex.name), Tags: $(ex.metadata)"
+        println("Running $title")
+        dummy_appxsol = [nothing for i in 1:length(probs)]
+        abstols = 1.0 ./ 10.0 .^ (5:8)
+        reltols = 1.0 ./ 10.0 .^ (1:4);
+        setups = [Dict(:alg => solver, :prob_choice => i) for i in 1:length(probs)]
+
+        wp = WorkPrecisionSet(probs, abstols, reltols, setups; names = disc_names,
+            save_everystep = false, appxsol = dummy_appxsol, maxiters = Int(1e5),
+            numruns = 10, wrap = Val(false))
+        display(plot(wp, title = title))
     end
 end
 ```

--- a/benchmarks/MethodOfLinesPDE/Manifest.toml
+++ b/benchmarks/MethodOfLinesPDE/Manifest.toml
@@ -1782,10 +1782,10 @@ uuid = "a7812802-0625-4b9e-961c-d332478797e5"
 version = "0.1.33"
 
 [[deps.PDESystemLibrary]]
-deps = ["CommonSolve", "Interpolations", "IntervalSets", "ModelingToolkitBase", "OrdinaryDiffEqSDIRK", "PrecompileTools", "SciMLBase", "Symbolics"]
-git-tree-sha1 = "4f8e511b7ef48994a740804da13905f3300a5884"
+deps = ["CommonSolve", "Interpolations", "IntervalSets", "ModelingToolkitBase", "OrdinaryDiffEqSDIRK", "PrecompileTools", "RuntimeGeneratedFunctions", "SciMLBase", "Symbolics"]
+git-tree-sha1 = "921f3d848ca43468f029bd1c3ee9da7bf5992f83"
 uuid = "d14f9848-fe58-4297-bd22-c1aba6f3000d"
-version = "0.1.8"
+version = "0.1.9"
 
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The PDESystemLibrary benchmark currently publishes no plots: it ranges over every stored PDE, silently catches every exception, and leaves each `Plots.Plot` undisplayed inside a loop. This limits the workload to the documented Burgers scope through the public `get_pdesys_with_tags` API, removes the blanket exception handler, explicitly displays each work-precision plot, and repairs the Weave front matter.

The manifest moves PDESystemLibrary from 0.1.8 to the registered 0.1.9 release. That release contains the fresh-process analytic-function repair from https://github.com/SciML/PDESystemLibrary.jl/pull/79; 0.1.8 throws a `KeyError` while retrieving the symbolic analytic functions used here. The manifest and notebook changes are intentionally atomic: updating only the manifest leaves the unbounded, failure-swallowing benchmark, while changing only the notebook leaves the 0.1.8 analytic-function failure.

## Verification

Failing before, with the explicit `display` call temporarily reverted to the original bare `plot` call:

```console
$ GKSwstype=100 timeout 3600 julia +1.11.9 --startup-file=no --threads=auto --project=. benchmark.jl benchmarks/MethodOfLinesPDE/MOLxPDESystemLibrary.jmd
[ Info: Weaved all chunks
[ Info: Weaved to .../markdown/MethodOfLinesPDE/MOLxPDESystemLibrary.md
$ stat -c %s markdown/MethodOfLinesPDE/MOLxPDESystemLibrary.md
5424
$ find markdown/MethodOfLinesPDE/figures -name 'MOLxPDESystemLibrary*' | wc -l
0
$ rg -c 'MOLxPDESystemLibrary_.*png' markdown/MethodOfLinesPDE/MOLxPDESystemLibrary.md
0
```

The same real weave with this change, using registered PDESystemLibrary 0.1.9:

```console
$ GKSwstype=100 timeout 3600 julia +1.11.9 --startup-file=no --threads=auto --project=. benchmark.jl benchmarks/MethodOfLinesPDE/MOLxPDESystemLibrary.jmd
[ Info: Weaved all chunks
[ Info: Weaved to .../markdown/MethodOfLinesPDE/MOLxPDESystemLibrary.md
$ stat -c '%n %s bytes' markdown/MethodOfLinesPDE/MOLxPDESystemLibrary.md markdown/MethodOfLinesPDE/figures/MOLxPDESystemLibrary_3_1.png markdown/MethodOfLinesPDE/figures/MOLxPDESystemLibrary_3_2.png
markdown/MethodOfLinesPDE/MOLxPDESystemLibrary.md 5517 bytes
markdown/MethodOfLinesPDE/figures/MOLxPDESystemLibrary_3_1.png 37698 bytes
markdown/MethodOfLinesPDE/figures/MOLxPDESystemLibrary_3_2.png 31488 bytes
$ rg -n 'ERROR:|LoadError|MethodError|UndefVarError|KeyError' mol-final-registered.log | wc -l
0
```

I inspected both rendered figures. The one- and two-dimensional Burgers diagrams each contain four populated algorithm series; neither is blank or degenerate.

```console
$ julia +1.11.9 --startup-file=no --project=benchmarks/MethodOfLinesPDE -e 'using Pkg; Pkg.resolve()'
No Changes to `benchmarks/MethodOfLinesPDE/Project.toml`
No Changes to `benchmarks/MethodOfLinesPDE/Manifest.toml`

$ GROUP=QA julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m58.4s
Testing SciMLBenchmarks tests passed

$ git diff --check
$ git diff -- benchmarks/MethodOfLinesPDE/MOLxPDESystemLibrary.jmd benchmarks/MethodOfLinesPDE/Manifest.toml | typos -
```

Both diff checks exited successfully. Runic is not applicable to the JMD/Manifest-only diff; the repository's shared Runic workflow does not parse JMD files.

## Not verified

I did not run every one of PDESystemLibrary's 427 systems as benchmarks. This notebook describes itself as a Burgers benchmark, and the previous all-system loop was both unbounded for CI and incapable of producing a meaningful artifact. No GPU path applies.

## Links

- Analytic-function fix: https://github.com/SciML/PDESystemLibrary.jl/pull/79
- PDESystemLibrary 0.1.9 release: https://github.com/SciML/PDESystemLibrary.jl/pull/80
- General registration: https://github.com/JuliaRegistries/General/pull/166197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
