### PR TITLE
Fix Bruss work-precision solver names

### DIFF
--- a/benchmarks/StiffODE/Bruss.jmd
+++ b/benchmarks/StiffODE/Bruss.jmd
@@ -465,7 +465,8 @@ setups = [
     Dict(:alg=>TSRKC3(), :prob_choice => 2),
 ]
 names = ["KenCarp47 KLU MTK", "KenCarp47 GMRES MTK",
-    "FBDF KLU MTK", "FBDF GMRES MTK",
+    "FBDF KLU MTK", "NordsieckBDF KLU MTK",
+    "FBDF GMRES MTK", "NordsieckBDF GMRES MTK",
     "CVODE MTK KLU", "CVODE iLU MTK GMRES",
     "ROCK4 MTK", "TSRKC3 MTK"
 ];
@@ -522,7 +523,8 @@ setups = [
     Dict(:alg=>TSRKC3(), :prob_choice => 2),
 ]
 names = ["KenCarp47 KLU MTK", "KenCarp47 GMRES MTK",
-    "FBDF KLU MTK", "FBDF GMRES MTK",
+    "FBDF KLU MTK", "NordsieckBDF KLU MTK",
+    "FBDF GMRES MTK", "NordsieckBDF GMRES MTK",
     "Rodas5P GMRES MTK",
     "CVODE MTK KLU", "CVODE iLU MTK GMRES",
     "ROCK4 MTK", "TSRKC3 MTK"

--- a/test/core.jl
+++ b/test/core.jl
@@ -53,6 +53,26 @@ end
     @test occursin("github.event.action != 'closed'", workflow)
 end
 
+@testset "StiffODE work-precision names" begin
+    benchmark = read(
+        joinpath(dirname(@__DIR__), "benchmarks", "StiffODE", "Bruss.jmd"), String
+    )
+    checked = 0
+    for chunk in eachmatch(r"(?ms)^```julia[^\n]*\n(?<code>.*?)^```", benchmark)
+        code = join(
+            (first(split(line, "#"; limit = 2)) for line in eachline(IOBuffer(chunk[:code]))),
+            "\n"
+        )
+        setups = match(r"(?ms)setups = \[(?<values>.*?)\]", code)
+        names = match(r"(?ms)names = \[(?<values>.*?)\]", code)
+        if !isnothing(setups) && !isnothing(names) && occursin("WorkPrecisionSet", code)
+            @test count("Dict(", setups[:values]) == count("\"", names[:values]) ÷ 2
+            checked += 1
+        end
+    end
+    @test checked == count("names = names", benchmark)
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed

The NordsieckBDF additions from https://github.com/SciML/SciMLBenchmarks.jl/commit/2bc643b16cfd5e058d2e3fda5659bae564c93848 added KLU and GMRES setups to two `Bruss.jmd` work-precision diagrams without adding the corresponding display names. `DiffEqDevTools.WorkPrecisionSet` therefore aborts before benchmarking because the setup and name counts differ.

This adds the four missing names in setup order and a Core regression test that checks every named work-precision block in `Bruss.jmd` has one name per setup.

## Verification

Narrow reproduction on unmodified upstream master `5ef7bd2cc6bf19d78c522ea3e16dee34dee44370`, Julia 1.11.9, using `benchmarks/StiffODE/Manifest.toml`:

```text
setups=10 names=8 => AssertionError: AssertionError("names === nothing || length(setups) == length(names)")
setups=11 names=9 => AssertionError: AssertionError("names === nothing || length(setups) == length(names)")
```

Failing-before, with only the new test applied to unmodified master:

```text
Test Summary:                      | Pass  Fail  Total   Time
Core                               |   21     2     23  54.6s
  StiffODE work-precision names    |    5     2      7   1.5s
ERROR: Package SciMLBenchmarks errored during testing
```

Passing-after, rebased onto current master:

```text
Test Summary: | Pass  Total   Time
Core          |   24     24  43.0s
     Testing SciMLBenchmarks tests passed
```

QA:

```text
Test Summary: | Pass  Total     Time
QA            |   19     19  1m03.3s
     Testing SciMLBenchmarks tests passed
```

Also passed:

```text
Runic --check test/core.jl
Typos benchmarks/StiffODE/Bruss.jmd test/core.jl
git diff --check
```

## Not verified

I did not run the complete `Bruss.jmd` weave because a full StiffODE verification run is already active in a separate worktree. This PR verifies the exact constructor invariant that aborted the page, but does not claim that all later solver runs in the page complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
