### PR TITLE
Fix E5 threaded extrapolation initialization order

### DIFF
--- a/benchmarks/StiffODE/E5.jmd
+++ b/benchmarks/StiffODE/E5.jmd
@@ -144,7 +144,7 @@ setups = [Dict(:alg=>Kvaerno4()),
         min_order = 4, init_order = 11, threading = OrdinaryDiffEqCore.PolyesterThreads())),
     Dict(:alg=>ImplicitEulerBarycentricExtrapolation(min_order = 4, init_order = 11, threading = false)),
     Dict(:alg=>ImplicitHairerWannerExtrapolation(
-        min_order = 3, init_order = 111, threading = OrdinaryDiffEqCore.PolyesterThreads())),
+        min_order = 3, init_order = 11, threading = OrdinaryDiffEqCore.PolyesterThreads())),
     Dict(:alg=>ImplicitHairerWannerExtrapolation(min_order = 3, init_order = 11, threading = false))
 ]
 wp = WorkPrecisionSet(probs, abstols, reltols, setups; verbose = SciMLLogging.None(), dense = false,

--- a/test/core.jl
+++ b/test/core.jl
@@ -73,19 +73,6 @@ end
     @test checked == count("names = names", benchmark)
 end
 
-@testset "StiffODE E5 extrapolation orders" begin
-    benchmark = read(joinpath(dirname(@__DIR__), "benchmarks", "StiffODE", "E5.jmd"), String)
-    init_orders = [
-        parse(Int, value[1]) for value in eachmatch(r"init_order\s*=\s*(\d+)", benchmark)
-    ]
-    @test length(init_orders) == 6
-    @test all(<=(15), init_orders)
-    @test occursin(
-        r"(?s)ImplicitHairerWannerExtrapolation\(.*?init_order\s*=\s*11,\s*threading\s*=\s*OrdinaryDiffEqCore\.PolyesterThreads\(\)",
-        benchmark
-    )
-end
-
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")

--- a/test/core.jl
+++ b/test/core.jl
@@ -73,6 +73,19 @@ end
     @test checked == count("names = names", benchmark)
 end
 
+@testset "StiffODE E5 extrapolation orders" begin
+    benchmark = read(joinpath(dirname(@__DIR__), "benchmarks", "StiffODE", "E5.jmd"), String)
+    init_orders = [
+        parse(Int, value[1]) for value in eachmatch(r"init_order\s*=\s*(\d+)", benchmark)
+    ]
+    @test length(init_orders) == 6
+    @test all(<=(15), init_orders)
+    @test occursin(
+        r"(?s)ImplicitHairerWannerExtrapolation\(.*?init_order\s*=\s*11,\s*threading\s*=\s*OrdinaryDiffEqCore\.PolyesterThreads\(\)",
+        benchmark
+    )
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed and why

The threaded ImplicitHairerWannerExtrapolation entry in StiffODE/E5.jmd used init_order = 111, while its non-threaded counterpart used 11. Solver initialization rejects orders above 15, so this benchmark entry always failed before running. This changes the threaded entry to 11 without removing OrdinaryDiffEqCore.PolyesterThreads() and adds a structural regression test for all six E5 extrapolation orders and the threaded Hairer-Wanner entry.

git bisect run identified https://github.com/SciML/SciMLBenchmarks.jl/commit/3d42af4b0a75179b5bd45087e56e36b6a2e68ba5 as the first commit containing init_order = 111.

## Verification

Failing before the fix, using the StiffODE manifest on Julia 1.11.9:

    ERROR: max_order > 15 not allowed for Float32 or Float64 with this algorithm.
    @ OrdinaryDiffEqExtrapolation .../extrapolation_caches.jl:747
    exit_status=1

The regression test also discriminates on the unfixed source:

    Test Summary:                      | Pass  Fail  Total
    Core                               |   25     2     27
      StiffODE E5 extrapolation orders |    1     2      3
    ERROR: Some tests did not pass: 25 passed, 2 failed

Passing after the fix, using the same threaded minimal solve:

    retcode = Success; final = 0.3678794411713607
    exit_status=0

After https://github.com/SciML/SciMLBenchmarks.jl/pull/1695 merged, I rebased this branch and ran the complete E5 page against the merged runtime changes:

    julia +1.11.9 --startup-file=no --threads=auto --project=. benchmark.jl benchmarks/StiffODE/E5.jmd
    Weaved all chunks
    Elapsed (wall clock): 5:36.73
    Maximum resident set size: 2583368 kbytes
    Exit status: 0

The generated artifact contains all four expected figures and loads Polyester.

Post-rebase tests:

    GROUP=Core julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
    Core | 27 passed / 27 total

    GROUP=QA julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
    QA | 21 passed / 21 total

Runic on test/core.jl, typos on the changed files, and git diff --check all exited 0.

## Not verified

No docs build was run because this changes benchmark input and an internal regression test, not documentation or public API. GPU paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
