### PR TITLE
Fix ParameterEstimation ModelingToolkit imports

### DIFF
--- a/benchmarks/ParameterEstimation/FitzHughNagumoParameterEstimation.jmd
+++ b/benchmarks/ParameterEstimation/FitzHughNagumoParameterEstimation.jmd
@@ -8,7 +8,13 @@ author: Vaibhav Dixit, Chris Rackauckas
 ```julia
 using ParameterizedFunctions, OrdinaryDiffEq, DiffEqParamEstim, Optimization
 using OptimizationBBO, OptimizationNLopt, ForwardDiff, Plots, BenchmarkTools
-using ModelingToolkit: t_nounits as t, D_nounits as D
+import ModelingToolkit
+using ModelingToolkit: @mtkbuild, D_nounits as D, t_nounits as t
+@static if isdefined(ModelingToolkit, Symbol("@mtkmodel"))
+    using ModelingToolkit: @mtkmodel
+else
+    using SciCompDSL: @mtkmodel
+end
 gr(fmt = :png)
 ```
 

--- a/benchmarks/ParameterEstimation/LorenzParameterEstimation.jmd
+++ b/benchmarks/ParameterEstimation/LorenzParameterEstimation.jmd
@@ -10,7 +10,13 @@ Note: If data is generated with a fixed time step method and then is tested agai
 ```julia
 using ParameterizedFunctions, OrdinaryDiffEq, DiffEqParamEstim, Optimization
 using OptimizationBBO, OptimizationNLopt, Plots, ForwardDiff, BenchmarkTools
-using ModelingToolkit: t_nounits as t, D_nounits as D
+import ModelingToolkit
+using ModelingToolkit: @mtkbuild, D_nounits as D, t_nounits as t
+@static if isdefined(ModelingToolkit, Symbol("@mtkmodel"))
+    using ModelingToolkit: @mtkmodel
+else
+    using SciCompDSL: @mtkmodel
+end
 gr(fmt = :png)
 ```
 

--- a/benchmarks/ParameterEstimation/LotkaVolterraParameterEstimation.jmd
+++ b/benchmarks/ParameterEstimation/LotkaVolterraParameterEstimation.jmd
@@ -8,7 +8,13 @@ author: Vaibhav Dixit, Chris Rackauckas
 ```julia
 using ParameterizedFunctions, OrdinaryDiffEq, DiffEqParamEstim, Optimization, ForwardDiff
 using OptimizationBBO, OptimizationNLopt, Plots, RecursiveArrayTools, BenchmarkTools
-using ModelingToolkit: t_nounits as t, D_nounits as D
+import ModelingToolkit
+using ModelingToolkit: @mtkbuild, D_nounits as D, t_nounits as t
+@static if isdefined(ModelingToolkit, Symbol("@mtkmodel"))
+    using ModelingToolkit: @mtkmodel
+else
+    using SciCompDSL: @mtkmodel
+end
 gr(fmt = :png)
 ```
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -65,6 +65,26 @@ end
     @test collect(Base.invokelatest(lorenz_grid, 4, Float32)) == Float32[0, 7, 14, 21]
 end
 
+@testset "ParameterEstimation ModelingToolkit imports" begin
+    benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks", "ParameterEstimation")
+    filenames = (
+        "FitzHughNagumoParameterEstimation.jmd",
+        "LorenzParameterEstimation.jmd",
+        "LotkaVolterraParameterEstimation.jmd",
+    )
+    for filename in filenames
+        source = read(joinpath(benchmarks_dir, filename), String)
+        imports = match(r"(?ms)^```julia\n(?<code>.*?)^```", source)
+        @test !isnothing(imports)
+        for name in ("@mtkbuild", "@mtkmodel")
+            @test occursin(name, imports[:code])
+        end
+        @test occursin("@static if isdefined(ModelingToolkit, Symbol(\"@mtkmodel\"))", imports[:code])
+        @test occursin("using ModelingToolkit: @mtkmodel", imports[:code])
+        @test occursin("using SciCompDSL: @mtkmodel", imports[:code])
+    end
+end
+
 @testset "subprocess" begin
     process = SciMLBenchmarks.@subprocess exit()
     @test success(process)


### PR DESCRIPTION
## What changed

Import the public `@mtkbuild` macro used by all three ParameterEstimation pages and load `@mtkmodel` from the package that owns it on each supported ModelingToolkit generation. The benchmark's checked-in manifest uses the older SciCompDSL definition, while current ModelingToolkit re-exports the macro, so the small static bridge keeps the pages loadable during the dependency transition.

Add a Core regression covering the import block in every affected page.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

The same new Core regression was run against the unfixed pages and then the proposed pages:

```text
# unfixed source restored
Some tests did not pass: 48 passed, 15 failed, 0 errored, 0 broken.

# proposed source
Test Summary: | Pass  Total
SciMLBenchmarks | 63     63
Testing SciMLBenchmarks tests passed
```

QA on the proposed source:

```text
Test Summary: | Pass  Total
SciMLBenchmarks | 21     21
Testing SciMLBenchmarks tests passed
```

The repository formatter, `typos` over all four changed files, and `git diff --check` all exited successfully.

I also ran all three pages sequentially against the checked-in Julia 1.10 manifest with the normal benchmark entry point:

```bash
julia --threads=auto --project=. benchmark.jl benchmarks/ParameterEstimation/FitzHughNagumoParameterEstimation.jmd
julia --threads=auto --project=. benchmark.jl benchmarks/ParameterEstimation/LorenzParameterEstimation.jmd
julia --threads=auto --project=. benchmark.jl benchmarks/ParameterEstimation/LotkaVolterraParameterEstimation.jmd
```

The three-command run exited 0 after each page completed weaving. The numerical optimization emitted existing solver/NaN warnings; this is not a warning-free claim.

## Not verified

I did not complete a full weave on a current-major ModelingToolkit environment. The import bridge is required there, but current SciCompDSL macro expansion is independently blocked by a macro-hygiene error being fixed upstream. This PR does not change the ParameterEstimation manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
