### PR TITLE
Weekly update: refresh one benchmark directory per run

### DIFF
--- a/.github/workflows/update.jl
+++ b/.github/workflows/update.jl
@@ -27,10 +27,16 @@ open_prs, _ = GitHub.pull_requests(
 )
 filter!(pr -> startswith(something(pr.head.label, ""), "SciML:"), open_prs)
 
+# One directory per run; see `WeeklyUpdateHelpers.select_update_directory`.
+all_dirs = sort!(filter(d -> isdir(joinpath(benchpath, d)), readdir(benchpath)))
+selected = WeeklyUpdateHelpers.select_update_directory(
+    all_dirs, get(ENV, "BENCHMARK_DIRECTORY", ""), Date(now(UTC))
+)
+@info "Refreshing one benchmark directory this run" selected of = length(all_dirs)
+
 failures = String[]
-for dir in readdir(benchpath)
+for dir in (selected,)
     model_dir = joinpath(benchpath, dir)
-    isdir(model_dir) || continue
     println("--- Inspecting $dir ---")
 
     existing_pr = WeeklyUpdateHelpers.find_update_pull_request(open_prs, dir)

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: 0 6 * * 6
   workflow_dispatch:
+    inputs:
+      directory:
+        description: >-
+          Benchmark directory to refresh. Leave blank to use the weekly rotation.
+        required: false
+        default: ''
 
 jobs:
   update_weekly:
@@ -27,3 +33,5 @@ jobs:
 
               julia .github/workflows/update_tests.jl
               julia -e 'include(".github/workflows/update.jl")' ${{ secrets.GITHUB_TOKEN }}
+        env:
+          BENCHMARK_DIRECTORY: ${{ inputs.directory }}

--- a/.github/workflows/update_helpers.jl
+++ b/.github/workflows/update_helpers.jl
@@ -1,5 +1,7 @@
 module WeeklyUpdateHelpers
 
+using Dates
+
 function git_cmd(repo::AbstractString, args::AbstractString...)
     return Cmd(Cmd(["git", args...]); dir = repo)
 end
@@ -19,6 +21,32 @@ function find_update_pull_request(prs, dir::AbstractString)
     prefix = "update/$dir/"
     current = findfirst(pr -> startswith(pr.head.ref, prefix), prs)
     return current === nothing ? nothing : prs[current]
+end
+
+"""
+    select_update_directory(dirs, requested, date) -> String
+
+Pick the single benchmark directory to refresh on this run.
+
+Refreshing every directory in one run opened a pull request per directory (~40 at once), which
+is more review load than the weekly cadence absorbs. A non-empty `requested` (the
+`workflow_dispatch` input) selects that directory explicitly; otherwise the choice rotates by
+week, so each directory comes up on a predictable cycle rather than at random.
+"""
+function select_update_directory(dirs, requested::AbstractString, date::Date)
+    isempty(dirs) && error("No benchmark directories found")
+    req = strip(requested)
+    if !isempty(req)
+        req in dirs ||
+            error("Requested directory $req not found. Available: $(join(dirs, ", "))")
+        return String(req)
+    end
+    # Count cron weeks, not calendar weeks. 1970-01-03 was a Saturday, and the schedule is
+    # `0 6 * * 6`, so anchoring there makes Saturday-through-Friday one bucket: a manual
+    # re-run later in the same week picks the same directory as that week's scheduled run.
+    epoch_saturday = Date(1970, 1, 3)
+    weeks = Dates.value(date - epoch_saturday) ÷ 7
+    return String(dirs[mod1(weeks + 1, length(dirs))])
 end
 
 function add_update_worktree(

--- a/.github/workflows/update_tests.jl
+++ b/.github/workflows/update_tests.jl
@@ -1,3 +1,4 @@
+using Dates
 using Test
 
 include("update_helpers.jl")
@@ -19,6 +20,37 @@ end
     @test isnothing(WeeklyUpdateHelpers.find_update_pull_request(prs, "Other"))
     legacy_prs = [(head = (ref = "Example",), number = 3)]
     @test WeeklyUpdateHelpers.find_update_pull_request(legacy_prs, "Example").number == 3
+
+    # One directory per run: explicit request wins, otherwise rotate by week.
+    dirs = ["Alpha", "Beta", "Gamma"]
+    @test WeeklyUpdateHelpers.select_update_directory(dirs, "Beta", Date(2026, 8, 29)) == "Beta"
+    @test WeeklyUpdateHelpers.select_update_directory(dirs, "  Beta  ", Date(2026, 8, 29)) == "Beta"
+    @test_throws ErrorException WeeklyUpdateHelpers.select_update_directory(
+        dirs, "Missing", Date(2026, 8, 29)
+    )
+    @test_throws ErrorException WeeklyUpdateHelpers.select_update_directory(
+        String[], "", Date(2026, 8, 29)
+    )
+
+    # The rotation advances exactly once per week and stays put within a week.
+    base = Date(2026, 8, 29)
+    picks = [WeeklyUpdateHelpers.select_update_directory(dirs, "", base + Day(7i)) for i in 0:5]
+    @test all(p -> p in dirs, picks)
+    @test picks[1:3] != picks[2:4]                       # consecutive weeks differ
+    @test picks[1] == picks[4] && picks[2] == picks[5]   # wraps with the directory count
+    # A manual re-run any day before the next Saturday picks that week's directory.
+    @test all(
+        WeeklyUpdateHelpers.select_update_directory(dirs, "", base + Day(d)) == picks[1]
+            for d in 0:6
+    )
+    @test WeeklyUpdateHelpers.select_update_directory(dirs, "", base + Day(7)) != picks[1]
+
+    # Every directory is reached over a full cycle, so nothing is starved.
+    cycle = Set(
+        WeeklyUpdateHelpers.select_update_directory(dirs, "", base + Day(7i))
+            for i in 0:(length(dirs) - 1)
+    )
+    @test cycle == Set(dirs)
 
     scratch_parent = get(ENV, "TMPDIR", tempdir())
     mktempdir(scratch_parent) do scratch


### PR DESCRIPTION
The 2026-08-29 run opened 40 pull requests in one go - the first Saturday after #1689
un-broke the updater, so every directory got as far as opening a PR for the first time in months.
That is more review load than the weekly cadence absorbs.

This makes each run refresh a single directory:

- `WeeklyUpdateHelpers.select_update_directory(dirs, requested, date)` picks it. A non-empty
  `requested` (the new `workflow_dispatch` `directory` input) selects explicitly; otherwise the
  choice rotates by week so every directory comes up on a predictable cycle rather than at random.
- The rotation is anchored to 1970-01-03, a Saturday, to match the `0 6 * * 6` schedule. That
  makes Saturday-through-Friday one bucket, so a manual re-run later in the same week picks the
  same directory as that week's scheduled run instead of jumping to the next one.

With ~38 directories, each is refreshed roughly every 38 weeks; dispatch the workflow with an
explicit `directory` to refresh one on demand.

Tests cover explicit selection, whitespace trimming, the unknown-directory and empty-list errors,
that the rotation advances exactly once per week, that it is stable within a cron week, and that a
full cycle reaches every directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R