### PR TITLE
Remove obsolete ComplicatedPDE GenericSchur pin

### DIFF
--- a/benchmarks/ComplicatedPDE/Manifest.toml
+++ b/benchmarks/ComplicatedPDE/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "106746c3c454dc963a91fa0c12bfcb39111106b2"
+project_hash = "ae7b034da38d0165a8d645af88438e3501461a80"
 
 [[deps.ADTypes]]
 deps = ["PrecompileTools"]
@@ -908,10 +908,10 @@ uuid = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
 version = "2.2.7"
 
 [[deps.GenericSchur]]
-deps = ["LinearAlgebra", "Printf"]
-git-tree-sha1 = "a694e2a57394e409f7a11ee0977362a9fafcb8c7"
+deps = ["LinearAlgebra", "MatrixFactorizations", "Preferences", "Printf", "UUIDs"]
+git-tree-sha1 = "e3d1202ab9ae72edd4c46134ecbb6746ec420486"
 uuid = "c145ed77-6b09-5dd9-b285-bf645a82121e"
-version = "0.5.6"
+version = "0.5.8"
 
 [[deps.GettextRuntime_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll"]
@@ -1446,6 +1446,16 @@ version = "0.1.8"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
+
+[[deps.MatrixFactorizations]]
+deps = ["ArrayLayouts", "LinearAlgebra", "Printf", "Random"]
+git-tree-sha1 = "3bb3cf4685f1c90f22883f4c4bb6d203fa882b79"
+uuid = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
+version = "3.1.3"
+weakdeps = ["BandedMatrices"]
+
+    [deps.MatrixFactorizations.extensions]
+    MatrixFactorizationsBandedMatricesExt = "BandedMatrices"
 
 [[deps.MaybeInplace]]
 deps = ["ArrayInterface", "LinearAlgebra", "MacroTools", "PrecompileTools"]

--- a/benchmarks/ComplicatedPDE/Project.toml
+++ b/benchmarks/ComplicatedPDE/Project.toml
@@ -2,7 +2,6 @@
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 GaussianRandomFields = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
-GenericSchur = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 LSODA = "7f56f5a3-f504-529b-bc02-0b1fe5e64312"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
@@ -31,10 +30,6 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 ADTypes = "1"
 DiffEqDevTools = "3"
 GaussianRandomFields = "2"
-# GenericSchur 0.5.7 pirates LinearAlgebra.eigen!(::SymTridiagonal) and forwards
-# `sortby` to a geigen! method that does not accept it, which breaks
-# ExponentialUtilities (and hence OrdinaryDiffEqExponentialRK) on Julia 1.11.
-GenericSchur = "=0.5.6"
 IJulia = "1"
 LSODA = "1"
 LinearSolve = "5"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed and why

The [GenericSchur 0.5.8 release](https://github.com/RalphAS/GenericSchur.jl/releases/tag/v0.5.8) fixes the [`eigen!(::SymTridiagonal)` regression](https://github.com/RalphAS/GenericSchur.jl/issues/24) that required ComplicatedPDE to pin 0.5.6. This removes the temporary direct dependency and exact compat pin, returning GenericSchur to a transitive dependency, and updates the manifest to 0.5.8.

GenericSchur 0.5.8 adds MatrixFactorizations transitively. Both packages use MIT-family licenses; no copyleft dependency is introduced.

## Failing before / passing after

On Julia 1.11.9, the standalone non-strided `SymTridiagonal` reproducer fails with GenericSchur 0.5.7:

```text
ERROR: MethodError: no method matching geigen!(::SymTridiagonal{Float64, SubArray{...}},
                                               ::LinearAlgebra.QRIteration;
                                               sortby::typeof(identity))
... got unsupported keyword argument "sortby"
```

The identical reproducer with GenericSchur 0.5.8 passes:

```text
F.values = [0.2679491924311228, 1.0000000000000004, 2.0,
            3.0, 3.732050807568878]
```

## Verification

Resolving the ComplicatedPDE environment changed only the intended dependency chain:

```text
GenericSchur v0.5.6 ⇒ v0.5.8
+ MatrixFactorizations v3.1.3
```

```console
$ julia +1.11.9 --project=benchmarks/ComplicatedPDE -e \
    'using Pkg; Pkg.precompile(); using OrdinaryDiffEqExponentialRK'
3 dependencies successfully precompiled in 77 seconds. 516 already precompiled.
OrdinaryDiffEqExponentialRK loads with GenericSchur 0.5.8

$ GROUP=Core julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Core | 24 passed / 24 total
Testing SciMLBenchmarks tests passed

$ GROUP=QA julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
QA | 21 passed / 21 total
Testing SciMLBenchmarks tests passed

$ typos benchmarks/ComplicatedPDE/{Project,Manifest}.toml
# exit 0
$ git diff --check
# exit 0
```

## Not verified

The exact ComplicatedPDE folder weave is still running locally and is not claimed as passed. No source, documentation, public API, or GPU path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
