### PR TITLE
Cancel superseded PR benchmark runs outside concurrency

### DIFF
--- a/.github/workflows/cancel-superseded-benchmarks.yml
+++ b/.github/workflows/cancel-superseded-benchmarks.yml
@@ -1,0 +1,61 @@
+name: Cancel Superseded Benchmark Runs
+
+on:
+  workflow_run:
+    workflows: [Benchmarks]
+    types: [requested]
+
+jobs:
+  cancel:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Cancel older runs for the pull request
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const source = context.payload.workflow_run;
+            const activeStatuses = new Set([
+              'in_progress', 'pending', 'queued', 'requested', 'waiting'
+            ]);
+            const pullRequests = new Set((source.pull_requests ?? []).map(pr => pr.number));
+            const { owner, repo } = context.repo;
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id: source.workflow_id,
+              branch: source.head_branch,
+              event: 'pull_request',
+              per_page: 100,
+            });
+
+            for (const run of runs) {
+              if (run.id === source.id || run.run_number >= source.run_number ||
+                  !activeStatuses.has(run.status)) {
+                continue;
+              }
+              const samePullRequest = (run.pull_requests ?? [])
+                .some(pr => pullRequests.has(pr.number));
+              const sameHead = source.head_repository && run.head_repository &&
+                run.head_branch === source.head_branch &&
+                run.head_repository.id === source.head_repository.id;
+              if (!samePullRequest && !sameHead) {
+                continue;
+              }
+
+              core.info(`Force-cancelling superseded benchmark run ${run.id}`);
+              try {
+                await github.request(
+                  'POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel',
+                  { owner, repo, run_id: run.id }
+                );
+              } catch (error) {
+                if (error.status !== 409 && error.status !== 422) {
+                  throw error;
+                }
+                core.info(`Run ${run.id} finished before cancellation`);
+              }
+            }

--- a/test/core.jl
+++ b/test/core.jl
@@ -45,12 +45,27 @@ end
     end
 end
 
-@testset "closed pull request cancellation" begin
+@testset "superseded pull request cancellation" begin
     workflow = read(joinpath(dirname(@__DIR__), ".github", "workflows", "benchmarks.yml"), String)
     @test occursin("types: [opened, synchronize, reopened, closed]", workflow)
     @test occursin("format('pr-{0}', github.event.pull_request.number)", workflow)
     @test occursin("github.event_name == 'pull_request' || github.ref != 'refs/heads/master'", workflow)
     @test occursin("github.event.action != 'closed'", workflow)
+
+    cancellation_path = joinpath(
+        dirname(@__DIR__), ".github", "workflows", "cancel-superseded-benchmarks.yml"
+    )
+    @test isfile(cancellation_path)
+    if isfile(cancellation_path)
+        cancellation = read(cancellation_path, String)
+        @test occursin("workflow_run:", cancellation)
+        @test occursin("workflows: [Benchmarks]", cancellation)
+        @test occursin("types: [requested]", cancellation)
+        @test occursin("actions: write", cancellation)
+        @test occursin("run.run_number >= source.run_number", cancellation)
+        @test occursin("run.pull_requests", cancellation)
+        @test occursin("/force-cancel", cancellation)
+    end
 end
 
 @testset "StiffODE work-precision names" begin


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed and why

Pull-request workflow concurrency does not cancel benchmark runs that are still in GitHub's queued state. The replacement run remains pending behind the older run, so synchronize and close events cannot execute the cancellation behavior they were intended to provide. This is visible on https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33165938708, which remains queued while its replacement https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33171156568 is pending.

This adds a separate default-branch workflow_run watcher. When a Benchmarks workflow is requested for a pull request, the watcher finds only older active runs for the same pull request (or the same repository/branch identity when GitHub omits pull_requests from the payload) and force-cancels them. It does not check out or execute pull-request code, and its Actions-write permission is scoped to the cancellation job.

## Verification

Failing before the workflow was added:

    GROUP=Core julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
    superseded pull request cancellation | 4 passed, 1 failed
    Core | 24 passed, 1 failed
    ERROR: Package SciMLBenchmarks errored during testing

Passing after:

    GROUP=Core julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
    Core | 32 passed / 32 total
    Testing SciMLBenchmarks tests passed

    GROUP=QA julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
    QA | 21 passed / 21 total
    Testing SciMLBenchmarks tests passed

A local JavaScript mock supplied older queued and pending runs plus completed, newer, unrelated, and current runs. The watcher selected exactly the two older active runs:

    cancelled=100,110

Additional checks:

    actionlint .github/workflows/cancel-superseded-benchmarks.yml .github/workflows/benchmarks.yml
    Runic --check test/core.jl
    typos .github/workflows/cancel-superseded-benchmarks.yml test/core.jl
    node --check on the extracted github-script body wrapped as an async function
    git diff --check

All exited 0.

## Not verified

Live cancellation cannot be tested until the watcher exists on the repository's default branch. No benchmark, documentation, or GPU execution path is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
