### PR TITLE
Pin V100 benchmarks to CUDA 12.9

### DIFF
--- a/benchmarks/DiffEqGPU/LocalPreferences.toml
+++ b/benchmarks/DiffEqGPU/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/DiffEqGPU/Project.toml
+++ b/benchmarks/DiffEqGPU/Project.toml
@@ -21,3 +21,6 @@ PythonCall = "0.9"
 SciMLBenchmarks = "0.1"
 StaticArrays = "1"
 StochasticDiffEq = "6"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/benchmarks/PINNErrorsVsTime/LocalPreferences.toml
+++ b/benchmarks/PINNErrorsVsTime/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/PINNErrorsVsTime/Project.toml
+++ b/benchmarks/PINNErrorsVsTime/Project.toml
@@ -41,3 +41,6 @@ Plots = "1"
 QuasiMonteCarlo = "0.3"
 ReverseDiff = "1"
 SciMLBenchmarks = "0.1"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/benchmarks/PINNOptimizers/LocalPreferences.toml
+++ b/benchmarks/PINNOptimizers/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/PINNOptimizers/Project.toml
+++ b/benchmarks/PINNOptimizers/Project.toml
@@ -27,3 +27,6 @@ OptimizationOptimJL = "0.4"
 OptimizationOptimisers = "0.3"
 Plots = "1"
 SciMLBenchmarks = "0.1"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/test/core.jl
+++ b/test/core.jl
@@ -105,6 +105,17 @@ end
     end
 end
 
+@testset "V100 CUDA runtime preferences" begin
+    benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
+    cuda_runtime = "CUDA_Runtime_jll = \"76a88914-d11a-5bdc-97e0-2f5a05c973a2\""
+    for folder in ("DiffEqGPU", "PINNErrorsVsTime", "PINNOptimizers")
+        preferences = read(joinpath(benchmarks_dir, folder, "LocalPreferences.toml"), String)
+        project = read(joinpath(benchmarks_dir, folder, "Project.toml"), String)
+        @test occursin("version = \"12.9\"", preferences)
+        @test occursin(cuda_runtime, project)
+    end
+end
+
 @testset "StiffODE work-precision names" begin
     benchmark = read(
         joinpath(dirname(@__DIR__), "benchmarks", "StiffODE", "Bruss.jmd"), String


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Pin `CUDA_Runtime_jll` to CUDA 12.9 in the three benchmark environments assigned to the V100 runner: DiffEqGPU, PINNErrorsVsTime, and PINNOptimizers. CUDA 13 dropped compute capability 7.0, so the automatic CUDA 13.2 selection rejected the runner's Tesla V100 before any benchmark could execute.

The runtime wrapper is listed in each environment's extras so the named local preference resolves without adding another loaded benchmark dependency. `CUDA_Runtime_jll` is already a transitive dependency of CUDA.jl; its Julia wrapper is MIT-licensed, and this does not introduce or un-gate a new binary dependency.

## Failure reproduced

The hosted PINNOptimizers job on the V100 failed before this change with:

```text
Your Tesla V100-PCIE-32GB GPU (compute capability 7.0) is not supported on CUDA 13+.
Compute capability 7.0.0 is not supported by CUDA 13.2.0
```

Job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33152526854/job/98787667132

The new regression test was also run against the unfixed checkout:

```text
V100 CUDA runtime preferences: Error During Test
SystemError: opening file ".../benchmarks/DiffEqGPU/LocalPreferences.toml": No such file or directory
Test Summary:                 | Error  Total
V100 CUDA runtime preferences |     1      1
```

The same test with this change:

```text
Test Summary:                 | Pass  Total
V100 CUDA runtime preferences |    6      6
```

## Verification

Each environment was resolved and instantiated with Julia 1.11.9, then queried through Preferences.jl:

```text
PROJECT DiffEqGPU
No Changes to Project.toml
No Changes to Manifest.toml
CUDA runtime preference = 12.9
PROJECT PINNErrorsVsTime
No Changes to Project.toml
No Changes to Manifest.toml
CUDA runtime preference = 12.9
PROJECT PINNOptimizers
No Changes to Project.toml
No Changes to Manifest.toml
CUDA runtime preference = 12.9
```

All three PR jobs subsequently ran on a physical Tesla V100. They installed `CUDA_Runtime_jll v0.21.0+1`, passed the former Julia CUDA 13 compute-capability rejection, loaded CUDA.jl, and reached benchmark GPU operations. This validates the preference change, but the folder jobs remain red because it exposed separate benchmark and dependency failures:

- DiffEqGPU reached both `crn_sde.jmd` and `lorenz_ensemble.jmd`, which failed on singleton `range(start, stop, length = 1)` calls. That source bug is addressed separately by https://github.com/SciML/SciMLBenchmarks.jl/pull/1715. Its Python section also selected `torch==2.13.0+cu130`, which warns that it has no kernels for compute capability 7.0; that Python CUDA pin is not addressed here.
- PINNOptimizers and PINNErrorsVsTime reached Lux GPU evaluation, then failed in Float64 `LuxLib.cublaslt_matmul_fused!` with `CUBLAS_STATUS_INVALID_VALUE`. PINNErrorsVsTime also has one independent `Array(::Float64)` failure. These are not the original CUDA 13 runtime-selection error and are not hidden by this configuration PR.

Physical-GPU jobs:

- https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33189080328/job/98935140077
- https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33189080328/job/98935140065
- https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33189080328/job/98935140080

Repository checks:

```text
GROUP=Core julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Core | 51 passed / 51 total

GROUP=QA julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
QA | 21 passed / 21 total

Runic --check --diff test/core.jl
exit 0

typos $(git diff --name-only HEAD^)
exit 0

git diff --check
exit 0
```

## Not verified locally

This machine has no NVIDIA device or `nvidia-smi`, so no CUDA kernel was executed locally. The hosted jobs provide the physical-V100 evidence above, but none of the three complete benchmark folders currently passes because of the independent failures listed above. No docs build was run because this changes only benchmark-local configuration and its regression test, with no documentation or public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512