### PR TITLE
Pin DiffEqGPU PyTorch to CUDA 12.6

### DIFF
--- a/benchmarks/DiffEqGPU/CondaPkg.toml
+++ b/benchmarks/DiffEqGPU/CondaPkg.toml
@@ -1,8 +1,9 @@
 [deps]
 numpy = ""
+python = "3.12.*"
 
 [pip.deps]
 diffrax = ">=0.5"
 equinox = ">=0.11"
 jax = {version=">=0.4", extras=["cuda12"]}
-torch = ">=2.0"
+torch = "@ https://download-r2.pytorch.org/whl/cu126/torch-2.13.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=8695f3c6b7966d44560275b90c5c28e5091ba33ddbb1ab33b2173782ca1e9145"

--- a/test/core.jl
+++ b/test/core.jl
@@ -214,6 +214,19 @@ end
     @test !occursin(r"@compile reactant_", benchmark)
 end
 
+@testset "DiffEqGPU PyTorch V100 runtime" begin
+    dependencies = read(
+        joinpath(dirname(@__DIR__), "benchmarks", "DiffEqGPU", "CondaPkg.toml"), String
+    )
+    @test occursin("python = \"3.12.*\"", dependencies)
+    @test occursin(
+        "torch = \"@ https://download-r2.pytorch.org/whl/cu126/" *
+            "torch-2.13.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl" *
+            "#sha256=8695f3c6b7966d44560275b90c5c28e5091ba33ddbb1ab33b2173782ca1e9145\"",
+        dependencies,
+    )
+end
+
 @testset "superseded pull request cancellation" begin
     workflow = read(joinpath(dirname(@__DIR__), ".github", "workflows", "benchmarks.yml"), String)
     @test occursin("types: [opened, synchronize, reopened, closed]", workflow)


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Pin DiffEqGPU's Python environment to Python 3.12 and the official PyTorch 2.13.0 CUDA 12.6 Linux x86-64 wheel, including its SHA-256. The unconstrained PyPI dependency selected `torch==2.13.0+cu130`; that build contains no compute-capability 7.0 kernels for the V100 runners and explicitly recommended reinstalling from PyTorch's CUDA 12.6 index.

This is a dependency-only change. The Julia CUDA 12.9 preferences are handled separately by https://github.com/SciML/SciMLBenchmarks.jl/pull/1733. The singleton benchmark-source fixes merged through https://github.com/SciML/SciMLBenchmarks.jl/pull/1715, with the CRN parameter-count follow-up in https://github.com/SciML/SciMLBenchmarks.jl/pull/1788.

## Failing before

The V100 validation run reported:

```text
Found GPU0 Tesla V100-PCIE-32GB which is of compute capability (CC) 7.0.
Your installed torch==2.13.0+cu130 does not include kernels for this GPU.
For CUDA 12.6 use pip install torch==2.13.0 --index-url https://download.pytorch.org/whl/cu126
```

The final dependency assertions fail against current `master`:

```text
Test Summary:                  | Fail  Total  Time
DiffEqGPU PyTorch V100 runtime |    2      2  1.9s
ERROR: Some tests did not pass: 0 passed, 2 failed, 0 errored, 0 broken.
```

## Passing after

A clean CondaPkg/Pixi environment resolved and installed successfully. Importing the package through the benchmark's PythonCall environment produced:

```text
TORCH_VERSION=2.13.0+cu126
TORCH_CUDA=12.6
```

Repository checks:

```text
$ GROUP=Core julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |   45     45  34.6s
Testing SciMLBenchmarks tests passed

$ GROUP=QA julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m44.7s
Testing SciMLBenchmarks tests passed
```

Runic 1.x checked `test/core.jl`, `typos` checked both changed files, and `git diff --check` passed.

## Not verified locally

This host has no NVIDIA GPU, so actual V100 execution remains unverified. The V100 run also requires the Julia CUDA 12.9 preferences from https://github.com/SciML/SciMLBenchmarks.jl/pull/1733 and the CRN follow-up from https://github.com/SciML/SciMLBenchmarks.jl/pull/1788. No docs build was run because this changes a benchmark dependency declaration and a private regression test, not public API or docstrings.

PyTorch was already a benchmark dependency, so this pin adds no dependency or license.

Failing V100 validation: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33298026014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
