### PR TITLE
Run SciPy global optimizers sequentially

### DIFF
--- a/benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd
+++ b/benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd
@@ -196,9 +196,20 @@ p
 
 ```julia
 results = Array{BBOB.BenchmarkResults}(undef, length(setup))
+algorithms = collect(keys(setup))
 
-Threads.@threads for (i, algo) in collect(enumerate(keys(setup)))
-    results[i] = run_bench(algo)
+Threads.@threads for i in eachindex(algorithms)
+    algo = algorithms[i]
+    if !startswith(algo, "Scipy")
+        results[i] = run_bench(algo)
+    end
+end
+
+# PythonCall can segfault when these SciPy solves run on different Julia threads.
+for (i, algo) in enumerate(algorithms)
+    if startswith(algo, "Scipy")
+        results[i] = run_bench(algo)
+    end
 end
 
 results


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Keep the non-SciPy global optimizers threaded, but run the four SciPy-backed entries sequentially. Concurrent OptimizationSciPy solves enter PythonCall from different Julia threads and segfault in `PyTuple_New`; serializing only those entries removes that unsafe overlap without giving up parallelism for the native optimizers.

The unsafe scheduling was originally added in https://github.com/SciML/SciMLBenchmarks.jl/commit/1a45bb323783291d4e98d2254fdf88a47bb32968, fixed in https://github.com/SciML/SciMLBenchmarks.jl/commit/1d073d3432cf4d4d98a5ffde1407ddab30091ae0, and reintroduced in https://github.com/SciML/SciMLBenchmarks.jl/commit/9c39e0f7b2d36fc922f34a73d45c1069f59b7039. This restores the intended serialization without the earlier error-swallowing behavior.

## Verification

Failing before, on clean master `5b6b86896b43296285f8e19aca7a2205c3530d13`:

```bash
timeout 3600 julia +1.12.6 --startup-file=no --threads=auto --project=. \
  benchmark.jl benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd
```

The process exited 139 after about 1 minute 50 seconds. Its stack ended in `PyTuple_New` → `OptimizationSciPy._build_bounds` → `run_bench` → `Threads.@threads`. A reduced one-problem reproducer running two `ScipyDifferentialEvolution()` solves concurrently also exited 139 in all three runs; the identical two solves sequentially exited 0.

Passing after:

- Reduced scheduler reproducer: exit 0; both SciPy solves returned.
- Each current SciPy algorithm (`ScipyDifferentialEvolution`, `ScipyShgo`, `ScipyDirect`, and `ScipyBrute`) completed a sequential one-problem smoke test.
- Full benchmark page on this focused commit ran for 4 hours 7 minutes, completed all
  iteration-benchmark calls (20/20 BBOB functions for each SciPy solver), and produced a
  nondegenerate iteration-success plot without a segfault. It then exposed a separate
  clean-master namespace bug in the wall-clock section: `OptimizationNOMAD` makes the
  unqualified `solve` binding ambiguous, so that section failed before running any solver.
- Applying the one-line `Optimization.solve(...)` correction as a separate temporary stacked
  commit made the exact full page pass in 5 hours 32 minutes 22 seconds (`exit=0`). It wrote
  the Markdown plus seven PNGs; all 7/7 image references resolve, all plots were inspected and
  contain meaningful data, and the log contains no `signal 11`, segfault, `ERROR`, `LoadError`,
  or `UndefVarError` marker. That independent correction is intentionally not included here; it
  is the stacked https://github.com/SciML/SciMLBenchmarks.jl/pull/1714.
- `GROUP=QA julia +1.12.6 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: 21 passed, exit 0.
- Runic on the changed Julia block: exit 0.
- `typos benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd`: exit 0.
- `git diff --check`: exit 0.

The branch's clean-master Core run reached 8 passes and then hit the pre-existing Julia 1.12
`MbedTLS_jll` Testing-manifest failure. Applying this exact source diff and the changes from
the now-closed https://github.com/SciML/SciMLBenchmarks.jl/pull/1702 temporarily on current
upstream master made Core pass 11/11 in 51.3 seconds. That manifest fix is intentionally not
included here.

## Not verified

- Hosted CI has not run yet.
- No GPU path is involved.
- No docs build was run because this changes a benchmark execution block, not package documentation or public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
