### PR TITLE
Fix E5 threaded extrapolation order

### DIFF
--- a/benchmarks/StiffODE/E5.jmd
+++ b/benchmarks/StiffODE/E5.jmd
@@ -144,7 +144,7 @@ setups = [Dict(:alg=>Kvaerno4()),
         min_order = 4, init_order = 11, threading = OrdinaryDiffEqCore.PolyesterThreads())),
     Dict(:alg=>ImplicitEulerBarycentricExtrapolation(min_order = 4, init_order = 11, threading = false)),
     Dict(:alg=>ImplicitHairerWannerExtrapolation(
-        min_order = 3, init_order = 111, threading = OrdinaryDiffEqCore.PolyesterThreads())),
+        min_order = 3, init_order = 11, threading = OrdinaryDiffEqCore.PolyesterThreads())),
     Dict(:alg=>ImplicitHairerWannerExtrapolation(min_order = 3, init_order = 11, threading = false))
 ]
 wp = WorkPrecisionSet(probs, abstols, reltols, setups; verbose = SciMLLogging.None(), dense = false,

--- a/test/core.jl
+++ b/test/core.jl
@@ -73,19 +73,6 @@ end
     @test checked == count("names = names", benchmark)
 end
 
-@testset "StiffODE E5 extrapolation orders" begin
-    benchmark = read(joinpath(dirname(@__DIR__), "benchmarks", "StiffODE", "E5.jmd"), String)
-    init_orders = [
-        parse(Int, value[1]) for value in eachmatch(r"init_order\s*=\s*(\d+)", benchmark)
-    ]
-    @test length(init_orders) == 6
-    @test all(<=(15), init_orders)
-    @test occursin(
-        r"(?s)ImplicitHairerWannerExtrapolation\(.*?init_order\s*=\s*11,\s*threading\s*=\s*OrdinaryDiffEqCore\.PolyesterThreads\(\)",
-        benchmark
-    )
-end
-
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")

--- a/test/core.jl
+++ b/test/core.jl
@@ -73,6 +73,19 @@ end
     @test checked == count("names = names", benchmark)
 end
 
+@testset "StiffODE E5 extrapolation orders" begin
+    benchmark = read(joinpath(dirname(@__DIR__), "benchmarks", "StiffODE", "E5.jmd"), String)
+    init_orders = [
+        parse(Int, value[1]) for value in eachmatch(r"init_order\s*=\s*(\d+)", benchmark)
+    ]
+    @test length(init_orders) == 6
+    @test all(<=(15), init_orders)
+    @test occursin(
+        r"(?s)ImplicitHairerWannerExtrapolation\(.*?init_order\s*=\s*11,\s*threading\s*=\s*OrdinaryDiffEqCore\.PolyesterThreads\(\)",
+        benchmark
+    )
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The threaded `ImplicitHairerWannerExtrapolation` setup in `E5.jmd` used `init_order = 111`, while the adjacent unthreaded setup used the intended order 11. The constructor consequently raised `max_order` to 112, and OrdinaryDiffEq correctly rejected that order for `Float64`. This changes the threaded setup to order 11 without removing `PolyesterThreads`, and adds a Core regression test covering the E5 extrapolation orders.

The bad value was introduced in https://github.com/SciML/SciMLBenchmarks.jl/commit/3d42af4b0a75179b5bd45087e56e36b6a2e68ba5. The OrdinaryDiffEq guard predates it: https://github.com/SciML/OrdinaryDiffEq.jl/commit/e0499c0e6a31aa09bcffcfcc9da60e918db3eb6c.

## Verification

Failing before the benchmark fix, with the regression test added:

```text
GROUP=Core julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
StiffODE E5 extrapolation orders: Test Failed
  Expression: all((<=)(15), init_orders)
StiffODE E5 extrapolation orders: Test Failed
  Expression: occursin(... init_order = 11 ... PolyesterThreads(), benchmark)
Core | 25 pass, 2 fail, 27 total
Exit status: 1
```

The exact current-master E5 page also failed before the fix:

```text
julia +1.11.9 --startup-file=no --threads=auto --project=. benchmark.jl benchmarks/StiffODE/E5.jmd
ERROR: LoadError: max_order > 15 not allowed for Float32 or Float64 with this algorithm. That's a bad idea.
Elapsed: 16:58.19
Exit status: 1
```

Passing with the fix:

```text
GROUP=Core julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Core | 27 pass, 27 total
Exit status: 0

GROUP=QA julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA | 21 pass, 21 total
Exit status: 0

julia +1.11.9 --startup-file=no --threads=auto --project=. benchmark.jl benchmarks/StiffODE/E5.jmd
Weaved all chunks
Elapsed: 15:13.29
Maximum resident set size: 4,458,976 KiB
Exit status: 0
```

The successful weave produced error-free markdown with four referenced, nonempty 576×384 PNG plots. I visually inspected all four plots, including the threaded and unthreaded Hairer–Wanner results.

```text
Runic 1.9.0 --check test/core.jl: exit 0
typos test/core.jl benchmarks/StiffODE/E5.jmd: exit 0
git diff --check: exit 0
```

## Not verified

The complete StiffODE folder was not rerun; verification targets the exact failing E5 page. CI has not run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
