### PR TITLE
Validate DiffEqGPU CUDA 12 singleton fixes together

### DIFF
--- a/benchmarks/DiffEqGPU/LocalPreferences.toml
+++ b/benchmarks/DiffEqGPU/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[CUDA_Runtime_jll]
+__clear__ = ["local"]
+version = "12.9"

--- a/benchmarks/DiffEqGPU/Project.toml
+++ b/benchmarks/DiffEqGPU/Project.toml
@@ -21,3 +21,6 @@ PythonCall = "0.9"
 SciMLBenchmarks = "0.1"
 StaticArrays = "1"
 StochasticDiffEq = "6"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"

--- a/benchmarks/DiffEqGPU/crn_sde.jmd
+++ b/benchmarks/DiffEqGPU/crn_sde.jmd
@@ -82,8 +82,8 @@ function crn_g(u, p, t)
 end
 
 function crn_parameters(N; T::Type = Float32)
-    S_grid = T.(10 .^ range(T(-1), stop = T(2), length = N))
-    D_grid = T.(10 .^ range(T(-1), stop = T(2), length = N))
+    S_grid = T.(10 .^ range(T(-1), stop = T(2), length = max(N, 2))[1:N])
+    D_grid = T.(10 .^ range(T(-1), stop = T(2), length = max(N, 2))[1:N])
     τ_grid = T[0.1, 0.15, 0.20, 0.30, 0.50, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 7.50,
                10.0, 15.0, 20.0, 30.0, 50.0, 75.0, 100.0][1:2:19]
     v0_grid = T[0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.15, 0.20]

--- a/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
+++ b/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
@@ -58,7 +58,7 @@ function make_ensemble(n; T::Type = Float32)
     u0 = SVector{3, T}(1, 0, 0)
     tspan = (zero(T), one(T))
     p = SVector{1, T}(21)
-    plist = range(zero(T), T(21); length = n)
+    plist = range(zero(T), T(21); length = max(n, 2))[1:n]
     prob = ODEProblem{false}(lorenz, u0, tspan, p)
     prob_func = (prob, i, repeat) -> remake(prob, p = SVector{1, T}(plist[i]))
     return EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)

--- a/test/core.jl
+++ b/test/core.jl
@@ -98,6 +98,16 @@ end
     end
 end
 
+@testset "DiffEqGPU V100 CUDA runtime preference" begin
+    benchmark_dir = joinpath(dirname(@__DIR__), "benchmarks", "DiffEqGPU")
+    preferences = read(joinpath(benchmark_dir, "LocalPreferences.toml"), String)
+    project = read(joinpath(benchmark_dir, "Project.toml"), String)
+    @test occursin("version = \"12.9\"", preferences)
+    @test occursin(
+        "CUDA_Runtime_jll = \"76a88914-d11a-5bdc-97e0-2f5a05c973a2\"", project
+    )
+end
+
 @testset "StiffODE work-precision names" begin
     benchmark = read(
         joinpath(dirname(@__DIR__), "benchmarks", "StiffODE", "Bruss.jmd"), String

--- a/test/core.jl
+++ b/test/core.jl
@@ -33,6 +33,31 @@ end
     end
 end
 
+function benchmark_assignment(path, variable)
+    prefix = string(variable, " = ")
+    line = only(line for line in eachline(path) if startswith(strip(line), prefix))
+    return Meta.parse(strip(split(line, "="; limit = 2)[2]))
+end
+
+@testset "DiffEqGPU singleton parameter grids" begin
+    benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks", "DiffEqGPU")
+
+    crn_path = joinpath(benchmarks_dir, "crn_sde.jmd")
+    for variable in ("S_grid", "D_grid")
+        crn_expression = benchmark_assignment(crn_path, variable)
+        crn_grid = Core.eval(@__MODULE__, :((N, T) -> $crn_expression))
+        @test crn_grid(1, Float32) == Float32[0.1]
+        @test crn_grid(2, Float32) == Float32[0.1, 100]
+    end
+
+    lorenz_expression = benchmark_assignment(
+        joinpath(benchmarks_dir, "lorenz_ensemble.jmd"), "plist"
+    )
+    lorenz_grid = Core.eval(@__MODULE__, :((n, T) -> $lorenz_expression))
+    @test collect(lorenz_grid(1, Float32)) == Float32[0]
+    @test collect(lorenz_grid(4, Float32)) == Float32[0, 7, 14, 21]
+end
+
 @testset "subprocess" begin
     process = SciMLBenchmarks.@subprocess exit()
     @test success(process)


### PR DESCRIPTION
> [!IMPORTANT]
> Validation-only PR. Do not merge. Ignore until reviewed by @ChrisRackauckas.

## Purpose

This composes the DiffEqGPU portion of the CUDA 12.9 pin from https://github.com/SciML/SciMLBenchmarks.jl/pull/1733 with the singleton parameter-grid fix from https://github.com/SciML/SciMLBenchmarks.jl/pull/1715. The production changes remain separate; this draft exists only because workflow dispatch is admin-gated and each production PR alone fails before exercising the other change.

Only `benchmarks/DiffEqGPU` is touched, so CI schedules one V100 folder job instead of rerunning the two PINN folders with known independent failures.

## Failing before the grid fix

```text
DiffEqGPU singleton parameter grids: Error During Test
  ArgumentError: range(-1.0, stop=2.0, length=1): endpoints differ
  ArgumentError: range(0.0, stop=21.0, length=1): endpoints differ

Test Summary:                         | Pass  Error  Total
Core                                  |   12      2     14
  DiffEqGPU singleton parameter grids |    2      2      4
```

The unpinned V100 run failed because CUDA 13 no longer supports compute capability 7.0: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33142802264.

## Local verification

```text
$ GROUP=Core julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
Core          |   41     41  1m06.8s
Testing SciMLBenchmarks tests passed

$ GROUP=QA julia +1.11.9 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m51.1s
Testing SciMLBenchmarks tests passed

$ julia +1.11.9 --project=../.runic-env -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff test/core.jl
# exit 0

$ typos <changed files>
# exit 0

$ git diff --check
# exit 0
```

## Not verified locally

This host has no CUDA GPU. The V100 benchmark job is the required end-to-end validation and is the sole reason for this draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
