### PR TITLE
Bound benchmark jobs to 24 hours

### DIFF
--- a/.github/benchmark_defaults.toml
+++ b/.github/benchmark_defaults.toml
@@ -5,7 +5,7 @@
 #   CPU benchmarks: ["self-hosted", "benchmark"]        — amdci1/amdci3 (stable hardware for regression checking)
 #   GPU benchmarks: ["self-hosted", "gpu", "exclusive"] — demeter3 (dedicated GPU runner with V100s)
 #
-# timeout is in minutes (default: 12000 = 200 hours)
+# timeout is in minutes (default: 1440 = 24 hours)
 
 runner = ["self-hosted", "benchmark"]
-timeout = 12000
+timeout = 1440

--- a/.github/scripts/read-benchmark-config.sh
+++ b/.github/scripts/read-benchmark-config.sh
@@ -2,7 +2,7 @@
 # Shared helper: read runner configuration for a benchmark target.
 # Usage: source this file, then call get_benchmark_config <target>
 # Returns: "runner_json|timeout|julia_version"
-#   e.g. '["self-hosted", "benchmark"]|12000|1.10'
+#   e.g. '["self-hosted", "benchmark"]|1440|1.10'
 
 # Read a key from a TOML file (simple parser for flat keys and arrays)
 read_toml_key() {
@@ -82,7 +82,7 @@ get_benchmark_config() {
         timeout=$(read_toml_key "${defaults_file}" "timeout")
     fi
     if [[ -z "${timeout}" ]]; then
-        timeout="12000"
+        timeout="1440"
     fi
 
     julia_version=$(get_julia_version "${bench_dir}")

--- a/benchmarks/DiffEqGPU/benchmark_config.toml
+++ b/benchmarks/DiffEqGPU/benchmark_config.toml
@@ -1,3 +1,2 @@
 # DiffEqGPU ensemble benchmarks — run on GPU runner (demeter3)
 runner = ["self-hosted", "gpu", "exclusive"]
-timeout = 12000

--- a/benchmarks/LinearSolveGPU/benchmark_config.toml
+++ b/benchmarks/LinearSolveGPU/benchmark_config.toml
@@ -1,3 +1,2 @@
 # LinearSolve GPU benchmarks — run on GPU runner (demeter3)
 runner = ["self-hosted", "gpu", "exclusive"]
-timeout = 12000

--- a/benchmarks/NeuralNetworks/benchmark_config.toml
+++ b/benchmarks/NeuralNetworks/benchmark_config.toml
@@ -1,3 +1,2 @@
 # Neural network benchmarks — run on GPU runner (demeter3)
 runner = ["self-hosted", "gpu", "exclusive"]
-timeout = 12000

--- a/benchmarks/PINNErrorsVsTime/benchmark_config.toml
+++ b/benchmarks/PINNErrorsVsTime/benchmark_config.toml
@@ -1,3 +1,2 @@
 # NeuralPDE benchmarks — run on GPU runner (demeter3)
 runner = ["self-hosted", "gpu", "exclusive"]
-timeout = 12000

--- a/benchmarks/PINNOptimizers/benchmark_config.toml
+++ b/benchmarks/PINNOptimizers/benchmark_config.toml
@@ -1,3 +1,2 @@
 # NeuralPDE benchmarks — run on GPU runner (demeter3)
 runner = ["self-hosted", "gpu", "exclusive"]
-timeout = 12000

--- a/benchmarks/PSOGlobalOptimization/benchmark_config.toml
+++ b/benchmarks/PSOGlobalOptimization/benchmark_config.toml
@@ -1,3 +1,2 @@
 # PSO benchmarks use ParallelParticleSwarms GPU kernels.
 runner = ["self-hosted", "gpu", "exclusive"]
-timeout = 12000

--- a/test/core.jl
+++ b/test/core.jl
@@ -41,3 +41,18 @@ end
     @test isfile(output)
     @test occursin("To locally run this benchmark", read(output, String))
 end
+
+@testset "benchmark configuration" begin
+    repository = dirname(@__DIR__)
+    read_config = raw"""
+    cd "$1"
+    source .github/scripts/read-benchmark-config.sh
+    get_benchmark_config "$2"
+    """
+
+    for (target, expected_timeout) in
+        (("benchmarks/Testing", "1440"), ("benchmarks/DynamicalODE", "180"))
+        config = readchomp(`bash -c $read_config bash $repository $target`)
+        @test split(config, '|')[2] == expected_timeout
+    end
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -50,8 +50,17 @@ end
     get_benchmark_config "$2"
     """
 
-    for (target, expected_timeout) in
-        (("benchmarks/Testing", "1440"), ("benchmarks/DynamicalODE", "180"))
+    expected_timeouts = (
+        "benchmarks/Testing" => "1440",
+        "benchmarks/DiffEqGPU" => "1440",
+        "benchmarks/LinearSolveGPU" => "1440",
+        "benchmarks/NeuralNetworks" => "1440",
+        "benchmarks/PINNErrorsVsTime" => "1440",
+        "benchmarks/PINNOptimizers" => "1440",
+        "benchmarks/PSOGlobalOptimization" => "1440",
+        "benchmarks/DynamicalODE" => "180",
+    )
+    for (target, expected_timeout) in expected_timeouts
         config = readchomp(`bash -c $read_config bash $repository $target`)
         @test split(config, '|')[2] == expected_timeout
     end


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Reduce the default benchmark timeout from 12,000 minutes (200 hours) to 1,440 minutes (24 hours). A hung benchmark can currently occupy a self-hosted runner for several days; the bounded default releases it within one day.

The six GPU folder configs retained the same 12,000-minute override, including PSOGlobalOptimization, whose current V100 job has remained stuck for days. Those configs now specify only their GPU runner labels and inherit the 24-hour default. DynamicalODE's measured folder-specific 180-minute timeout remains unchanged.

The shell helper's hard fallback agrees with the TOML default. A Core test exercises an ordinary folder, all six GPU folders, and the existing DynamicalODE override.

## Verification

With the expanded regression test applied after changing only the default, all six GPU configurations still failed because their explicit overrides bypassed it:

```text
Expression: split(config, '|')[2] == expected_timeout
Evaluated: "12000" == "1440"
Test Summary:             | Pass  Fail  Total
Core                      |   12     6     18
  benchmark configuration |    2     6      8
```

After removing those overrides, the same test passes unchanged:

```bash
GROUP=Core julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Total   Time
Core          |   18     18  49.1s
Testing SciMLBenchmarks tests passed
```

```bash
GROUP=QA julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Total     Time
QA            |   21     21  1m56.5s
Testing SciMLBenchmarks tests passed
```

Runic, typos, `bash -n`, and `git diff --check` also exited successfully. ShellCheck reports only the pre-existing SC2001 style warning at `read-benchmark-config.sh:16`.

## Not verified

This does not terminate workflow runs that were already started. No GPU benchmark was executed locally; the test verifies the exact timeout values emitted for the workflow matrix, while actual timeout enforcement is performed by GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
