### PR TITLE
Pin V100 benchmarks to CUDA 12.9

### DIFF
--- a/benchmarks/DiffEqGPU/LocalPreferences.toml
+++ b/benchmarks/DiffEqGPU/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/DiffEqGPU/Project.toml
+++ b/benchmarks/DiffEqGPU/Project.toml
@@ -21,3 +21,6 @@ PythonCall = "0.9"
 SciMLBenchmarks = "0.1"
 StaticArrays = "1"
 StochasticDiffEq = "6"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/benchmarks/PINNErrorsVsTime/LocalPreferences.toml
+++ b/benchmarks/PINNErrorsVsTime/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/PINNErrorsVsTime/Project.toml
+++ b/benchmarks/PINNErrorsVsTime/Project.toml
@@ -39,3 +39,6 @@ Plots = "1"
 QuasiMonteCarlo = "0.3"
 ReverseDiff = "1"
 SciMLBenchmarks = "0.1"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/benchmarks/PINNOptimizers/LocalPreferences.toml
+++ b/benchmarks/PINNOptimizers/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/PINNOptimizers/Project.toml
+++ b/benchmarks/PINNOptimizers/Project.toml
@@ -25,3 +25,6 @@ OptimizationOptimJL = "0.4"
 OptimizationOptimisers = "0.3"
 Plots = "1"
 SciMLBenchmarks = "0.1"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/test/core.jl
+++ b/test/core.jl
@@ -33,6 +33,17 @@ end
     @test success(process)
 end
 
+@testset "V100 CUDA runtime preferences" begin
+    benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
+    cuda_runtime = "CUDA_Runtime_jll = \"76a88914-d11a-5bdc-97e0-2f5a05c973a2\""
+    for folder in ("DiffEqGPU", "PINNErrorsVsTime", "PINNOptimizers")
+        preferences = read(joinpath(benchmarks_dir, folder, "LocalPreferences.toml"), String)
+        project = read(joinpath(benchmarks_dir, folder, "Project.toml"), String)
+        @test occursin("version = \"12.9\"", preferences)
+        @test occursin(cuda_runtime, project)
+    end
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Pin the DiffEqGPU, PINNErrorsVsTime, and PINNOptimizers environments to CUDA 12.9 so they remain compatible with the V100 runners (compute capability 7.0). Each environment also maps the already-transitive `CUDA_Runtime_jll` package in `[extras]`; without that UUID mapping, Julia ignores the transitive JLL preference.

This follows the existing PSOGlobalOptimization environment configuration. It does not add a new runtime dependency: CUDA already brings in `CUDA_Runtime_jll`.

## Verification

Failing before on unmodified master:

```text
V100 CUDA runtime preferences: Error During Test
SystemError: opening file ".../benchmarks/DiffEqGPU/LocalPreferences.toml":
No such file or directory
Test Summary:                 | Error  Total
V100 CUDA runtime preferences |     1      1
```

The same new regression test passes after the change:

```text
Test Summary: | Pass  Total     Time
Core          |   16     16  1m12.3s
Testing SciMLBenchmarks tests passed
```

The active preference lookup reports `12.9` in all three environments:

```text
DiffEqGPU:          12.9
PINNErrorsVsTime:   12.9
PINNOptimizers:     12.9
```

Exact Julia 1.11.9 `Pkg.resolve(); Pkg.instantiate()` completed in each environment with no Project or Manifest changes.

```text
Test Summary: | Pass  Total     Time
QA            |   21     21  1m51.9s
Testing SciMLBenchmarks tests passed
```

Julia Runic, typos, and `git diff --check` also pass.

## Not verified locally

This host has no NVIDIA GPU, so I could not execute the three GPU benchmark folders or confirm V100 kernel execution locally. The changed-folder CI jobs are the required hardware validation. No docs build was run because this changes benchmark environment configuration and no documentation or public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512