### PR TITLE
Publish each completed benchmark immediately

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -122,38 +122,8 @@ jobs:
             script/
           retention-days: 30
 
-  publish:
-    name: Publish Results
-    needs: benchmark
-    # Publish whenever the benchmark stage actually ran (success OR failure),
-    # so one folder's failure doesn't block other folders' artifacts from
-    # reaching SciMLBenchmarksOutput. download-artifact pulls only artifacts
-    # that were actually uploaded (only successful builds upload), and
-    # publish_benchmark_output.sh is a no-op when there's nothing new.
-    if: always() && github.ref == 'refs/heads/master' && (needs.benchmark.result == 'success' || needs.benchmark.result == 'failure')
-    # Hosted runner on purpose: publishing only needs git + ssh + the small
-    # markdown/notebook/pdf/script artifacts. On the self-hosted benchmark
-    # runners this 1-minute job queues behind multi-hour (sometimes multi-day)
-    # benchmark jobs, so finished results sit unpublished for hours even though
-    # their benchmark job succeeded.
-    runs-on: ubuntu-latest
-    # No concurrency group here on purpose. A job-level group has the same
-    # one-running + one-pending semantics as above, so with several master runs
-    # finishing close together the middle run's publish job would be cancelled
-    # and its results lost. Concurrent publishes are instead made safe by
-    # publish_benchmark_output.sh, which re-clones and retries when the push to
-    # SciMLBenchmarksOutput is rejected as non-fast-forward.
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Download all benchmark artifacts
-        uses: actions/download-artifact@v8
-        with:
-          pattern: benchmark-*
-          merge-multiple: true
-        continue-on-error: true
-
       - name: Publish to SciMLBenchmarksOutput
+        if: success() && github.ref == 'refs/heads/master'
         run: .github/scripts/publish_benchmark_output.sh
         env:
           DEPLOY_KEY: ${{ secrets.SCIML_BENCHMARKS_DEPLOY_KEY }}

--- a/test/core.jl
+++ b/test/core.jl
@@ -33,6 +33,18 @@ end
     @test success(process)
 end
 
+@testset "benchmark publication" begin
+    workflow = read(joinpath(dirname(@__DIR__), ".github", "workflows", "benchmarks.yml"), String)
+    benchmark_job = match(
+        r"(?ms)^  benchmark:\n(?<body>.*?)(?=^  [a-zA-Z][a-zA-Z0-9_-]*:\n|\z)", workflow
+    )
+    @test !isnothing(benchmark_job)
+    if !isnothing(benchmark_job)
+        @test occursin("- name: Publish to SciMLBenchmarksOutput", benchmark_job[:body])
+        @test occursin("if: success() && github.ref == 'refs/heads/master'", benchmark_job[:body])
+    end
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Each matrix entry now publishes its own successful output immediately after artifact upload. This removes the matrix-wide `needs: benchmark` barrier that currently leaves completed folders unpublished while unrelated jobs remain queued or stuck; concurrent output pushes retain the existing clone-and-retry protection in `publish_benchmark_output.sh`.

The deployment key is now used inside successful master benchmark jobs rather than a separate GitHub-hosted publish job. Pull-request jobs cannot reach this step because the `github.ref == 'refs/heads/master'` condition is false and fork PRs do not receive the secret.

## Failing before

With the new regression test applied to unmodified master:

```text
benchmark publication: Test Failed
Expression: occursin("- name: Publish to SciMLBenchmarksOutput", benchmark_job[:body])
benchmark publication: Test Failed
Expression: occursin("if: success() && github.ref == 'refs/heads/master'", benchmark_job[:body])
Test Summary:           | Pass  Fail  Total
Core                    |   11     2     13
```

Command:

```bash
GROUP=Core julia +1.10.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

## Passing after

The identical command with the workflow change:

```text
Test Summary: | Pass  Total
Core          |   13     13
Testing SciMLBenchmarks tests passed
```

Additional local verification:

```text
GROUP=QA julia +1.10.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA | 19 passed / 19 total

actionlint .github/workflows/benchmarks.yml
# exit 0

julia +1.10.11 --project=.validation/runic-env -e 'using Runic; exit(Runic.main(["--check", "test/core.jl"]))'
# exit 0

typos .github/workflows/benchmarks.yml test/core.jl
# exit 0

git diff --check
# exit 0
```

Not verified locally: an authenticated Actions publication to `SciMLBenchmarksOutput`; that requires the repository deployment secret. No docs, public API, GPU, or downstream paths are changed.

Reviewer judgment: confirm that exposing the output-only deployment key to trusted master self-hosted benchmark jobs is acceptable. This is the tradeoff that permits per-folder publication without waiting for the entire dynamic matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
