### PR TITLE
Fix DiffEqGPU CRN Float64 parameter call

### DIFF
--- a/benchmarks/DiffEqGPU/crn_sde.jmd
+++ b/benchmarks/DiffEqGPU/crn_sde.jmd
@@ -146,7 +146,7 @@ for N in NS
         min_seconds(() -> (CUDA.@sync solve(ens, GPUEM(), KERNEL; trajectories = n,
             save_everystep = false, adaptive = false, dt = 0.1f0); nothing)))
     @info "crn cpu" N n
-    ens64 = make_crn_ensemble(crn_parameters(N; Float64); T = Float64)
+    ens64 = make_crn_ensemble(crn_parameters(N; T = Float64); T = Float64)
     push!(t_cpu,
         min_seconds(() -> (solve(ens64, EM(), EnsembleThreads(); trajectories = n,
             save_everystep = false, adaptive = false, dt = 0.1); nothing);

--- a/test/core.jl
+++ b/test/core.jl
@@ -48,6 +48,19 @@ end
     @test !occursin("ps = crn_parameters(1)", crn_source)
     @test occursin("GPUEM(), KERNEL; trajectories = 2", crn_source)
     @test !occursin("GPUEM(), KERNEL; trajectories = 1", crn_source)
+    crn_definition = match(r"(?ms)^function crn_parameters\b.*?^end$", crn_source)
+    @test !isnothing(crn_definition)
+    if !isnothing(crn_definition)
+        Core.eval(@__MODULE__, Meta.parse(crn_definition.match))
+        cpu_expression = benchmark_assignment(crn_path, "ens64")
+        cpu_parameters_expression = only(
+            argument for argument in cpu_expression.args if Meta.isexpr(argument, :call)
+        )
+        cpu_parameters = Core.eval(@__MODULE__, :((N) -> $cpu_parameters_expression))
+        parameters = Base.invokelatest(cpu_parameters, 1)
+        @test length(parameters) == 1680
+        @test all(parameter -> parameter isa NTuple{6, Float64}, parameters)
+    end
     for variable in ("S_grid", "D_grid")
         crn_expression = benchmark_assignment(crn_path, variable)
         crn_grid = Core.eval(@__MODULE__, :((N, T) -> $crn_expression))


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The DiffEqGPU CRN CPU timing branch passed `Float64` as an anonymous keyword to `crn_parameters`, whose keyword is named `T`, so the benchmark failed after completing its first GPU timing. This changes the call to `crn_parameters(N; T = Float64)` and adds an executable regression test that evaluates the benchmark's real function definition and nested CPU parameter call.

## Verification

Failing before the fix, with the regression test applied to the unfixed benchmark:

```text
$ GROUP=Core /home/crackauc/.juliaup/bin/julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
DiffEqGPU singleton parameter grids: Error During Test
  MethodError: no method matching crn_parameters(::Int64; Float64::DataType)
  crn_parameters(::Any; T) got unsupported keyword argument "Float64"
Test Summary: | Pass  Error  Total
Core          |   38      1     39
ERROR: Some tests did not pass: 38 passed, 0 failed, 1 errored, 0 broken.
```

Passing after the fix:

```text
$ GROUP=Core /home/crackauc/.juliaup/bin/julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |   48     48  41.4s
Testing SciMLBenchmarks tests passed

$ GROUP=QA /home/crackauc/.juliaup/bin/julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m49.3s
Testing SciMLBenchmarks tests passed

$ /home/crackauc/.juliaup/bin/julia +1.11 --startup-file=no --project=/home/crackauc/.julia/environments/runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff test/core.jl
# exit 0, no output

$ typos benchmarks/DiffEqGPU/crn_sde.jmd test/core.jl
# exit 0, no output

$ git diff --check
# exit 0, no output
```

The CPU-only benchmark path was run from the actual notebook definitions in the pinned DiffEqGPU environment:

```text
$ /home/crackauc/.juliaup/bin/julia +1.11 --threads=auto --project=benchmarks/DiffEqGPU -e 'using StochasticDiffEq, StaticArrays; path = "benchmarks/DiffEqGPU/crn_sde.jmd"; chunks = collect(eachmatch(r"(?ms)^```julia[^\n]*\n(?<code>.*?)^```", read(path, String))); include_string(Main, chunks[2][:code], path); ps = crn_parameters(1; T = Float64); ens = make_crn_ensemble(ps; T = Float64); sol = solve(ens, EM(), EnsembleThreads(); trajectories = 2, save_everystep = false, adaptive = false, dt = 0.1); @assert length(sol) == 2; @assert all(i -> length(sol[i].u[end]) == 4, 1:2); println("CPU_CRN_OK trajectories=", length(sol), " parameter_count=", length(ps), " parameter_type=", eltype(first(ps)), " retcodes=", [sol[i].retcode for i in 1:2])'
CPU_CRN_OK trajectories=2 parameter_count=1680 parameter_type=Float64 retcodes=SciMLBase.ReturnCode.T[SciMLBase.ReturnCode.Success, SciMLBase.ReturnCode.Success]
```

## What was not verified

This host has no CUDA device (`nvidia-smi` is unavailable). The authoritative command successfully instantiated and precompiled the pinned environment, then stopped at the notebook's explicit GPU guard before reaching any solves:

```text
$ /home/crackauc/.juliaup/bin/julia +1.11 --threads=auto --project=. benchmark.jl benchmarks/DiffEqGPU/crn_sde.jmd
caused by: LoadError: AssertionError: This benchmark requires a functional CUDA GPU
exit_status=1
```

The exclusive GPU CI runner was also attempted, but failed in the first GPU smoke solve before reaching the corrected Float64 CPU branch:

```text
caused by: LoadError: Compute capability 7.0.0 is not supported by CUDA 13.2.0
```

That V100/CUDA runtime problem is tracked separately by PR 1733 and is intentionally not folded into this focused fix. A supplemental Julia 1.12 Core run passed this change's `DiffEqGPU singleton parameter grids` testset 15/15, but the overall group hit the separately investigated clean-master `Failed to find path for package MbedTLS_jll` error in `weave_file` (46 passed, 1 errored).

## Reviewer pushback

The regression test executes the Base-only `crn_parameters` definition and the exact nested CPU call parsed from the benchmark. It intentionally does not pretend to replace the GPU Weave; the exclusive runner is still authoritative for that path.

## Links

- Failing hosted job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33419948741/job/99604609204
- This PR's blocked GPU job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33450975836/job/99680624377
- Introducing commit: https://github.com/SciML/SciMLBenchmarks.jl/commit/aa722c48401474ce44e2fbafa07ec8fc75233834
- Introducing PR: https://github.com/SciML/SciMLBenchmarks.jl/pull/1658
- Separate V100/CUDA runtime fix: https://github.com/SciML/SciMLBenchmarks.jl/pull/1733
- Related clean-master Julia 1.12 investigation: https://github.com/SciML/SciMLBenchmarks.jl/pull/1792

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
