### PR TITLE
Fix QA compatibility after v0.2 release

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,7 +6,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 JET = "0.9, 0.10, 0.11, 0.12"
-SciMLBenchmarks = "0.1"
+SciMLBenchmarks = "0.2"
 SciMLTesting = "2.8"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Update the isolated QA environment's `SciMLBenchmarks` compatibility from `0.1` to `0.2`. The package release commit changed the root project to version 0.2.0, but SciMLTesting develops that local package into the QA group environment, whose stale `0.1` bound makes resolution impossible before any QA checks run.

The regression was introduced by https://github.com/SciML/SciMLBenchmarks.jl/commit/9efc785e4be22b57bdcdbb69377b2fa1dd72f432. This PR changes only the QA environment; the 35 benchmark environments that intentionally resolve registered SciMLBenchmarks 0.1.x are a separate Project/Manifest migration.

## Verification

Failing before the fix on clean master (`091b3f407fada09417f47a7ccb3df8d8bf029d40`):

```text
$ GROUP=QA julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
  Activating project at `~/tmp/jl_sciml_group_env_ZY4oIj`
   Resolving package versions...
ERROR: LoadError: empty intersection between SciMLBenchmarks@0.2.0 and project compatibility 0.1
ERROR: Package SciMLBenchmarks errored during testing
```

The focused resolver discriminator also separated the release commit from its parent:

```text
release_commit_exit=1
parent_commit_exit=0
release diagnostic:
ERROR: empty intersection between SciMLBenchmarks@0.2.0 and project compatibility 0.1
```

Passing after the fix:

```text
$ GROUP=QA julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   19     19  1m01.8s
     Testing SciMLBenchmarks tests passed
```

The same disposable-environment resolver probe now develops the local package successfully:

```text
fixed_resolver_exit=0
[31c91b34] + SciMLBenchmarks v0.2.0 `.../scimlbench-qa-compat`
```

The relevant core group also passes:

```text
$ GROUP=Core julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
Core          |   10     10  2m49.9s
     Testing SciMLBenchmarks tests passed
```

Static checks:

```text
julia +1.12 --startup-file=no --project=@runic -m Runic --check --diff .
runic_exit=0
typos <changed files>
typos_exit=0
git diff --check
diff_check_exit=0
```

## Not verified / out of scope

- No documentation build was run because this changes no documentation, docstring, or public API.
- No benchmark folder was run; this only repairs QA environment resolution.
- The 35 benchmark `Project.toml` files still bounded to SciMLBenchmarks 0.1 require a separate mechanical Project/Manifest audit and are deliberately not mixed into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
