### PR TITLE
SimpleHandwrittenPDE: restore ranges after solver fixes

### DIFF
--- a/benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/kdv_fdm_wpd.jmd
@@ -26,7 +26,7 @@ The spatial derivative operators are represented via finite difference approxima
 
 ```julia
 using OrdinaryDiffEq
-using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
 using DiffEqDevTools
 using SciMLOperators
 using LinearSolve
@@ -73,7 +73,7 @@ L = 16.0  # Domain length
 alpha = 5.0 # Time scaling factor
 xs, prob = kortwrieg_de_vries(N, L, alpha)
 
-@time sol = solve(prob, AutoVern7(RadauIIA5(autodiff=AutoFiniteDiff())); 
+@time sol = solve(prob, AutoVern7(Rodas5P(autodiff=AutoFiniteDiff()));
                   dt = 1e-4, abstol = 1e-14, reltol = 1e-14);
 
 test_sol = TestSolution(sol) # Reference solution for error estimation
@@ -170,7 +170,7 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 
 #### Implicit-Explicit Methods
 
-Dense and Krylov linear solvers.
+OrdinaryDiffEq defaults and Sundials Krylov linear solvers.
 ```julia
 abstols = 0.1 .^ (8:12)
 reltols = 0.1 .^ (5:9)
@@ -183,9 +183,9 @@ setups = [
     Dict(:alg => ARKODE(Sundials.Implicit(), order=5, linear_solver=:GMRES)),
 ]
 labels = hcat(
-    "KenCarp3 (dense)",
-    "KenCarp4 (dense)",
-    "KenCarp5 (dense)",
+    "KenCarp3 (default)",
+    "KenCarp4 (default)",
+    "KenCarp5 (default)",
     "ARKODE3 (Krylov)",
     "ARKODE4 (Krylov)",
     "ARKODE5 (Krylov)",

--- a/benchmarks/SimpleHandwrittenPDE/kdv_spectral_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/kdv_spectral_wpd.jmd
@@ -5,7 +5,7 @@ author: Arjit Seth
 
 ```julia
 using OrdinaryDiffEq
-using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqSDIRK
+using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqRosenbrock, OrdinaryDiffEqSDIRK
 using DiffEqDevTools
 using SciMLOperators
 using LinearSolve
@@ -69,7 +69,7 @@ n = 128 # Number of Chebyshev points
 alpha = 5.0 # Time scaling factor
 xs, prob = korteweg_de_vries(n, L, alpha)
 
-@time sol = solve(prob, AutoVern7(RadauIIA5(autodiff=AutoFiniteDiff())); 
+@time sol = solve(prob, AutoVern7(Rodas5P(autodiff=AutoFiniteDiff()));
                   dt = 1e-4, reltol = 1e-12, abstol = 1e-12);
 
 test_sol = TestSolution(sol) # Reference solution for error estimation

--- a/benchmarks/SimpleHandwrittenPDE/ks_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/ks_fdm_wpd.jmd
@@ -375,7 +375,7 @@ plot(wp, label=labels, markershape=:auto, title="Between Families, High Toleranc
 
 #### Implicit-Explicit Methods
 
-Dense and Krylov linear solvers.
+Default and explicit Krylov linear solvers.
 ```julia
 abstols = 0.1 .^ (7:11)
 reltols = 0.1 .^ (7:11)
@@ -391,9 +391,9 @@ setups = [
     Dict(:alg => ARKODE(Sundials.Implicit(), order=5, linear_solver=:GMRES)),
 ]
 labels = hcat(
-    "KenCarp3 (dense)",
-    "KenCarp4 (dense)",
-    "KenCarp5 (dense)",
+    "KenCarp3 (default)",
+    "KenCarp4 (default)",
+    "KenCarp5 (default)",
     "KenCarp3 (Krylov)",
     "KenCarp4 (Krylov)",
     "KenCarp5 (Krylov)",
@@ -412,7 +412,7 @@ plot(wp, label=labels, markershape=:auto, title="IMEX Methods, Low Tolerances")
 
 ```julia
 abstols = 0.1 .^ (7:11) # all fixed dt methods so these don't matter much
-reltols = 0.1 .^ (7:11)
+reltols = 0.1 .^ (4:8)
 multipliers = 0.5 .^ (0:4)
 setups = [
     Dict(:alg => ETDRK3(), :dts => 1e-4 * multipliers),
@@ -435,7 +435,7 @@ plot(wp, label=labels, markershape=:auto, title="ExpRK Methods, Low Tolerances")
 
 ```julia
 abstols = 0.1 .^ (7:11)
-reltols = 0.1 .^ (7:11)
+reltols = 0.1 .^ (4:8)
 multipliers = 0.5 .^ (0:4)
 setups = [
     Dict(:alg => ARKODE(Sundials.Implicit(), order=5, linear_solver=:GMRES)),

--- a/benchmarks/SimpleHandwrittenPDE/nls_fdm_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/nls_fdm_wpd.jmd
@@ -98,7 +98,7 @@ L = 16.0  # Domain half-length
 alpha = 5.0 # Dispersive coefficient
 xs, prob = nonlinear_schrodinger(N, L, alpha)
 
-@time sol = solve(prob, AutoVern7(RadauIIA5(autodiff=AutoFiniteDiff()));
+@time sol = solve(prob, AutoVern7(Rodas5P(autodiff=AutoFiniteDiff()));
                   dt = 1e-4, abstol = 1e-14, reltol = 1e-14);
 
 test_sol = TestSolution(sol) # Reference solution for error estimation

--- a/benchmarks/SimpleHandwrittenPDE/nls_spectral_wpd.jmd
+++ b/benchmarks/SimpleHandwrittenPDE/nls_spectral_wpd.jmd
@@ -5,7 +5,7 @@ author: Chris Rackauckas
 
 ```julia
 using OrdinaryDiffEq
-using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqHighOrderRK, OrdinaryDiffEqIMEXMultistep
+using OrdinaryDiffEqBDF, OrdinaryDiffEqExponentialRK, OrdinaryDiffEqFIRK, OrdinaryDiffEqHighOrderRK, OrdinaryDiffEqIMEXMultistep, OrdinaryDiffEqRosenbrock
 using DiffEqDevTools
 using SciMLOperators
 using LinearSolve
@@ -86,7 +86,7 @@ n = 256 # Number of grid points
 alpha = 5.0 # Dispersive coefficient
 xs, prob = nonlinear_schrodinger(n, L, alpha)
 
-@time sol = solve(prob, AutoVern7(RadauIIA5(autodiff=AutoFiniteDiff()));
+@time sol = solve(prob, AutoVern7(Rodas5P(autodiff=AutoFiniteDiff()));
                   dt = 1e-4, reltol = 1e-12, abstol = 1e-12);
 
 test_sol = TestSolution(sol) # Reference solution for error estimation


### PR DESCRIPTION
This replaces https://github.com/SciML/SciMLBenchmarks.jl/pull/1672 and should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The released default-linear-solver regression fixes now allow the original SimpleHandwrittenPDE KenCarp work-precision ranges to run again. This restores those ranges, removes the temporary regression comments and caps, and renames the misleading `dense` labels to `default`.

The separate `AutoVern7(RadauIIA5(...))` / `CompositeCache` failure is not fixed by that release chain, so the four affected reference solves continue to use the verified `AutoVern7(Rodas5P(...))` workaround. The two KS fixed-step plotting ranges also return to their last-published `reltols = 0.1 .^ (4:8)` values.

The source diff is five files. The required manifest-only release update was kept mechanical and merged separately in https://github.com/SciML/SciMLBenchmarks.jl/pull/1784.

## Discriminating regression evidence

Before the upstream fixes, the old PR head with its registry environment reached chunk 7 of `kdv_fdm_wpd.jmd` and then hit the full 3,600-second Bash timeout inside the default GMRES path. Only figures 3 through 6 were produced.

Against the merged release stack—SciMLOperators 1.30.0, LinearSolve 5.15.0, OrdinaryDiffEqDifferentiation 3.11.1, and OrdinaryDiffEqNonlinearSolve 2.9.3—the same page with the original tolerance ranges completed all ten chunks with exit status 0. It generated markdown and all seven figures in 21m21.31s, including fresh worktree compilation. The generated markdown contains no Julia exception. One deliberately broad solver sweep emitted an instability warning in chunk 9 and continued; Weave completed normally.

Earlier validation against the exact upstream development fix ran all ten restored-range pages successfully; the measurements are recorded at https://github.com/SciML/SciMLBenchmarks.jl/pull/1672#issuecomment-5458431694.

## Repository verification

- `GROUP=QA ... Pkg.test()`: 19/19 passed.
- `GROUP=Core ... Pkg.test()`: 33/33 passed.
- Runic over every tracked Julia file: passed.
- `typos` over the five changed benchmark pages: passed.
- `git diff --check`: passed.
- Exact release-version assertions: passed for all four packages listed above.

No separate docs build was run: this changes benchmark pages, and the relevant KdV page was fully woven instead. No GPU-specific path was tested.

## Reviewer decision

The remaining Rodas5P substitution is intentional until the separate AutoSwitch/FIRK controller bug is fixed. It should not be reverted as part of the default-linear-solver restoration.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a04fab-48db-7e03-9f47-20c69464527f)
