### PR TITLE
Qualify the Optimization solve call

### DIFF
--- a/benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd
+++ b/benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd
@@ -196,9 +196,20 @@ p
 
 ```julia
 results = Array{BBOB.BenchmarkResults}(undef, length(setup))
+algorithms = collect(keys(setup))
 
-Threads.@threads for (i, algo) in collect(enumerate(keys(setup)))
-    results[i] = run_bench(algo)
+Threads.@threads for i in eachindex(algorithms)
+    algo = algorithms[i]
+    if !startswith(algo, "Scipy")
+        results[i] = run_bench(algo)
+    end
+end
+
+# PythonCall can segfault when these SciPy solves run on different Julia threads.
+for (i, algo) in enumerate(algorithms)
+    if startswith(algo, "Scipy")
+        results[i] = run_bench(algo)
+    end
 end
 
 results

--- a/benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd
+++ b/benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd
@@ -51,7 +51,7 @@ function solve_problem_timed(optimizer::BenchmarkSetup, tracked_f, D::Int, run_l
     else
         prob = OptimizationProblem(optf, u0)
     end
-    sol = solve(prob, method; maxiters = run_length)
+    sol = Optimization.solve(prob, method; maxiters = run_length)
     sol
 end
 


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Qualify the wall-clock benchmark's solver call as `Optimization.solve`. Loading
`OptimizationNOMAD` also loads NOMAD's distinct exported `solve`, which makes the unqualified
binding ambiguous; every time-to-success trial was caught as `UndefVarError`, and the final plot
then failed while reducing the empty finite-results vector.

This is stacked on https://github.com/SciML/SciMLBenchmarks.jl/pull/1713, which lets the benchmark
safely reach the wall-clock phase.
The ambiguous call was introduced in
https://github.com/SciML/SciMLBenchmarks.jl/commit/1901480c62dc512d612e16ecdb19b5062486c493.

## Verification

Failing before, with the threading fix applied but this commit reverted:

```bash
timeout 86400 julia +1.12.6 --startup-file=no --threads=auto --project=. \
  benchmark.jl benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd
```

The iteration benchmark completed without a segfault, but all 16,000 wall-clock trials caught
`UndefVarError: solve not defined`; the weave exited 1 after 4 hours 7 minutes when the final plot
called `minimum` on an empty vector.

Passing after, with the same command:

- The full page exited 0 in 5 hours 32 minutes 22 seconds and wrote
  `markdown/GlobalOptimization/blackbox_global_optimizers.md`.
- All 7/7 referenced PNGs exist and decode, and visual inspection found meaningful iteration,
  wall-clock, per-function, distance, and relative-runtime results.
- The log contains no `signal 11`, segfault, `ERROR`, `LoadError`, or `UndefVarError` marker.
- An identical reduced probe that extracts the notebook's setup/helper blocks exited 1 on clean
  master with the same `UndefVarError`, then exited 0 here with
  `retcode=Success objective=1.2377733284625547e-9`.
- `GROUP=QA julia +1.12.6 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`:
  21/21 passed in 1 minute 34.8 seconds.
- Runic on the changed Julia statement: exit 0.
- `typos benchmarks/GlobalOptimization/blackbox_global_optimizers.jmd`: exit 0.
- `git diff --check HEAD^ HEAD`: exit 0.

Clean master's Core group reaches 8 passes and then hits the pre-existing Julia 1.12
`MbedTLS_jll` Testing-manifest failure. Applying both source commits and the changes from the
now-closed https://github.com/SciML/SciMLBenchmarks.jl/pull/1702 temporarily on current upstream
master made Core pass 11/11 in 1 minute 5.3 seconds. That manifest fix is intentionally not
included here.

## Not verified

- Hosted CI has not run yet.
- No GPU path is involved.
- No docs build was run because this changes a private benchmark helper, not package documentation
  or public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
