### PR TITLE
Skip oversized OPF models before construction

### DIFF
--- a/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
+++ b/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
@@ -2423,17 +2423,17 @@ function multidata_multisolver_benchmark(dataset_files; sizelimit = SIZE_LIMIT)
         @show file
         dataset = load_and_setup_data(file)
 
-        prob = build_opf_optimization_prob(dataset)
-        @info "Number of Variables: $(length(prob.u0))"
-        @info "Number of Constraints: $(length(prob.lcons))"
+        model_variables = length(dataset.var_init)
+        @info "Number of Variables: $(model_variables)"
 
-        if length(prob.u0) > sizelimit
+        if model_variables > sizelimit
             @info "Variable size over global limit. Skipping for now"
             continue
         end
 
         @info "Running Optimization.jl"
         model, res = solve_opf_optimization(dataset)
+        @info "Number of Constraints: $(res["constraints"])"
         push!(cases, split(file, "/")[end])
         push!(vars, res["variables"])
         push!(cons, res["constraints"])
@@ -2472,9 +2472,8 @@ function multidata_multisolver_benchmark(dataset_files; sizelimit = SIZE_LIMIT)
         push!(nonconvex_cost, res["cost"])
         =#
 
-        if length(prob.u0) > 400
-            @info "Running Optim.jl"
-            model, res = solve_opf_optim(dataset)
+        if model_variables > 400
+            @info "Variable size over Optim.jl limit. Skipping for now"
             push!(optim_time, NaN)
             push!(optim_time_modelbuild, NaN)
             push!(optim_time_compilation, NaN)

--- a/test/core.jl
+++ b/test/core.jl
@@ -93,6 +93,34 @@ end
     @test checked == count("names = names", benchmark)
 end
 
+@testset "OptimizationFrameworks size guard" begin
+    benchmark = read(
+        joinpath(
+            dirname(@__DIR__), "benchmarks", "OptimizationFrameworks", "optimal_powerflow.jmd"
+        ),
+        String
+    )
+    loop_body = split(benchmark, "function multidata_multisolver_benchmark"; limit = 2)[2]
+    loop_body = split(loop_body, "test_datasets ="; limit = 2)[1]
+    size_guard = findfirst(r"if [^\n]+ > sizelimit", loop_body)
+    @test !isnothing(size_guard)
+    if !isnothing(size_guard)
+        before_guard = SubString(loop_body, firstindex(loop_body), first(size_guard) - 1)
+        @test occursin("model_variables = length(dataset.var_init)", before_guard)
+        @test !occursin("build_opf_optimization_prob(dataset)", before_guard)
+    end
+    @test !occursin(r"\bprob\b", loop_body)
+
+    optim_guard = match(
+        r"(?s)if model_variables > 400(?<large>.*?)else(?<small>.*?)end", loop_body
+    )
+    @test !isnothing(optim_guard)
+    if !isnothing(optim_guard)
+        @test !occursin("solve_opf_optim", optim_guard[:large])
+        @test occursin("solve_opf_optim", optim_guard[:small])
+    end
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")

--- a/test/core.jl
+++ b/test/core.jl
@@ -93,34 +93,6 @@ end
     @test checked == count("names = names", benchmark)
 end
 
-@testset "OptimizationFrameworks size guard" begin
-    benchmark = read(
-        joinpath(
-            dirname(@__DIR__), "benchmarks", "OptimizationFrameworks", "optimal_powerflow.jmd"
-        ),
-        String
-    )
-    loop_body = split(benchmark, "function multidata_multisolver_benchmark"; limit = 2)[2]
-    loop_body = split(loop_body, "test_datasets ="; limit = 2)[1]
-    size_guard = findfirst(r"if [^\n]+ > sizelimit", loop_body)
-    @test !isnothing(size_guard)
-    if !isnothing(size_guard)
-        before_guard = SubString(loop_body, firstindex(loop_body), first(size_guard) - 1)
-        @test occursin("model_variables = length(dataset.var_init)", before_guard)
-        @test !occursin("build_opf_optimization_prob(dataset)", before_guard)
-    end
-    @test !occursin(r"\bprob\b", loop_body)
-
-    optim_guard = match(
-        r"(?s)if model_variables > 400(?<large>.*?)else(?<small>.*?)end", loop_body
-    )
-    @test !isnothing(optim_guard)
-    if !isnothing(optim_guard)
-        @test !occursin("solve_opf_optim", optim_guard[:large])
-        @test occursin("solve_opf_optim", optim_guard[:small])
-    end
-end
-
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

The optimal-power-flow benchmark now checks `length(dataset.var_init)` before constructing an `OptimizationProblem`. Previously the size guard inspected `prob.u0` only after `build_opf_optimization_prob(dataset)` had already built the oversized Enzyme-backed model, so the cases the guard was meant to skip could exhaust memory first.

The separate 400-variable Optim.jl guard now skips the Optim.jl solve instead of running it and then discarding its result. Oversized Optim.jl entries remain explicit `NaN` values in the result table.

## Regression test

With the test retained and the benchmark source restored to current `master`:

```text
GROUP=Core julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:                          | Pass  Fail  Total   Time
Core                                   |   34     4     38  53.5s
  OptimizationFrameworks size guard    |    1     4      5   2.2s
ERROR: LoadError: Some tests did not pass: 34 passed, 4 failed
```

With this fix applied:

```text
GROUP=Core julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |   40     40  54.2s
Testing SciMLBenchmarks tests passed
```

## Benchmark verification

I ran the complete `optimal_powerflow.jmd` page in a validation worktree using the staged OptimizationBase Enzyme fix from https://github.com/SciML/Optimization.jl/pull/1328. It completed in approximately 2 hours 30 minutes:

```text
chunks:                         47
selected cases in final table:  10
valid Optimization.jl solves:   12
global size skips:              56
Optim.jl size skips:             3
runtime error markers:           0
[ Info: Weaved all chunks
[ Info: Weaved to .../markdown/OptimizationFrameworks/optimal_powerflow.md
```

The three Optim.jl skips were the expected 448-, 518-, and 824-variable cases. The generated 10-row table retained those cases with `NaN` Optim.jl columns, while the other frameworks completed.

## Other local checks

```text
GROUP=QA julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
QA | 21 passed / 21 total

Runic 1.10.0 --check test/core.jl
clean

typos benchmarks/OptimizationFrameworks/optimal_powerflow.jmd test/core.jl
clean

git diff --check
clean
```

No GPU path was exercised. This PR does not include the stacked OptimizationBase change from https://github.com/SciML/Optimization.jl/pull/1328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
