### PR TITLE
Fix PINNOptimizers DomainSets imports

### DIFF
--- a/benchmarks/PINNOptimizers/1d_diffusion.jmd
+++ b/benchmarks/PINNOptimizers/1d_diffusion.jmd
@@ -14,7 +14,7 @@ science-guided AI techniques.
 ```julia
 using NeuralPDE, ModelingToolkit, Optimization, OptimizationOptimJL
 using Lux, Plots, OptimizationOptimisers
-import ModelingToolkit: Interval, infimum, supremum
+import DomainSets: Interval, infimum, supremum
 using CUDA, LuxCUDA, ComponentArrays, Random
 
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"

--- a/benchmarks/PINNOptimizers/1d_poisson_nernst_planck.jmd
+++ b/benchmarks/PINNOptimizers/1d_poisson_nernst_planck.jmd
@@ -14,7 +14,7 @@ science-guided AI techniques.
 ```julia
 using NeuralPDE, ModelingToolkit, Optimization, OptimizationOptimJL
 using Lux, Plots, OptimizationOptimisers
-import ModelingToolkit: Interval, infimum, supremum
+import DomainSets: Interval, infimum, supremum
 using CUDA, LuxCUDA, ComponentArrays, Random
 
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"

--- a/benchmarks/PINNOptimizers/Manifest.toml
+++ b/benchmarks/PINNOptimizers/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "20eea30cfd09eb320c5bae5e3acaf1c6e9493ed7"
+project_hash = "48c9892b43507c6688124cac645726f434567428"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "5970c86505ae9c07bf5bc521ef2bbbb3849e8b7b"

--- a/benchmarks/PINNOptimizers/Project.toml
+++ b/benchmarks/PINNOptimizers/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
@@ -15,6 +16,7 @@ SciMLBenchmarks = "31c91b34-3c75-11e9-0341-95557aab0344"
 [compat]
 CUDA = "5, 6"
 ComponentArrays = "0.15"
+DomainSets = "0.7"
 Lux = "1"
 LuxCUDA = "0.3"
 MLDataDevices = "1"

--- a/benchmarks/PINNOptimizers/allen_cahn.jmd
+++ b/benchmarks/PINNOptimizers/allen_cahn.jmd
@@ -14,7 +14,7 @@ science-guided AI techniques.
 ```julia
 using NeuralPDE, ModelingToolkit, Optimization, OptimizationOptimJL
 using Lux, Plots, OptimizationOptimisers
-import ModelingToolkit: Interval, infimum, supremum
+import DomainSets: Interval, infimum, supremum
 using CUDA, LuxCUDA, ComponentArrays, Random
 
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"

--- a/benchmarks/PINNOptimizers/burgers_equation.jmd
+++ b/benchmarks/PINNOptimizers/burgers_equation.jmd
@@ -14,7 +14,7 @@ science-guided AI techniques.
 ```julia
 using NeuralPDE, ModelingToolkit, Optimization, OptimizationOptimJL
 using Lux, Plots, OptimizationOptimisers
-import ModelingToolkit: Interval, infimum, supremum
+import DomainSets: Interval, infimum, supremum
 using CUDA, LuxCUDA, ComponentArrays, Random
 
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"

--- a/benchmarks/PINNOptimizers/hamilton_jacobi.jmd
+++ b/benchmarks/PINNOptimizers/hamilton_jacobi.jmd
@@ -14,7 +14,7 @@ science-guided AI techniques.
 ```julia
 using NeuralPDE, ModelingToolkit, Optimization, OptimizationOptimJL
 using Lux, Plots, OptimizationOptimisers
-import ModelingToolkit: Interval, infimum, supremum
+import DomainSets: Interval, infimum, supremum
 using CUDA, LuxCUDA, ComponentArrays, Random
 
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"

--- a/benchmarks/PINNOptimizers/poisson.jmd
+++ b/benchmarks/PINNOptimizers/poisson.jmd
@@ -14,7 +14,7 @@ science-guided AI techniques.
 ```julia
 using NeuralPDE, ModelingToolkit, Optimization, OptimizationOptimJL
 using Lux, Plots, OptimizationOptimisers
-import ModelingToolkit: Interval, infimum, supremum
+import DomainSets: Interval, infimum, supremum
 using CUDA, LuxCUDA, ComponentArrays, Random
 
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The six PINNOptimizers pages that use interval domains now import `Interval`, `infimum`, and `supremum` from their owning package, DomainSets, instead of ModelingToolkit. DomainSets is added as a direct dependency with `0.7` compatibility; its license is MIT.

The CUDA 12 runtime probe reached these pages successfully, but all six stopped before solving because ModelingToolkit no longer provides `Interval`. This source fix is separate from the CUDA runtime pin.

Root `Core` validation on Julia 1.12 also depends on https://github.com/SciML/SciMLBenchmarks.jl/pull/1716, which repairs the pre-existing Testing manifest.

## Failing before

```console
$ julia +1.11.9 --project=benchmarks/PINNOptimizers -e 'import ModelingToolkit: Interval, infimum, supremum; d = Interval(0.0, 1.0); @assert infimum(d) == 0.0; @assert supremum(d) == 1.0'
WARNING: could not import ModelingToolkit.Interval into Main
ERROR: UndefVarError: `Interval` not defined in `Main`
```

## Passing after

```console
$ julia +1.11.9 --project=benchmarks/PINNOptimizers -e 'import DomainSets: Interval, infimum, supremum; d = Interval(0.0, 1.0); @assert infimum(d) == 0.0; @assert supremum(d) == 1.0; println("DomainSets Interval API: PASS")'
DomainSets Interval API: PASS
```

## Verification

```console
$ julia +1.11.9 --project=benchmarks/PINNOptimizers -e 'using Pkg; Pkg.resolve()'
No Changes to `benchmarks/PINNOptimizers/Project.toml`
No Changes to `benchmarks/PINNOptimizers/Manifest.toml`

$ GROUP=QA julia +1.11.9 --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m58.8s

$ GROUP=Core julia +1.12.6 -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(path=pwd()); Pkg.test("SciMLBenchmarks")'
Test Summary: | Pass  Total     Time
Core          |   10     10  3m46.4s
```

The Core command was run on this commit plus the prerequisite commit from https://github.com/SciML/SciMLBenchmarks.jl/pull/1716. `typos` and `git diff --check` pass. Runic is not applicable because the diff contains no `.jl` files.

## Not verified

The complete benchmark pages were not run locally because this host has no CUDA GPU. The GPU CI job is required to validate the full NeuralPDE solves and rendering.

DomainSets license: https://github.com/JuliaApproximation/DomainSets.jl/blob/master/LICENSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
