### PR TITLE
Fix DiffEqGPU singleton grids and GPU smoke solves

### DIFF
--- a/benchmarks/DiffEqGPU/crn_sde.jmd
+++ b/benchmarks/DiffEqGPU/crn_sde.jmd
@@ -82,8 +82,8 @@ function crn_g(u, p, t)
 end
 
 function crn_parameters(N; T::Type = Float32)
-    S_grid = T.(10 .^ range(T(-1), stop = T(2), length = N))
-    D_grid = T.(10 .^ range(T(-1), stop = T(2), length = N))
+    S_grid = T.(10 .^ range(T(-1), stop = T(2), length = max(N, 2))[1:N])
+    D_grid = T.(10 .^ range(T(-1), stop = T(2), length = max(N, 2))[1:N])
     τ_grid = T[0.1, 0.15, 0.20, 0.30, 0.50, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 7.50,
                10.0, 15.0, 20.0, 30.0, 50.0, 75.0, 100.0][1:2:19]
     v0_grid = T[0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.15, 0.20]

--- a/benchmarks/DiffEqGPU/crn_sde.jmd
+++ b/benchmarks/DiffEqGPU/crn_sde.jmd
@@ -123,10 +123,10 @@ end
 let
     ps = crn_parameters(1)
     ens = make_crn_ensemble(ps)
-    sol = solve(ens, GPUEM(), KERNEL; trajectories = 1, save_everystep = false,
+    sol = solve(ens, GPUEM(), KERNEL; trajectories = 2, save_everystep = false,
         adaptive = false, dt = 0.1f0)
-    println("CRN smoke: 1 trajectory, u[end] = ", sol[1].u[end])
-    @assert length(sol[1].u[end]) == 4
+    println("CRN smoke: 2 trajectories, u[1][end] = ", sol[1].u[end])
+    @assert all(i -> length(sol[i].u[end]) == 4, 1:2)
 end
 ```
 

--- a/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
+++ b/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
@@ -58,7 +58,7 @@ function make_ensemble(n; T::Type = Float32)
     u0 = SVector{3, T}(1, 0, 0)
     tspan = (zero(T), one(T))
     p = SVector{1, T}(21)
-    plist = range(zero(T), T(21); length = n)
+    plist = range(zero(T), T(21); length = max(n, 2))[1:n]
     prob = ODEProblem{false}(lorenz, u0, tspan, p)
     prob_func = (prob, i, repeat) -> remake(prob, p = SVector{1, T}(plist[i]))
     return EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)

--- a/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
+++ b/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
@@ -127,17 +127,17 @@ const TRAJ_TORCH = [8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288]
 
 ## Correctness
 
-One kernel trajectory against a CPU `Tsit5` reference at the same `Float32`
-problem.
+Two kernel trajectories against CPU `Tsit5` references at the same `Float32`
+problems.
 
 ```julia
 let
-    ens = make_ensemble(1)
-    sol_gpu = solve(ens, GPUTsit5(), KERNEL; trajectories = 1,
+    ens = make_ensemble(2)
+    sol_gpu = solve(ens, GPUTsit5(), KERNEL; trajectories = 2,
         save_everystep = false, adaptive = false, dt = 0.001f0)
-    sol_cpu = solve(ens, Tsit5(), EnsembleSerial(); trajectories = 1,
+    sol_cpu = solve(ens, Tsit5(), EnsembleSerial(); trajectories = 2,
         save_everystep = false, adaptive = false, dt = 0.001f0)
-    err = maximum(abs.(sol_gpu[1].u[end] .- sol_cpu[1].u[end]))
+    err = maximum(i -> maximum(abs.(sol_gpu[i].u[end] .- sol_cpu[i].u[end])), 1:2)
     println("kernel vs CPU |Δu|∞ at t=1: ", err)
     @assert err < 1.0f-2
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -43,6 +43,9 @@ end
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks", "DiffEqGPU")
 
     crn_path = joinpath(benchmarks_dir, "crn_sde.jmd")
+    crn_source = read(crn_path, String)
+    @test occursin("GPUEM(), KERNEL; trajectories = 2", crn_source)
+    @test !occursin("GPUEM(), KERNEL; trajectories = 1", crn_source)
     for variable in ("S_grid", "D_grid")
         crn_expression = benchmark_assignment(crn_path, variable)
         crn_grid = Core.eval(@__MODULE__, :((N, T) -> $crn_expression))
@@ -50,9 +53,11 @@ end
         @test crn_grid(2, Float32) == Float32[0.1, 100]
     end
 
-    lorenz_expression = benchmark_assignment(
-        joinpath(benchmarks_dir, "lorenz_ensemble.jmd"), "plist"
-    )
+    lorenz_path = joinpath(benchmarks_dir, "lorenz_ensemble.jmd")
+    lorenz_source = read(lorenz_path, String)
+    @test occursin("make_ensemble(2)", lorenz_source)
+    @test !occursin("make_ensemble(1)", lorenz_source)
+    lorenz_expression = benchmark_assignment(lorenz_path, "plist")
     lorenz_grid = Core.eval(@__MODULE__, :((n, T) -> $lorenz_expression))
     @test collect(lorenz_grid(1, Float32)) == Float32[0]
     @test collect(lorenz_grid(4, Float32)) == Float32[0, 7, 14, 21]

--- a/test/core.jl
+++ b/test/core.jl
@@ -33,6 +33,31 @@ end
     end
 end
 
+function benchmark_assignment(path, variable)
+    prefix = string(variable, " = ")
+    line = only(line for line in eachline(path) if startswith(strip(line), prefix))
+    return Meta.parse(strip(split(line, "="; limit = 2)[2]))
+end
+
+@testset "DiffEqGPU singleton parameter grids" begin
+    benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks", "DiffEqGPU")
+
+    crn_path = joinpath(benchmarks_dir, "crn_sde.jmd")
+    for variable in ("S_grid", "D_grid")
+        crn_expression = benchmark_assignment(crn_path, variable)
+        crn_grid = Core.eval(@__MODULE__, :((N, T) -> $crn_expression))
+        @test crn_grid(1, Float32) == Float32[0.1]
+        @test crn_grid(2, Float32) == Float32[0.1, 100]
+    end
+
+    lorenz_expression = benchmark_assignment(
+        joinpath(benchmarks_dir, "lorenz_ensemble.jmd"), "plist"
+    )
+    lorenz_grid = Core.eval(@__MODULE__, :((n, T) -> $lorenz_expression))
+    @test collect(lorenz_grid(1, Float32)) == Float32[0]
+    @test collect(lorenz_grid(4, Float32)) == Float32[0, 7, 14, 21]
+end
+
 @testset "subprocess" begin
     process = SciMLBenchmarks.@subprocess exit()
     @test success(process)


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

This fixes two independent failures in the new DiffEqGPU pages:

- singleton endpoint-inclusive parameter grids now retain their lower endpoint instead of calling `range` with unequal endpoints and `length = 1`;
- the GPU correctness smoke solves use two trajectories, because DiffEqGPU 3.13 routes `trajectories == 1` through `EnsembleSerial`, where `GPUEM()` and `GPUTsit5()` are not valid solver algorithms.

The two-trajectory smoke solves retain the intended GPU-vs-CPU correctness checks. Source regression tests cover both failures without requiring a GPU.

## Failing before

The original parameter grids failed before reaching CUDA:

```text
ArgumentError: range(-1.0, stop=2.0, length=1): endpoints differ
ArgumentError: range(0.0, stop=21.0, length=1): endpoints differ
```

After the grids were fixed, the physical V100 run exposed the singleton solver dispatches: the CRN page failed with `Default algorithm choices require DifferentialEquations.jl`, while the Lorenz page passed `GPUTsit5()` into the serial fallback and errored during initialization.

The new smoke-solve assertions fail against the unfixed sources:

```text
Test Summary:                         | Pass  Fail  Total     Time
Core                                  |   16     4     20  6m16.7s
  DiffEqGPU singleton parameter grids |    6     4     10     2.9s
ERROR: Some tests did not pass: 16 passed, 4 failed, 0 errored, 0 broken.
```

## Passing after

After rebasing onto current `master`:

```text
$ GROUP=Core julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |   43     43  50.1s
Testing SciMLBenchmarks tests passed

$ GROUP=QA julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m43.7s
Testing SciMLBenchmarks tests passed
```

Runic 1.x checked `test/core.jl`, `typos` checked all three changed files, and `git diff --check` passed.

## Not verified locally

This host has no CUDA GPU. The rebased Lorenz job reached the new two-trajectory `GPUTsit5` kernel path, then failed because this source-only branch does not include the separate V100 CUDA 12.9 preferences from https://github.com/SciML/SciMLBenchmarks.jl/pull/1733:

```text
Compute capability 7.0.0 is not supported by CUDA 13.2.0
```

That run is https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33353936117/job/99372427249. A composed V100 run remains required after the CUDA preference and PyTorch CUDA 12.6 dependency changes are applied. No docs build was run because this changes benchmark pages and a private regression test, not public API or docstrings.

The failing composed V100 validation run was https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33298026014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
