### PR TITLE
Document Weave validation for benchmark changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent instructions
+
+## Validating benchmark changes
+
+For changes confined to benchmark sources or their environments under `benchmarks/`, the authoritative test is that every affected benchmark Weaves without error. Run the same entrypoint used by CI:
+
+```sh
+julia --threads=auto --project=. benchmark.jl benchmarks/<folder>/<benchmark>.jmd
+```
+
+Run the folder instead when a dependency or environment change can affect multiple pages:
+
+```sh
+julia --threads=auto --project=. benchmark.jl benchmarks/<folder>
+```
+
+If the benchmark directory has a `setup.sh`, reproduce the complete CI sequence with `.github/scripts/build_benchmark.sh <target>`.
+
+Do not add tests under `test/` that merely inspect benchmark source text or assert dependency strings in a benchmark `Project.toml` or `Manifest.toml`. Those checks do not establish that the benchmark executes successfully. Add unit tests when changing the shared benchmark harness or another independently testable code path; otherwise, report the exact Weave command and result in the pull request.


### PR DESCRIPTION
## What changed and why

Add a root `AGENTS.md` that defines repository-specific validation for benchmark-only changes. The authoritative check is to run the affected `.jmd` page or folder through the same Weave entrypoint used by CI, rather than adding tests that inspect benchmark source text or dependency strings.

The guidance preserves unit tests for changes to the shared benchmark harness or other independently testable code. It also records when to use `.github/scripts/build_benchmark.sh` so per-folder setup runs before Weave.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Verification

```text
typos AGENTS.md
exit 0

git diff --cached --check
exit 0

GROUP=QA julia +1.10.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
QA            |   19     19  57.8s
Testing SciMLBenchmarks tests passed
```

Runic was not run because the PR changes only Markdown. A docs build was not run because `AGENTS.md` is repository policy and is not part of the rendered documentation. No benchmark behavior changes in this PR.

## Links

- Commit: https://github.com/ChrisRackauckas-Claude/SciMLBenchmarks.jl/commit/edaf873e

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5; session: 01a04ff8-cd1c-74c0-9f3b-afc48cf1bbff, transcript: /home/crackauc/.codex/sessions/2026/08/29/rollout-2026-08-29T20-01-40-01a04ff8-cd1c-74c0-9f3b-afc48cf1bbff.jsonl)
