### PR TITLE
Use isolated Conda Python and R for MultiLanguage benchmarks

### DIFF
--- a/benchmarks/MultiLanguage/setup.sh
+++ b/benchmarks/MultiLanguage/setup.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# These sentinel values make PyCall and RCall use their managed Conda environments.
+# PyCall and RCall use Conda; R also needs Conda's newer libstdc++ ahead of Julia's.
 if [[ -n "${BENCHMARK_ENV_FILE:-}" ]]; then
     echo 'export PYTHON=""' >> "${BENCHMARK_ENV_FILE}"
     echo 'export R_HOME="*"' >> "${BENCHMARK_ENV_FILE}"
+    echo 'export CONDA_JL_HOME="${CONDA_JL_HOME:-${HOME}/.julia/conda/3/x86_64}"' >> "${BENCHMARK_ENV_FILE}"
+    echo 'export LD_LIBRARY_PATH="${CONDA_JL_HOME}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"' >> "${BENCHMARK_ENV_FILE}"
 fi

--- a/benchmarks/MultiLanguage/setup.sh
+++ b/benchmarks/MultiLanguage/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+# An empty PYTHON makes PyCall use its Conda environment, where SciPyDiffEq can install SciPy.
+if [[ -n "${BENCHMARK_ENV_FILE:-}" ]]; then
+    echo 'export PYTHON=""' >> "${BENCHMARK_ENV_FILE}"
+fi

--- a/benchmarks/MultiLanguage/setup.sh
+++ b/benchmarks/MultiLanguage/setup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# An empty PYTHON makes PyCall use its Conda environment, where SciPyDiffEq can install SciPy.
+# These sentinel values make PyCall and RCall use their managed Conda environments.
 if [[ -n "${BENCHMARK_ENV_FILE:-}" ]]; then
     echo 'export PYTHON=""' >> "${BENCHMARK_ENV_FILE}"
+    echo 'export R_HOME="*"' >> "${BENCHMARK_ENV_FILE}"
 fi

--- a/benchmarks/MultiLanguage/setup.sh
+++ b/benchmarks/MultiLanguage/setup.sh
@@ -5,6 +5,6 @@ set -euo pipefail
 if [[ -n "${BENCHMARK_ENV_FILE:-}" ]]; then
     echo 'export PYTHON=""' >> "${BENCHMARK_ENV_FILE}"
     echo 'export R_HOME="*"' >> "${BENCHMARK_ENV_FILE}"
-    echo 'export CONDA_JL_HOME="${CONDA_JL_HOME:-${HOME}/.julia/conda/3/x86_64}"' >> "${BENCHMARK_ENV_FILE}"
+    echo 'export CONDA_JL_HOME="${CONDA_JL_HOME:-${HOME}/.julia/conda/SciMLBenchmarks/MultiLanguage}"' >> "${BENCHMARK_ENV_FILE}"
     echo 'export LD_LIBRARY_PATH="${CONDA_JL_HOME}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"' >> "${BENCHMARK_ENV_FILE}"
 fi

--- a/test/core.jl
+++ b/test/core.jl
@@ -6,14 +6,15 @@ using Test
     @test !isfile(joinpath(repository_root, ".github", "workflows", "DocPreviewCleanup.yml"))
 end
 
-@testset "MultiLanguage Python setup" begin
+@testset "MultiLanguage managed language setup" begin
     setup = joinpath(
         dirname(@__DIR__), "benchmarks", "MultiLanguage", "setup.sh"
     )
     mktemp() do environment_file, io
         close(io)
         run(setenv(`bash $setup`, "BENCHMARK_ENV_FILE" => environment_file))
-        @test read(environment_file, String) == "export PYTHON=\"\"\n"
+        @test read(environment_file, String) ==
+            "export PYTHON=\"\"\nexport R_HOME=\"*\"\n"
     end
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -16,7 +16,7 @@ end
         @test read(environment_file, String) ==
             "export PYTHON=\"\"\n" *
             "export R_HOME=\"*\"\n" *
-            "export CONDA_JL_HOME=\"\${CONDA_JL_HOME:-\${HOME}/.julia/conda/3/x86_64}\"\n" *
+            "export CONDA_JL_HOME=\"\${CONDA_JL_HOME:-\${HOME}/.julia/conda/SciMLBenchmarks/MultiLanguage}\"\n" *
             "export LD_LIBRARY_PATH=\"\${CONDA_JL_HOME}/lib\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}\"\n"
     end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -6,6 +6,17 @@ using Test
     @test !isfile(joinpath(repository_root, ".github", "workflows", "DocPreviewCleanup.yml"))
 end
 
+@testset "MultiLanguage Python setup" begin
+    setup = joinpath(
+        dirname(@__DIR__), "benchmarks", "MultiLanguage", "setup.sh"
+    )
+    mktemp() do environment_file, io
+        close(io)
+        run(setenv(`bash $setup`, "BENCHMARK_ENV_FILE" => environment_file))
+        @test read(environment_file, String) == "export PYTHON=\"\"\n"
+    end
+end
+
 @testset "IJulia extension" begin
     fallback_method = which(SciMLBenchmarks.open_notebooks, Tuple{})
     @test fallback_method.module === SciMLBenchmarks

--- a/test/core.jl
+++ b/test/core.jl
@@ -14,7 +14,10 @@ end
         close(io)
         run(setenv(`bash $setup`, "BENCHMARK_ENV_FILE" => environment_file))
         @test read(environment_file, String) ==
-            "export PYTHON=\"\"\nexport R_HOME=\"*\"\n"
+            "export PYTHON=\"\"\n" *
+            "export R_HOME=\"*\"\n" *
+            "export CONDA_JL_HOME=\"\${CONDA_JL_HOME:-\${HOME}/.julia/conda/3/x86_64}\"\n" *
+            "export LD_LIBRARY_PATH=\"\${CONDA_JL_HOME}/lib\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}\"\n"
     end
 end
 


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until reviewed by @ChrisRackauckas.

## What changed and why

The MultiLanguage runner previously built PyCall against `/usr/bin/python3`, whose environment does not contain SciPy, and RCall had no managed R configuration. This adds the benchmark setup hook that selects Conda for both wrappers, places them in a dedicated persistent MultiLanguage Conda root, and loads Conda's C++ runtime before Julia's older bundled copy so the installed `libR` can be opened.

The dedicated root is important on the persistent runners: resolving `r-base` against the existing shared 243-package Julia Conda environment remained CPU-bound in the classic solver for the full one-hour local bound. A clean benchmark-specific root installed a current Miniforge environment and resolved R without inheriting unrelated constraints.

The hook is scoped to MultiLanguage and preserves an explicitly supplied `CONDA_JL_HOME`.

## Failing before

The previous full runner failed before any benchmark comparison ran:

```text
ModuleNotFoundError: No module named 'scipy'
```

https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33042289225/job/98418417866

The setup regression test failed on unmodified master because the hook did not exist. After the initial shared-root setup, the same exact test failed when changed to require the isolated fallback:

```text
Test Summary:                          | Pass  Fail  Total
Core                                   |   85     1     86
  MultiLanguage managed language setup |          1      1

Evaluated: .../.julia/conda/3/x86_64 == .../.julia/conda/SciMLBenchmarks/MultiLanguage
```

The real shared-root R build was bounded externally with Bash and timed out during dependency solving:

```text
Collecting package metadata (repodata.json): done
Solving environment: working...
# exit 124 after 3600 seconds
```

## Passing after

The same repository regression test passes with the dedicated fallback:

```text
Test Summary: | Pass  Total   Time
Core          |   86     86  37.6s
Testing SciMLBenchmarks tests passed
```

I then built Conda and RCall against an empty isolated root while applying the exact `PYTHON`, `R_HOME`, `CONDA_JL_HOME`, and `LD_LIBRARY_PATH` setup. The install completed and a real R evaluation passed:

```text
ISOLATED_RCALL_PASS result=2.0 Rhome=.../.validation/conda-multilanguage/lib/R
```

The same isolated root installed SciPy through SciPyDiffEq. A public SciPyDiffEq RK45 solve completed successfully:

```text
value=0.36787944119184823 error=2.0405899192610377e-11 retcode=Success
ISOLATED_SCIPY_SOLVE_PASS
```

Repository gates on the exact rebased tree:

```text
Core | 86/86
QA   | 21/21 | 1m52.0s
bash -n benchmarks/MultiLanguage/setup.sh: exit 0
Runic on test/core.jl: exit 0
typos on both changed files: exit 0
git diff --check: exit 0
```

## Not verified locally

I did not run the complete MultiLanguage weave because this host does not have MATLAB. The full self-hosted runner job is still required to verify MATLAB, R, SciPy, and Julia together. No docs build was run because this changes benchmark setup and a private regression test, not public API or docstrings.

## Links

- This PR: https://github.com/SciML/SciMLBenchmarks.jl/pull/1801
- Previous failing runner: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33042289225/job/98418417866
- Stacked dependency declaration PR: https://github.com/SciML/SciMLBenchmarks.jl/pull/1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
