### PR TITLE
Fix SpringBlock state ordering after MTK compilation

### DIFF
--- a/benchmarks/ComplicatedPDE/SpringBlockNonLinearResistance.jmd
+++ b/benchmarks/ComplicatedPDE/SpringBlockNonLinearResistance.jmd
@@ -137,12 +137,6 @@ output = similar(input);
 sparsity_pattern = Symbolics.jacobian_sparsity(f0, output, input, nothing, 0.0);
 jac_sparsity = Float64.(sparse(sparsity_pattern));
 f = ODEFunction{true, SciMLBase.FullSpecialize}(f0; jac_prototype = jac_sparsity);
-#Callbacks--------------------------------------------------------------------------------------------------------------------
-is_start(u, t, integrator) = sum(abs.(integrator.u[(Ny * Nx + 1):(2 * Ny * Nx)]))>0.01 #detects onset of high cumulative velocity phase
-is_end(u, t, integrator) = sum(abs.(integrator.u[(Ny * Nx + 1):(2 * Ny * Nx)]))<0.01 #detects end of high cumulative velocity phase
-affect!(integrator) = terminate!(integrator)
-cb1 = DiscreteCallback(is_start, terminate!, save_positions = (false, false))
-cb2 = DiscreteCallback(is_end, terminate!, save_positions = (false, false))
 #Solver Setup-------------------------------------------------------------------------------------------------------------------
 solver = KenCarp47(linsolve = KLUFactorization());
 abstol = 1e-12;
@@ -151,28 +145,42 @@ reltol = 1e-8;
 u0 = get_IC();
 tspan = (0.0, 1e9);
 prob1 = ODEProblem(f, u0, tspan, nothing);
-@mtkcompile sys = modelingtoolkitize(prob1)
+@named uncompiled_sys = modelingtoolkitize(prob1)
+sys = mtkcompile(uncompiled_sys)
 prob_mtk1 = ODEProblem(sys, [], tspan, jac = true, sparse = true);
+state_indices1 = Dict(state => i for (i, state) in pairs(unknowns(sys)))
+original_state_indices1 = [state_indices1[state] for state in unknowns(uncompiled_sys)]
+velocity_indices1 = original_state_indices1[(Ny * Nx + 1):(2 * Ny * Nx)]
+is_start(u, t, integrator) = sum(abs, @view(integrator.u[velocity_indices1])) > 0.01
+cb1 = DiscreteCallback(is_start, terminate!, save_positions = (false, false))
 global sol, tcpu,
 bytes,
 gctime,
 memallocs = @timed solve(
     prob_mtk1, solver, reltol = reltol, abstol = abstol, maxiters = Int(1e12),
     save_everystep = false, dtmin = 1e-20, callback = cb1); #about 55 sec
-u1 = sol.u[end];
+@assert SciMLBase.successful_retcode(sol) "Phase 1 reference solve failed: $(sol.retcode)"
+u1 = sol.u[end][original_state_indices1];
 t1 = sol.t[end];
 test_sol1 = TestSolution(sol)
 #code (2): high cumulative velocity (>0.01) following phase (1)
 tspan = (0.0, 1e4);
 prob2 = ODEProblem(f, convU0(u1), tspan, nothing);
-@mtkcompile sys2 = modelingtoolkitize(prob2)
+@named uncompiled_sys2 = modelingtoolkitize(prob2)
+sys2 = mtkcompile(uncompiled_sys2)
 prob_mtk2 = ODEProblem(sys2, [], tspan, jac = true, sparse = true);
+state_indices2 = Dict(state => i for (i, state) in pairs(unknowns(sys2)))
+original_state_indices2 = [state_indices2[state] for state in unknowns(uncompiled_sys2)]
+velocity_indices2 = original_state_indices2[(Ny * Nx + 1):(2 * Ny * Nx)]
+is_end(u, t, integrator) = sum(abs, @view(integrator.u[velocity_indices2])) < 0.01
+cb2 = DiscreteCallback(is_end, terminate!, save_positions = (false, false))
 global sol, tcpu,
 bytes,
 gctime,
 memallocs = @timed solve(
     prob_mtk2, solver, reltol = reltol, abstol = abstol, maxiters = Int(1e12),
     save_everystep = false, dtmin = 1e-20, callback = cb2); #about 175 sec
+@assert SciMLBase.successful_retcode(sol) "Phase 2 reference solve failed: $(sol.retcode)"
 u2 = sol.u[end];
 t2 = t1 + sol.t[end];
 
@@ -182,8 +190,8 @@ test_sol2 = TestSolution(sol)
 The WP diagram setup:
 
 ```julia
-abstols = 1.0 ./ 10.0 .^ (6:12)
-reltols = 1.0 ./ 10.0 .^ (2:8)
+abstols = 1.0 ./ 10.0 .^ (6:11)
+reltols = 1.0 ./ 10.0 .^ (2:7)
 setups = [
     Dict(:alg=>KenCarp47(linsolve = KLUFactorization()), :prob_choice=>1),
     Dict(:alg=>Rodas5(), :prob_choice=>1),
@@ -193,9 +201,12 @@ names = ["KenCarp47 KLU MTK", "Rodas5 KLU MTK", "Rodas5P KLU MTK"]
 
 probs = [prob_mtk1, prob_mtk2]
 test_sols = [test_sol1, test_sol2]
-wp = WorkPrecisionSet(probs, abstols, reltols, setups; names = names,
-    save_everystep = false, maxiters = Int(1e5),
-    numruns = 10, appxsol = test_sols, callback = cb2, dtmin = 1e-20)
+wp = WorkPrecisionSet(
+    probs, abstols, reltols, setups; names = names,
+    save_everystep = false, maxiters = Int(1.0e5),
+    numruns = 10, appxsol = test_sols, callback = cb1, dtmin = 1.0e-20
+)
+@assert all(w -> all(error -> isfinite(error[:final]) && error[:final] > 0, w.errors), wp.wps) "A solver produced an invalid work-precision point"
 
 plot(wp, label = reduce(hcat, names), markershape = :auto, title = "Spring Block PDE work precision set")
 ```


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`mtkcompile` reorders the SpringBlock states, but the benchmark's callbacks and phase handoff treated the compiled solution vector as if it retained the original `(displacement, velocity)` ordering. The phase-2 reference consequently diverged while Weave continued and published an empty work-precision plot.

This maps the original symbolic state order to the compiled order before selecting velocities or handing the phase-1 endpoint to `convU0`. It also checks both reference retcodes and rejects non-finite, zero, or negative work-precision errors so this page cannot silently publish another invalid plot.

The benchmark sweep stops one tolerance short of the independently computed reference tolerance; the previous last KenCarp47 point compared the reference solve with itself and produced exactly zero error.

## Failing before the fix

I added only the two reference-retcode assertions to the unmodified benchmark at `5b6b86896b43296285f8e19aca7a2205c3530d13`, tangled it, and ran the generated script:

```text
$ timeout 3600 julia +1.11.9 --startup-file=no --threads=auto --project=benchmarks/ComplicatedPDE script/ComplicatedPDE/SpringBlockNonLinearResistance.jl
At t=0.00024530745867691947, dt was forced below floating point epsilon ...
u[1200] = 1.841e+218 has grown >1e6× its initial value
ERROR: LoadError: AssertionError: Phase 2 reference solve failed: Unstable
exit=1
```

The current hosted run exhibits the same failure but remains green because benchmark weaving uses `error = false`: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32768161665/job/98059719949

## Passing after the fix

```text
$ JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.11.9 --threads=auto --project=. benchmark.jl benchmarks/ComplicatedPDE/SpringBlockNonLinearResistance.jmd
[ Info: Weaved all chunks
[ Info: Weaved to .../markdown/ComplicatedPDE/SpringBlockNonLinearResistance.md
exit=0
```

The generated page contains one populated plot with finite positive errors for KenCarp47, Rodas5, and Rodas5P. The log contains no solver errors, instability warnings, or assertion failures.

```text
$ GROUP=Core julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |   10     10  51.3s

$ GROUP=QA julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m53.0s

$ typos benchmarks/ComplicatedPDE/SpringBlockNonLinearResistance.jmd
# no output; exit 0

$ git diff --check
# no output; exit 0
```

Runic also reports no formatting changes for the changed Julia blocks. The complete generated script retains unrelated pre-existing formatting drift, which this focused behavior fix does not sweep.

## Not verified

I did not run the other ComplicatedPDE pages. This PR changes only `SpringBlockNonLinearResistance.jmd`; the full affected page, repository Core tests, and QA group were run locally. No public API, documentation build, or GPU path is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
