### PR TITLE
Pin V100 benchmarks to CUDA 12.9

### DIFF
--- a/benchmarks/DiffEqGPU/LocalPreferences.toml
+++ b/benchmarks/DiffEqGPU/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/DiffEqGPU/Project.toml
+++ b/benchmarks/DiffEqGPU/Project.toml
@@ -21,3 +21,6 @@ PythonCall = "0.9"
 SciMLBenchmarks = "0.1"
 StaticArrays = "1"
 StochasticDiffEq = "6"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/benchmarks/PINNErrorsVsTime/LocalPreferences.toml
+++ b/benchmarks/PINNErrorsVsTime/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/PINNErrorsVsTime/Project.toml
+++ b/benchmarks/PINNErrorsVsTime/Project.toml
@@ -41,3 +41,6 @@ Plots = "1"
 QuasiMonteCarlo = "0.3"
 ReverseDiff = "1"
 SciMLBenchmarks = "0.1"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/benchmarks/PINNOptimizers/LocalPreferences.toml
+++ b/benchmarks/PINNOptimizers/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/PINNOptimizers/Project.toml
+++ b/benchmarks/PINNOptimizers/Project.toml
@@ -27,3 +27,6 @@ OptimizationOptimJL = "0.4"
 OptimizationOptimisers = "0.3"
 Plots = "1"
 SciMLBenchmarks = "0.1"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"


### PR DESCRIPTION
> Ignore until reviewed by @ChrisRackauckas.

## What changed and why

Pin the CUDA runtime to 12.9 for `DiffEqGPU`, `PINNErrorsVsTime`, and `PINNOptimizers`, the three benchmark environments assigned to the V100 pool. CUDA 13 no longer supports the V100's compute capability 7.0.

Each environment now names `CUDA_Runtime_jll` under `[extras]` and carries the same `LocalPreferences.toml` setting already used by `PSOGlobalOptimization`. The `[extras]` entry is necessary: without a Project UUID mapping, Julia ignores the named `CUDA_Runtime_jll` preference table.

## Failing before / passing after

Before the change:

```
julia +1.11.9 --startup-file=no --project=benchmarks/DiffEqGPU \
  -e 'using CUDA; @show CUDA.toolkit_version; @assert CUDA.toolkit_version == v"12.9"'
ERROR: AssertionError: CUDA.toolkit_version == v"12.9"
CUDA.toolkit_version = nothing
exit 1
```

After the change, the same assertion passed in all three environments:

```
DiffEqGPU:         CUDA.toolkit_version = v"12.9.0"
PINNErrorsVsTime: CUDA.toolkit_version = v"12.9.0"
PINNOptimizers:   CUDA.toolkit_version = v"12.9.0"
```

The `DiffEqGPU` check included a fresh CUDA precompile:

```
66713.4 ms  ✓ CUDA
5439.6 ms   ✓ Atomix → AtomixCUDAExt
CUDA.toolkit_version = v"12.9.0"
```

## Other verification

- `Pkg.resolve()` under Julia 1.11.9 reported no Project or Manifest package changes for all three environments.
- `GROUP=Core julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: 10/10 passed.
- `GROUP=QA julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: 21/21 passed.
- `git diff --check` and `typos` passed.
- Runic is not applicable to the TOML-only change.

## Not verified

This machine has no NVIDIA GPU, so I did not execute the benchmark pages or compile a kernel for `sm_70`. The V100 path must be verified by the GPU CI runner. Docs were not run because no documentation or public API changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512