### PR TITLE
Release 0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBenchmarks"
 uuid = "31c91b34-3c75-11e9-0341-95557aab0344"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Chris Rackauckas, Yingbo Ma, Vaibhav Dixit"]
 
 [deps]
@@ -24,7 +24,7 @@ Pkg = "1"
 Plots = "1.41.6"
 PrecompileTools = "1.2.1"
 SciMLTesting = "2.8"
-SafeTestsets = "0.1, 1"
+SafeTestsets = "0.1"
 Test = "1"
 Weave = "0.10"
 julia = "1"


### PR DESCRIPTION
Release the accumulated source changes: the package no longer pulls the full solver stack as hard dependencies, IJulia moved behind an extension, and the Markdown rendering path was rewritten.

Also drops the phantom SafeTestsets `1` major from `[compat]` (the registry only has 0.0.1 and 0.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R