### PR TITLE
Fix DiffEqGPU grid tests on Julia 1.12

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -51,8 +51,8 @@ end
     for variable in ("S_grid", "D_grid")
         crn_expression = benchmark_assignment(crn_path, variable)
         crn_grid = Core.eval(@__MODULE__, :((N, T) -> $crn_expression))
-        @test crn_grid(1, Float32) == Float32[0.1]
-        @test crn_grid(2, Float32) == Float32[0.1, 100]
+        @test Base.invokelatest(crn_grid, 1, Float32) == Float32[0.1]
+        @test Base.invokelatest(crn_grid, 2, Float32) == Float32[0.1, 100]
     end
 
     lorenz_path = joinpath(benchmarks_dir, "lorenz_ensemble.jmd")
@@ -61,8 +61,8 @@ end
     @test !occursin("make_ensemble(1)", lorenz_source)
     lorenz_expression = benchmark_assignment(lorenz_path, "plist")
     lorenz_grid = Core.eval(@__MODULE__, :((n, T) -> $lorenz_expression))
-    @test collect(lorenz_grid(1, Float32)) == Float32[0]
-    @test collect(lorenz_grid(4, Float32)) == Float32[0, 7, 14, 21]
+    @test collect(Base.invokelatest(lorenz_grid, 1, Float32)) == Float32[0]
+    @test collect(Base.invokelatest(lorenz_grid, 4, Float32)) == Float32[0, 7, 14, 21]
 end
 
 @testset "subprocess" begin


### PR DESCRIPTION
## What changed and why

Call the DiffEqGPU grid closures created with `Core.eval` through `Base.invokelatest`. Julia 1.12 otherwise rejects the immediate calls from the Core test group because the newly evaluated closure methods are newer than the caller's world age.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Failure before

On clean `upstream/master` at `711e56cd`, this command reproduced four errors in the affected testset on Julia 1.12.7:

```bash
GROUP=Core ~/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
```

```text
DiffEqGPU singleton parameter grids: Error During Test at test/core.jl:54
  Expression: crn_grid(1, Float32) == Float32[0.1]
  MethodError: no method matching (::Main.var"##Core#277".var"#6#7")(::Int64, ::Type{Float32})
  The applicable method may be too new: running in world age 38802, while current world is 38805.

Test Summary:                          | Pass  Error  Total
Core                                   |   39      5     44
  DiffEqGPU singleton parameter grids  |    8      4     12
  weave_file                           |           1      1
```

The fifth error is a separate clean-master Julia 1.12 `MbedTLS_jll` failure in `weave_file`; it is under a separate investigation. `git bisect run` identified `29756d4a700fd3e3caa2b569d47e59eaaefdc57c` as the first commit with the singleton-grid world-age errors.

## Verification

With this change, the same Julia 1.12.7 command shows the affected testset passing:

```text
Test Summary:                          | Pass  Error  Total
Core                                   |   43      1     44
  DiffEqGPU singleton parameter grids  |   12            12
  weave_file                           |           1      1
```

The supported CI version passes the full relevant and QA groups:

```bash
GROUP=Core ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
GROUP=QA ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Total   Time
Core          |   45     45  28.7s
Testing SciMLBenchmarks tests passed

Test Summary: | Pass  Total   Time
QA            |   19     19  58.8s
Testing SciMLBenchmarks tests passed
```

Formatting, spelling, and diff checks:

```text
Runic 1.10.0: pass
typos test/core.jl: pass
git diff --check: pass
```

No documentation build was run because this changes no documentation or public API. No DiffEqGPU benchmark was woven because benchmark sources and environments are unchanged. The full Core group on Julia 1.12 remains blocked only by the separate pre-existing `MbedTLS_jll` error described above.

## Links

- Introducing PR: https://github.com/SciML/SciMLBenchmarks.jl/pull/1715
- First bad commit: https://github.com/SciML/SciMLBenchmarks.jl/commit/29756d4a700fd3e3caa2b569d47e59eaaefdc57c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
