### PR TITLE
Validate PINN Float64 cuBLASLt failure on V100

### DIFF
--- a/benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
+++ b/benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
@@ -14,7 +14,7 @@ println("GPU: ", CUDA.name(CUDA.device()))
 
 layer = Lux.Dense(2 => 18, tanh)
 
-for T in (Float32, Float64), batch_size in (1, 16, 0)
+for T in (Float32, Float64), batch_size in (1, 16)
     parameters = (
         weight = CUDA.rand(T, 18, 2),
         bias = CUDA.rand(T, 18),

--- a/benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
+++ b/benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
@@ -14,12 +14,12 @@ println("GPU: ", CUDA.name(CUDA.device()))
 const gpud = gpu_device()
 
 cases = (
+    (name = "PINN optimizer", input_dim = 2, width = 18, activation = tanh),
     (name = "Allen-Cahn", input_dim = 5, width = 10, activation = Lux.σ),
     (name = "Nernst-Planck", input_dim = 4, width = 16, activation = tanh),
-    (name = "PINN optimizer", input_dim = 2, width = 18, activation = tanh),
 )
 
-for case in cases, T in (Float32, Float64)
+for case in cases, T in (Float64, Float32)
     chain = Lux.Chain(
         Lux.Dense(case.input_dim => case.width, case.activation),
         Lux.Dense(case.width => case.width, case.activation),
@@ -29,7 +29,7 @@ for case in cases, T in (Float32, Float64)
     parameters = parameters |> ComponentArray |> gpud .|> T
     state = state |> gpud
 
-    for batch_size in (1, 16, 100)
+    for batch_size in (0, 1, 16, 100)
         input = CUDA.rand(T, case.input_dim, batch_size)
 
         @info "Running Lux Chain" case.name T batch_size

--- a/benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
+++ b/benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
@@ -3,27 +3,39 @@ title: Lux Float64 Dense Layer cuBLASLt Reproducer
 author: Chris Rackauckas
 ---
 
-This standalone reproducer exercises the Lux layer operation used by the PINN optimizer
-benchmarks without importing NeuralPDE or another SciML package.
+This standalone reproducer exercises the Lux parameter layout and layer operations used
+by the PINN benchmarks without importing NeuralPDE or another SciML package.
 
 ```julia
-using CUDA, Lux
+using CUDA, ComponentArrays, Lux, LuxCUDA, Random
 
 @assert CUDA.functional() "This reproducer requires a functional CUDA GPU"
 println("GPU: ", CUDA.name(CUDA.device()))
+const gpud = gpu_device()
 
-layer = Lux.Dense(2 => 18, tanh)
+cases = (
+    (name = "Allen-Cahn", input_dim = 5, width = 10, activation = Lux.σ),
+    (name = "Nernst-Planck", input_dim = 4, width = 16, activation = tanh),
+    (name = "PINN optimizer", input_dim = 2, width = 18, activation = tanh),
+)
 
-for T in (Float32, Float64), batch_size in (1, 16)
-    parameters = (
-        weight = CUDA.rand(T, 18, 2),
-        bias = CUDA.rand(T, 18),
+for case in cases, T in (Float32, Float64)
+    chain = Lux.Chain(
+        Lux.Dense(case.input_dim => case.width, case.activation),
+        Lux.Dense(case.width => case.width, case.activation),
+        Lux.Dense(case.width => 1),
     )
-    input = CUDA.rand(T, 2, batch_size)
+    parameters, state = Lux.setup(Random.default_rng(), chain)
+    parameters = parameters |> ComponentArray |> gpud .|> T
+    state = state |> gpud
 
-    @info "Running Lux Dense layer" T batch_size
-    output, _ = layer(input, parameters, NamedTuple())
-    CUDA.synchronize()
-    @assert size(output) == (18, batch_size)
+    for batch_size in (1, 16, 100)
+        input = CUDA.rand(T, case.input_dim, batch_size)
+
+        @info "Running Lux Chain" case.name T batch_size
+        output, _ = chain(input, parameters, state)
+        CUDA.synchronize()
+        @assert size(output) == (1, batch_size)
+    end
 end
 ```

--- a/benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
+++ b/benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
@@ -1,0 +1,29 @@
+---
+title: Lux Float64 Dense Layer cuBLASLt Reproducer
+author: Chris Rackauckas
+---
+
+This standalone reproducer exercises the Lux layer operation used by the PINN optimizer
+benchmarks without importing NeuralPDE or another SciML package.
+
+```julia
+using CUDA, Lux
+
+@assert CUDA.functional() "This reproducer requires a functional CUDA GPU"
+println("GPU: ", CUDA.name(CUDA.device()))
+
+layer = Lux.Dense(2 => 18, tanh)
+
+for T in (Float32, Float64), batch_size in (1, 16, 0)
+    parameters = (
+        weight = CUDA.rand(T, 18, 2),
+        bias = CUDA.rand(T, 18),
+    )
+    input = CUDA.rand(T, 2, batch_size)
+
+    @info "Running Lux Dense layer" T batch_size
+    output, _ = layer(input, parameters, NamedTuple())
+    CUDA.synchronize()
+    @assert size(output) == (18, batch_size)
+end
+```

--- a/benchmarks/PINNOptimizers/neuralpde_cublaslt_mwe.jmd
+++ b/benchmarks/PINNOptimizers/neuralpde_cublaslt_mwe.jmd
@@ -1,0 +1,58 @@
+---
+title: NeuralPDE Float64 cuBLASLt Reproducer
+author: SciML
+---
+
+This focused reproducer evaluates one Poisson PINN loss on a V100. It records
+the Lux input shapes that reach the failing dense-layer path.
+
+```julia
+using CUDA, ComponentArrays, Lux, LuxCUDA, ModelingToolkit, NeuralPDE, Random
+import DomainSets: Interval
+
+@assert CUDA.functional() "This reproducer requires a functional CUDA GPU"
+println("GPU: ", CUDA.name(CUDA.device()))
+const gpud = gpu_device()
+const input_call = Ref(0)
+
+function inspect_input(input)
+    input_call[] += 1
+    if input_call[] <= 30
+        @info "NeuralPDE Lux input" call = input_call[] size = size(input) strides = strides(input) eltype = eltype(input) type = typeof(input)
+    end
+    return input
+end
+
+@parameters x y
+@variables u(..)
+Dxx = Differential(x)^2
+Dyy = Differential(y)^2
+equation = Dxx(u(x, y)) + Dyy(u(x, y)) ~ -sinpi(x) * sinpi(y)
+boundary_conditions = [
+    u(0, y) ~ 0.0,
+    u(1, y) ~ 0.0,
+    u(x, 0) ~ 0.0,
+    u(x, 1) ~ 0.0,
+]
+domains = [x in Interval(0.0, 1.0), y in Interval(0.0, 1.0)]
+chain = Lux.Chain(
+    Lux.WrappedFunction(inspect_input),
+    Lux.Dense(2 => 16, tanh),
+    Lux.Dense(16 => 16, tanh),
+    Lux.Dense(16 => 1),
+)
+parameters = Lux.setup(Random.default_rng(), chain)[1] |>
+    ComponentArray |> gpud .|> Float64
+discretization = PhysicsInformedNN(
+    chain, QuadratureTraining(); init_params = parameters
+)
+@named pde_system = PDESystem(
+    equation, boundary_conditions, domains, [x, y], [u(x, y)]
+)
+problem = discretize(pde_system, discretization)
+loss = problem.f.f(problem.u0, nothing)
+CUDA.synchronize()
+
+@assert isfinite(loss)
+println("Loss: ", loss)
+```

--- a/benchmarks/PINNOptimizers/setup.sh
+++ b/benchmarks/PINNOptimizers/setup.sh
@@ -2,4 +2,12 @@
 set -euo pipefail
 
 benchmark_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project="${benchmark_dir}/Project.toml"
+if ! grep -q '^CUDA_Runtime_jll = ' "${project}"; then
+    if grep -q '^\[extras\]' "${project}"; then
+        sed -i '/^\[extras\]/a CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"' "${project}"
+    else
+        printf '\n[extras]\nCUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"\n' >> "${project}"
+    fi
+fi
 printf '[CUDA_Runtime_jll]\n__clear__ = ["local"]\nversion = "12.9"\n' > "${benchmark_dir}/LocalPreferences.toml"

--- a/benchmarks/PINNOptimizers/setup.sh
+++ b/benchmarks/PINNOptimizers/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+benchmark_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+printf '[CUDA_Runtime_jll]\n__clear__ = ["local"]\nversion = "12.9"\n' > "${benchmark_dir}/LocalPreferences.toml"


### PR DESCRIPTION
## Purpose

This is a validation-only PR and is not intended to merge. The CUDA 12.9 PINN runs in https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33419948741 fail in every PINN page with `CUBLAS_STATUS_INVALID_VALUE` inside Lux's cuBLASLt-backed `Dense` call. The stack shows the first `Dense(2 => 18, tanh)` operating on `CuArray{Float64}` parameters and inputs.

This adds a standalone GPU reproducer that imports only CUDA and Lux. It exercises the matching layer dimensions and activation for Float32 and Float64 at ordinary and empty batch sizes. The per-file benchmark job will establish the smallest failing type/size combination on the V100 runner.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Local verification

The Julia block parses, and the repository gates that do not require a GPU pass:

```text
julia +1.11.9 -e 'source = read(ARGS[1], String); code = only(eachmatch(r"```julia\n(.*?)```"s, source)).captures[1]; Meta.parseall(code); println("JULIA_PARSE_PASS")' benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
JULIA_PARSE_PASS

GROUP=Core julia +1.11.9 --project -e 'using Pkg; Pkg.test()'
Core | 45 passed

GROUP=QA julia +1.11.9 --project -e 'using Pkg; Pkg.test()'
QA | 21 passed

typos benchmarks/PINNOptimizers/cublaslt_float64_mwe.jmd
git diff --check upstream/master...HEAD
```

## Not verified

This host has no CUDA GPU. The new page is intentionally waiting for the V100 benchmark job; no claim is made yet about which input case reproduces the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
