### PR TITLE
Cancel benchmark runs when pull requests merge

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ on:
 # to SciMLBenchmarksOutput, which publish_benchmark_output.sh handles itself.
 concurrency:
   group: benchmarks-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.ref == 'refs/heads/master' && github.run_id || github.ref) }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/master' }}
 
 jobs:
   detect-changes:

--- a/test/core.jl
+++ b/test/core.jl
@@ -49,6 +49,7 @@ end
     workflow = read(joinpath(dirname(@__DIR__), ".github", "workflows", "benchmarks.yml"), String)
     @test occursin("types: [opened, synchronize, reopened, closed]", workflow)
     @test occursin("format('pr-{0}', github.event.pull_request.number)", workflow)
+    @test occursin("github.event_name == 'pull_request' || github.ref != 'refs/heads/master'", workflow)
     @test occursin("github.event.action != 'closed'", workflow)
 end
 


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

A merged pull request's `closed` event can report `github.ref` as `refs/heads/master`. The cancellation condition merged in https://github.com/SciML/SciMLBenchmarks.jl/pull/1723 would then evaluate false, so this follow-up makes every `pull_request` event cancellable regardless of its ref and adds a regression assertion for that guard.

## Failing before

With only the new assertion applied to current master:

```text
Test Summary:                      | Pass  Fail  Total
Core                               |   16     1     17
  closed pull request cancellation |    3     1      4
```

The failure was:

```text
Expression: occursin("github.event_name == 'pull_request' || github.ref != 'refs/heads/master'", workflow)
```

Command:

```bash
GROUP=Core julia +1.10.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

## Passing after

```text
Test Summary: | Pass  Total
Core          |   17     17
Testing SciMLBenchmarks tests passed

Test Summary: | Pass  Total
QA            |   19     19
Testing SciMLBenchmarks tests passed
```

Additional local verification:

```text
actionlint .github/workflows/benchmarks.yml
# exit 0

julia +1.10.11 --project=../cancel-closed-pr-benchmarks/.validation/runic-env -e 'using Runic; exit(Runic.main(["--check", "test/core.jl"]))'
# exit 0

typos .github/workflows/benchmarks.yml test/core.jl
# exit 0

git diff --check
# exit 0
```

Not verified locally: an actual merged-PR close event, because that requires this workflow change to be on the default branch. No docs, public API, benchmark code, GPU, or downstream paths are changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
