### PR TITLE
Fix DiffEqGPU CRN smoke parameter count

### DIFF
--- a/benchmarks/DiffEqGPU/crn_sde.jmd
+++ b/benchmarks/DiffEqGPU/crn_sde.jmd
@@ -121,7 +121,7 @@ end
 
 ```julia
 let
-    ps = crn_parameters(1)
+    ps = crn_parameters(2)
     ens = make_crn_ensemble(ps)
     sol = solve(ens, GPUEM(), KERNEL; trajectories = 2, save_everystep = false,
         adaptive = false, dt = 0.1f0)

--- a/test/core.jl
+++ b/test/core.jl
@@ -44,6 +44,8 @@ end
 
     crn_path = joinpath(benchmarks_dir, "crn_sde.jmd")
     crn_source = read(crn_path, String)
+    @test occursin("ps = crn_parameters(2)", crn_source)
+    @test !occursin("ps = crn_parameters(1)", crn_source)
     @test occursin("GPUEM(), KERNEL; trajectories = 2", crn_source)
     @test !occursin("GPUEM(), KERNEL; trajectories = 1", crn_source)
     for variable in ("S_grid", "D_grid")


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until reviewed by @ChrisRackauckas.

## What changed

Build the CRN smoke ensemble from `crn_parameters(2)` so its parameter collection covers both requested GPU trajectories. The benchmark's `prob_func` indexes `parameters[i]`; the previous one-point collection had no value for trajectory 2.

The regression test now keeps the smoke parameter count and trajectory count at two together.

## Failing before

```text
$ GROUP=Core julia +1.11.9 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary:                         | Pass  Fail  Total
Core                                  |   43     2     45
  DiffEqGPU singleton parameter grids |   10     2     12
ERROR: Package SciMLBenchmarks errored during testing
```

Both new assertions failed: the page contained `ps = crn_parameters(1)` and did not contain `ps = crn_parameters(2)`.

## Passing after

```text
$ GROUP=Core julia +1.11.9 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |   45     45  39.7s
Testing SciMLBenchmarks tests passed

$ GROUP=QA julia +1.11.9 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m47.3s
Testing SciMLBenchmarks tests passed

$ julia +1.11.9 --project=../.tools/runic --startup-file=no -e 'using Runic; exit(Runic.main(copy(ARGS)))' -- --check test/core.jl
# exit 0

$ typos benchmarks/DiffEqGPU/crn_sde.jmd test/core.jl
# exit 0

$ git diff --check
# exit 0
```

## Not verified locally

This host has no CUDA GPU, so the V100 smoke solve was not executed locally. CUDA 12 preferences remain separate in https://github.com/SciML/SciMLBenchmarks.jl/pull/1733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
