### PR TITLE
Fix PowerModels logging across Weave chunks

### DIFF
--- a/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
+++ b/benchmarks/OptimizationFrameworks/optimal_powerflow.jmd
@@ -24,6 +24,7 @@ SIZE_LIMIT = 1000
 
 ```julia
 import PowerModels
+PowerModels.silence()
 import ConcreteStructs
 using BenchmarkTools
 using DataFrames

--- a/test/core.jl
+++ b/test/core.jl
@@ -65,6 +65,19 @@ end
     @test collect(Base.invokelatest(lorenz_grid, 4, Float32)) == Float32[0, 7, 14, 21]
 end
 
+@testset "OptimizationFrameworks logging" begin
+    benchmark = read(
+        joinpath(
+            dirname(@__DIR__),
+            "benchmarks",
+            "OptimizationFrameworks",
+            "optimal_powerflow.jmd",
+        ),
+        String,
+    )
+    @test occursin("import PowerModels\nPowerModels.silence()", benchmark)
+end
+
 @testset "subprocess" begin
     process = SciMLBenchmarks.@subprocess exit()
     @test success(process)


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until reviewed by @ChrisRackauckas.

## What changed

Call the public `PowerModels.silence()` API immediately after importing PowerModels in `optimal_powerflow.jmd`. PowerModels/Memento otherwise retains Weave's first-chunk pipe as a log sink; later `parse_file` warnings then write to that closed pipe and fail the completed page with `IOError: stream is closed or unusable`.

The regression test keeps the logging setup next to the first import. The model-size guard remains a separate change in https://github.com/SciML/SciMLBenchmarks.jl/pull/1779.

## Failing before

A two-chunk Weave reproducer imported PowerModels in chunk 1 and called `PowerModels.parse_file` in chunk 2:

```text
┌ Info: Weaving chunk 2 from line 10
└   progress = 0.5
┌ InfrastructureModels | Warn]: Matlab parser skipping the following line:
└   };
┌ Warning: ERROR: Base.IOError occurred, including output in Weaved document
└ @ Weave .../src/run.jl:224
```

The generated Markdown contained:

```text
Error: IOError: stream is closed or unusable
```

The repository regression check also failed before the notebook change:

```text
Test Summary:                    | Pass  Fail  Total
Core                             |   43     1     44
  OptimizationFrameworks logging |          1      1
ERROR: Package SciMLBenchmarks errored during testing
```

## Passing after

The identical two-chunk reproducer with `PowerModels.silence()` completed with exit 0 and generated no `IOError`.

```text
┌ Info: Weaving chunk 1 from line 5
┌ Info: Weaving chunk 2 from line 11
┌ Info: Weaved all chunks
[ Info: Weaved to .../.validation/powermodels_pipe.md
EXIT=0
```

Repository checks:

```text
$ GROUP=Core julia +1.11.9 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |   44     44  37.0s
Testing SciMLBenchmarks tests passed

$ GROUP=QA julia +1.11.9 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m39.8s
Testing SciMLBenchmarks tests passed

$ julia +1.11.9 --project=../.tools/runic --startup-file=no -e 'using Runic; exit(Runic.main(copy(ARGS)))' -- --check test/core.jl
# exit 0

$ typos benchmarks/OptimizationFrameworks/optimal_powerflow.jmd test/core.jl
# exit 0

$ git diff --check
# exit 0
```

## Full-page coverage and remaining gap

The full `optimal_powerflow.jmd` weave remained CPU-active until the one-hour Bash timeout. It reached chunk 45 of 47, including the PowerModels parsing and solver runs that previously emitted the closed-stream failure, with no `IOError: stream is closed or unusable`:

```text
┌ Info: Weaving chunk 45 from line 2538
└   progress = 0.9361702127659575
[ Info: Number of Variables: 118
[ Info: Number of Constraints: 169
[ Info: Running Optimization.jl
[ Info: Running ModelingToolkit.jl
[ Info: Running JuMP.jl
[ Info: Running NLPModels.jl
[ Info: Running Optim.jl
EXIT=124
```

I did not observe a complete full-page weave inside the local one-hour window. No docs build was run because this changes benchmark code and a private regression test, not public API or docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
