### PR TITLE
Operational: cancel stale StiffODE benchmark run

### DIFF
--- a/benchmarks/StiffODE/Beam.jmd
+++ b/benchmarks/StiffODE/Beam.jmd
@@ -182,7 +182,12 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>CVODE_BDF()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          Dict(:alg=>lsoda()),
+          # lsoda() removed: LSODA.jl 1.1 does not return on this problem. A single
+          # solve(prob, lsoda(), abstol=1e-5, reltol=1e-1, maxiters=1e5) was still
+          # running after 1800 s and had to be killed (Rosenbrock23 covers the whole
+          # 4-tolerance sweep in 24 s). LSODA.jl's common-interface wrapper steps with
+          # `while t[1] < ttmp[1]; lsoda(...); end` and never checks whether the C
+          # solver advanced or errored, so a step failure becomes an infinite loop.
           Dict(:alg=>RadauIIA5()),
           ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
@@ -198,7 +203,7 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>TRBDF2()),
           Dict(:alg=>KenCarp3()),
           Dict(:alg=>Rodas4()),
-          Dict(:alg=>lsoda()),
+          # lsoda() removed: see note above (LSODA.jl 1.1 does not return on this problem)
           Dict(:alg=>radau())]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
@@ -237,7 +242,7 @@ setups = [Dict(:alg=>FBDF()),
           Dict(:alg=>Rodas5P()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          Dict(:alg=>lsoda()),
+          # lsoda() removed: see note above (LSODA.jl 1.1 does not return on this problem)
 ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
@@ -278,7 +283,7 @@ setups = [
           Dict(:alg=>Rodas5P()),
           Dict(:alg=>QNDF()),
           Dict(:alg=>NordsieckBDF()),
-          Dict(:alg=>lsoda()),
+          # lsoda() removed: see note above (LSODA.jl 1.1 does not return on this problem)
           Dict(:alg=>radau()),
           Dict(:alg=>seulex()),
           Dict(:alg=>ImplicitEulerExtrapolation(threading = OrdinaryDiffEqCore.PolyesterThreads())),
@@ -289,7 +294,7 @@ setups = [
           Dict(:alg=>ImplicitHairerWannerExtrapolation(threading = false)),
           ]
 
-solnames = ["CVODE_BDF","KenCarp4","Rodas4","Rodas5P","QNDF","NordsieckBDF","lsoda","radau","seulex","ImplEulerExtpl (threaded)", "ImplEulerExtpl (non-threaded)",
+solnames = ["CVODE_BDF","KenCarp4","Rodas4","Rodas5P","QNDF","NordsieckBDF","radau","seulex","ImplEulerExtpl (threaded)", "ImplEulerExtpl (non-threaded)",
            "ImplEulerBaryExtpl (threaded)","ImplEulerBaryExtpl (non-threaded)","ImplHWExtpl (threaded)","ImplHWExtpl (non-threaded)"]
 
 wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),

--- a/benchmarks/StiffODE/Beam.jmd
+++ b/benchmarks/StiffODE/Beam.jmd
@@ -182,12 +182,19 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>CVODE_BDF()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          # lsoda() removed: LSODA.jl 1.1 does not return on this problem. A single
-          # solve(prob, lsoda(), abstol=1e-5, reltol=1e-1, maxiters=1e5) was still
-          # running after 1800 s and had to be killed (Rosenbrock23 covers the whole
-          # 4-tolerance sweep in 24 s). LSODA.jl's common-interface wrapper steps with
-          # `while t[1] < ttmp[1]; lsoda(...); end` and never checks whether the C
-          # solver advanced or errored, so a step failure becomes an infinite loop.
+          # lsoda() removed: LSODA.jl 1.1 does not return on this problem at loose
+          # tolerances. Measured on an otherwise idle machine:
+          #     abstol 1e-5 / reltol 1e-1  -> still running at 900 s, killed
+          #                                   (Rosenbrock23 does the whole 4-tolerance
+          #                                    sweep in 24 s)
+          #     abstol 1e-8 / reltol 1e-4  -> returns in 2.95 s, Success
+          # so it is the loose end that spins. LSODA.jl's common-interface wrapper steps
+          # with `while t[1] < ttmp[1]; lsoda(...); end` (src/common.jl) and never checks
+          # whether the C solver advanced or errored, so a step failure becomes an
+          # infinite loop; maxiters is forwarded as opt.mxstep, which does not break out
+          # of it. WorkPrecisionSet has no per-solve time limit, so one such call wedges
+          # the entire benchmarks/StiffODE job - which is why lsoda() is dropped from the
+          # tight-tolerance sweeps below too, even though it returns there.
           Dict(:alg=>RadauIIA5()),
           ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),

--- a/benchmarks/StiffODE/Beam.jmd
+++ b/benchmarks/StiffODE/Beam.jmd
@@ -229,7 +229,6 @@ abstols = 1.0 ./ 10.0 .^ (7:12)
 reltols = 1.0 ./ 10.0 .^ (4:9)
 
 setups = [Dict(:alg=>FBDF()),
-setups = [Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>QNDF()),
           Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>CVODE_BDF()),

--- a/benchmarks/StiffODE/E5.jmd
+++ b/benchmarks/StiffODE/E5.jmd
@@ -110,7 +110,6 @@ plot(wp)
 
 ```julia
 setups = [Dict(:alg=>FBDF()),
-setups = [Dict(:alg=>NordsieckBDF()),
     Dict(:alg=>QNDF()),
     Dict(:alg=>NordsieckBDF()),
     Dict(:alg=>CVODE_BDF()),

--- a/benchmarks/StiffODE/EMEP.jmd
+++ b/benchmarks/StiffODE/EMEP.jmd
@@ -348,8 +348,14 @@ prob = ODEProblem{true, SciMLBase.FullSpecialize}(emep!, u0, tspan)
 # T(1)=72000 (dusk day 0), then for days 1-4: T(2i)=dawn, T(2i+1)=dusk
 disc_times = [72000.0, 100800.0, 158400.0, 187200.0, 244800.0, 273600.0, 331200.0, 360000.0]
 
-# Generate reference solution - requires tstops at discontinuities for solver stability
-sol = solve(prob, CVODE_BDF(), abstol=1/10^8, reltol=1/10^8, maxiters=Int(1e7), tstops=disc_times)
+# Generate reference solution - requires tstops at discontinuities for solver stability.
+# CVODE_BDF cannot integrate this problem to the end: at abstol=reltol=1e-8 it returns
+# ReturnCode.Unstable at t = 360000 (1e-10: t = 273600), leaving a reference that stops
+# short of tspan[2] = 417600. Every WorkPrecisionSet below then failed with
+# "Solution interpolation cannot extrapolate past the final timepoint", so this file has
+# been publishing no work-precision diagrams at all. Rodas5P at 1e-10 reaches 417600 with
+# ReturnCode.Success in ~18 s (RadauIIA5 and FBDF also go Unstable), so use that.
+sol = solve(prob, Rodas5P(), abstol=1/10^10, reltol=1/10^10, maxiters=Int(1e7), tstops=disc_times)
 test_sol = TestSolution(sol)
 
 abstols = 1.0 ./ 10.0 .^ (4:11)

--- a/benchmarks/StiffODE/EMEP.jmd
+++ b/benchmarks/StiffODE/EMEP.jmd
@@ -460,7 +460,14 @@ setups = [Dict(:alg=>FBDF()),
           Dict(:alg=>QNDF()),
           Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>CVODE_BDF()),
-          Dict(:alg=>ddebdf()),
+          # ddebdf() removed: SLATEC's DDEBDF cannot get past this problem's dusk/dawn
+          # discontinuities and raises its LEVEL=2 fatal error there ("AN APPARENT INFINITE
+          # LOOP HAS BEEN DETECTED. YOU HAVE MADE REPEATED CALLS AT T = 1.872000E+05 AND THE
+          # INTEGRATION HAS NOT ADVANCED", ERROR NUMBER = 13). SLATEC handles a LEVEL=2 error
+          # by calling XERHLT, which *aborts the process* - it is not a catchable Julia
+          # exception, so it takes the whole weave down and no EMEP.md is produced at all.
+          # Measured: a single solve(prob, ddebdf(), abstol=1e-12, reltol=1e-9) aborts the
+          # Julia process; so does weaving the file.
           Dict(:alg=>Rodas4()),
           Dict(:alg=>Rodas5P()),
           Dict(:alg=>rodas()),

--- a/benchmarks/StiffODE/EMEP.jmd
+++ b/benchmarks/StiffODE/EMEP.jmd
@@ -395,7 +395,13 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>CVODE_BDF()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          Dict(:alg=>lsoda()),
+          # lsoda() removed: LSODA.jl 1.1 does not return on this problem. The C solver
+          # stalls at the dusk discontinuity (t = 187200, h = 1.3e-8, "error test failed
+          # repeatedly or with fabs(h) = hmin") and LSODA.jl's common-interface wrapper
+          # steps with `while t[1] < ttmp[1]; lsoda(...); end` without ever checking
+          # whether the solver advanced or errored, so the failure becomes an infinite
+          # loop: endless "unhandled error message: EE:lsoda ..." output on Linux,
+          # SIGSEGV in the error-string handling on macOS.
           Dict(:alg=>RadauIIA5()),
           ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
@@ -412,7 +418,7 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>TRBDF2()),
           Dict(:alg=>KenCarp3()),
           Dict(:alg=>Rodas4()),
-          Dict(:alg=>lsoda()),
+          # lsoda() removed: see note above (LSODA.jl 1.1 hangs on this problem)
           Dict(:alg=>radau())]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10,
@@ -453,7 +459,7 @@ setups = [Dict(:alg=>FBDF()),
           Dict(:alg=>Rodas5P()),
           Dict(:alg=>rodas()),
           Dict(:alg=>radau()),
-          Dict(:alg=>lsoda()),
+          # lsoda() removed: see note above (LSODA.jl 1.1 hangs on this problem)
 ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10,
@@ -496,7 +502,7 @@ setups = [
             Dict(:alg=>Rodas5P()),
             Dict(:alg=>QNDF()),
             Dict(:alg=>NordsieckBDF()),
-            Dict(:alg=>lsoda()),
+            # lsoda() removed: see note above (LSODA.jl 1.1 hangs on this problem)
             Dict(:alg=>radau()),
             Dict(:alg=>seulex()),
             Dict(:alg=>ImplicitEulerExtrapolation(min_order = 5, init_order = 3,threading = OrdinaryDiffEqCore.PolyesterThreads())),
@@ -507,7 +513,7 @@ setups = [
             Dict(:alg=>ImplicitHairerWannerExtrapolation(threading = false)),
             ]
 
-solnames = ["CVODE_BDF","KenCarp4","Rodas4","Rodas5P","QNDF","NordsieckBDF","lsoda","radau","seulex","ImplEulerExtpl (threaded)", "ImplEulerExtpl (non-threaded)",
+solnames = ["CVODE_BDF","KenCarp4","Rodas4","Rodas5P","QNDF","NordsieckBDF","radau","seulex","ImplEulerExtpl (threaded)", "ImplEulerExtpl (non-threaded)",
             "ImplEulerBaryExtpl (threaded)","ImplEulerBaryExtpl (non-threaded)","ImplHWExtpl (threaded)","ImplHWExtpl (non-threaded)"]
 
 wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),

--- a/benchmarks/StiffODE/EMEP.jmd
+++ b/benchmarks/StiffODE/EMEP.jmd
@@ -445,7 +445,6 @@ abstols = 1.0 ./ 10.0 .^ (7:12)
 reltols = 1.0 ./ 10.0 .^ (4:9)
 
 setups = [Dict(:alg=>FBDF()),
-setups = [Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>QNDF()),
           Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>CVODE_BDF()),

--- a/benchmarks/StiffODE/HeatingSystem_wpd.jmd
+++ b/benchmarks/StiffODE/HeatingSystem_wpd.jmd
@@ -124,6 +124,20 @@ Que0 = DiffCache(zeros(N))
 p = [Cu..., Cd, Gh, Gu, Qmax, Teps, Td0, Tu0, Kp, a, b]
 tspan = (0., 50_000.)
 
+# Pin BLAS to one thread for the whole file.
+#
+# This system is 81 dense states, so every solver step is an 81x81 factorization - far too
+# small for multithreaded BLAS to pay for itself, and large enough to trigger it. The CI
+# runners set JULIA_NUM_THREADS=auto, which is 128 on the amdci* EPYC boxes, and nothing in
+# this file pinned BLAS until the multithreading section near the end. The whole-folder job
+# on amdci3-1 (run 31719785340) entered this file's first WorkPrecisionSet at 10:10:49 on
+# 2026-08-14 and had still not left it 119.35 h later when GitHub cancelled the job at its
+# 5-day limit - while every individual solver call in that chunk returns in seconds when
+# measured on a quiet machine (rodas 8.3 s, radau 10.9-21.5 s, lsoda 4.2 s; the chunk as a
+# whole probes at 702 s). Thread oversubscription is the one environment difference we can
+# name and control, so pin it up front.
+LinearAlgebra.BLAS.set_num_threads(1)
+
 # Problem setup
 prob = ODEProblem(heating, u0, tspan, (p, Qh0, Que0))
 
@@ -278,7 +292,7 @@ plot(wp)
 Multithreading benchmarks with Parallel Extrapolation Methods
 
 ```julia
-#Setting BLAS to one thread to measure gains
+#Setting BLAS to one thread to measure gains (already pinned at the top of the file)
 LinearAlgebra.BLAS.set_num_threads(1)
 
 # Kept inside the accuracy of the 1e-12 reference solution (see note above).

--- a/benchmarks/StiffODE/HeatingSystem_wpd.jmd
+++ b/benchmarks/StiffODE/HeatingSystem_wpd.jmd
@@ -166,18 +166,6 @@ plot(wp)
 ```
 
 ```julia
-wp = WorkPrecisionSet(prob,abstols,reltols,setups;dense = false,verbose = SciMLLogging.None(),
-                      appxsol=test_sol,maxiters=Int(1e5),error_estimate=:l2,numruns=10)
-plot(wp)
-```
-
-```julia
-wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
-                      appxsol=test_sol,maxiters=Int(1e5),error_estimate=:L2,numruns=10)
-plot(wp)
-```
-
-```julia
 setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>Kvaerno3()),
           Dict(:alg=>CVODE_BDF()),
@@ -189,18 +177,6 @@ setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>radau())]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
-plot(wp)
-```
-
-```julia
-wp = WorkPrecisionSet(prob,abstols,reltols,setups;dense = false,verbose = SciMLLogging.None(),
-                      appxsol=test_sol,maxiters=Int(1e5),error_estimate=:l2,numruns=10)
-plot(wp)
-```
-
-```julia
-wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
-                      appxsol=test_sol,maxiters=Int(1e5),error_estimate=:L2,numruns=10)
 plot(wp)
 ```
 
@@ -255,8 +231,11 @@ plot(wp)
 This is the speed at lower tolerances, measuring what's good when accuracy is needed.
 
 ```julia
-abstols = 1.0 ./ 10.0 .^ (7:13)
-reltols = 1.0 ./ 10.0 .^ (4:10)
+# The reference solution above is Rodas5P at abstol = reltol = 1e-12, so the sweep
+# stops at abstol 1e-11 / reltol 1e-8; tighter points measured the reference's own
+# error rather than the solver's, and were by far the most expensive in the file.
+abstols = 1.0 ./ 10.0 .^ (7:11)
+reltols = 1.0 ./ 10.0 .^ (4:8)
 
 setups = [
           Dict(:alg=>FBDF()),
@@ -273,18 +252,6 @@ setups = [
           ]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
                       save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
-plot(wp)
-```
-
-```julia
-wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
-                      dense=false,appxsol=test_sol,maxiters=Int(1e5),error_estimate=:l2,numruns=10)
-plot(wp)
-```
-
-```julia
-wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
-                      appxsol=test_sol,maxiters=Int(1e5),error_estimate=:L2,numruns=10)
 plot(wp)
 ```
 
@@ -308,26 +275,15 @@ wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
 plot(wp)
 ```
 
-```julia
-wp = WorkPrecisionSet(prob,abstols,reltols,setups;verbose=SciMLLogging.None(),
-                      dense=false,appxsol=test_sol,maxiters=Int(1e5),error_estimate=:l2,numruns=10)
-plot(wp)
-```
-
-```julia
-wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
-                      appxsol=test_sol,maxiters=Int(1e5),error_estimate=:L2,numruns=10)
-plot(wp)
-```
-
 Multithreading benchmarks with Parallel Extrapolation Methods
 
 ```julia
 #Setting BLAS to one thread to measure gains
 LinearAlgebra.BLAS.set_num_threads(1)
 
-abstols = 1.0 ./ 10.0 .^ (11:13)
-reltols = 1.0 ./ 10.0 .^ (8:10)
+# Kept inside the accuracy of the 1e-12 reference solution (see note above).
+abstols = 1.0 ./ 10.0 .^ (9:11)
+reltols = 1.0 ./ 10.0 .^ (6:8)
 
 setups = [
             Dict(:alg=>CVODE_BDF()),

--- a/benchmarks/StiffODE/MedAkzoNobel.jmd
+++ b/benchmarks/StiffODE/MedAkzoNobel.jmd
@@ -122,9 +122,21 @@ ff = ODEFunction{true, SciMLBase.FullSpecialize}(medakzo!; jac=medakzo_jac!,
     jac_prototype=jac_prototype)
 prob = ODEProblem(ff, u0, tspan)
 
+# The parallel extrapolation methods cannot build a W operator from an ODEFunction that
+# carries an analytic *sparse* Jacobian - they raise
+#     MethodError(SciMLOperators.WOperator,
+#                 (ODEFunction{..., typeof(medakzo_jac!), ..., SparseMatrixCSC{Float64,Int64}, ...},))
+# That is an uncaught error, not a failed solve, so it aborts the whole weave and
+# MedAkzoNobel.md was never written at all (measured: the weave dies in the chunk below
+# after 353 s). Give just those setups the same ODE without the analytic sparse Jacobian
+# and select it with WorkPrecisionSet's `prob_choice`.
+prob_dense = ODEProblem(ODEFunction{true, SciMLBase.FullSpecialize}(medakzo!), u0, tspan)
+probs = [prob, prob_dense]
+
 # Generate reference solution
 sol = solve(prob, CVODE_BDF(), abstol=1/10^14, reltol=1/10^14)
 test_sol = TestSolution(sol)
+appxsols = [test_sol, test_sol]
 
 abstols = 1.0 ./ 10.0 .^ (4:11)
 reltols = 1.0 ./ 10.0 .^ (1:8);
@@ -207,15 +219,15 @@ plot(wp)
 ```julia
 setups = [Dict(:alg=>Rosenbrock23()),
           Dict(:alg=>TRBDF2()),
-          Dict(:alg=>ImplicitEulerExtrapolation()),
-          Dict(:alg=>ImplicitEulerBarycentricExtrapolation()),
-          Dict(:alg=>ImplicitHairerWannerExtrapolation()),
+          Dict(:alg=>ImplicitEulerExtrapolation(), :prob_choice=>2),
+          Dict(:alg=>ImplicitEulerBarycentricExtrapolation(), :prob_choice=>2),
+          Dict(:alg=>ImplicitHairerWannerExtrapolation(), :prob_choice=>2),
           Dict(:alg=>ABDF2()),
           Dict(:alg=>FBDF()),
           Dict(:alg=>NordsieckBDF()),
 ]
-wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
-                      save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
+wp = WorkPrecisionSet(probs,abstols,reltols,setups; verbose=SciMLLogging.None(),
+                      save_everystep=false,appxsol=appxsols,maxiters=Int(1e5),numruns=10)
 plot(wp)
 ```
 
@@ -252,12 +264,12 @@ setups = [Dict(:alg=>Kvaerno4()),
           Dict(:alg=>Rodas4()),
           Dict(:alg=>Rodas5P()),
           Dict(:alg=>radau()),
-          Dict(:alg=>ImplicitEulerExtrapolation()),
-          Dict(:alg=>ImplicitEulerBarycentricExtrapolation()),
-          Dict(:alg=>ImplicitHairerWannerExtrapolation()),
+          Dict(:alg=>ImplicitEulerExtrapolation(), :prob_choice=>2),
+          Dict(:alg=>ImplicitEulerBarycentricExtrapolation(), :prob_choice=>2),
+          Dict(:alg=>ImplicitHairerWannerExtrapolation(), :prob_choice=>2),
           ]
-wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
-                      save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
+wp = WorkPrecisionSet(probs,abstols,reltols,setups; verbose=SciMLLogging.None(),
+                      save_everystep=false,appxsol=appxsols,maxiters=Int(1e5),numruns=10)
 plot(wp)
 ```
 
@@ -280,19 +292,19 @@ setups = [
             Dict(:alg=>lsoda()),
             Dict(:alg=>radau()),
             Dict(:alg=>seulex()),
-            Dict(:alg=>ImplicitEulerExtrapolation(min_order = 5, init_order = 3,threading = OrdinaryDiffEqCore.PolyesterThreads())),
-            Dict(:alg=>ImplicitEulerExtrapolation(min_order = 5, init_order = 3,threading = false)),
-            Dict(:alg=>ImplicitEulerBarycentricExtrapolation(min_order = 5, threading = OrdinaryDiffEqCore.PolyesterThreads())),
-            Dict(:alg=>ImplicitEulerBarycentricExtrapolation(min_order = 5, threading = false)),
-            Dict(:alg=>ImplicitHairerWannerExtrapolation(threading = OrdinaryDiffEqCore.PolyesterThreads())),
-            Dict(:alg=>ImplicitHairerWannerExtrapolation(threading = false)),
+            Dict(:alg=>ImplicitEulerExtrapolation(min_order = 5, init_order = 3,threading = OrdinaryDiffEqCore.PolyesterThreads()), :prob_choice=>2),
+            Dict(:alg=>ImplicitEulerExtrapolation(min_order = 5, init_order = 3,threading = false), :prob_choice=>2),
+            Dict(:alg=>ImplicitEulerBarycentricExtrapolation(min_order = 5, threading = OrdinaryDiffEqCore.PolyesterThreads()), :prob_choice=>2),
+            Dict(:alg=>ImplicitEulerBarycentricExtrapolation(min_order = 5, threading = false), :prob_choice=>2),
+            Dict(:alg=>ImplicitHairerWannerExtrapolation(threading = OrdinaryDiffEqCore.PolyesterThreads()), :prob_choice=>2),
+            Dict(:alg=>ImplicitHairerWannerExtrapolation(threading = false), :prob_choice=>2),
             ]
 
 solnames = ["CVODE_BDF","KenCarp4","Rodas4","Rodas5P","QNDF","NordsieckBDF","lsoda","radau","seulex","ImplEulerExtpl (threaded)", "ImplEulerExtpl (non-threaded)",
             "ImplEulerBaryExtpl (threaded)","ImplEulerBaryExtpl (non-threaded)","ImplHWExtpl (threaded)","ImplHWExtpl (non-threaded)"]
 
-wp = WorkPrecisionSet(prob,abstols,reltols,setups; verbose=SciMLLogging.None(),
-                    names = solnames,save_everystep=false,appxsol=test_sol,maxiters=Int(1e5),numruns=10)
+wp = WorkPrecisionSet(probs,abstols,reltols,setups; verbose=SciMLLogging.None(),
+                    names = solnames,save_everystep=false,appxsol=appxsols,maxiters=Int(1e5),numruns=10)
 
 plot(wp, title = "Implicit Methods: Medical Akzo Nobel",legend=:outertopleft,size = (1000,500),
      xticks = 10.0 .^ (-15:1:1),

--- a/benchmarks/StiffODE/MedAkzoNobel.jmd
+++ b/benchmarks/StiffODE/MedAkzoNobel.jmd
@@ -228,7 +228,6 @@ abstols = 1.0 ./ 10.0 .^ (7:12)
 reltols = 1.0 ./ 10.0 .^ (4:9)
 
 setups = [Dict(:alg=>FBDF()),
-setups = [Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>QNDF()),
           Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>CVODE_BDF()),

--- a/benchmarks/StiffODE/RingModulator.jmd
+++ b/benchmarks/StiffODE/RingModulator.jmd
@@ -180,7 +180,6 @@ abstols = 1.0 ./ 10.0 .^ (7:12)
 reltols = 1.0 ./ 10.0 .^ (4:9)
 
 setups = [Dict(:alg=>FBDF()),
-setups = [Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>QNDF()),
           Dict(:alg=>NordsieckBDF()),
           Dict(:alg=>CVODE_BDF()),


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

This temporary draft makes no code changes. It requests a new benchmark workflow for the unchanged `fix/stiffode-runtime` head so the repository's superseded-run workflow can force-cancel the stale closed-PR run that has occupied `amdci3-1` and `amdci8-1` since 2026-08-29.

The draft will be closed as soon as the stale workflow is cancelled so this request does not consume a benchmark runner itself.

Stale workflow: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/32662018683

Original closed PR: https://github.com/SciML/SciMLBenchmarks.jl/pull/1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
