### PR TITLE
Update SimpleHandwrittenPDE to released KenCarp fix

### DIFF
--- a/benchmarks/SimpleHandwrittenPDE/Manifest.toml
+++ b/benchmarks/SimpleHandwrittenPDE/Manifest.toml
@@ -1720,9 +1720,9 @@ version = "2.5.0"
 
 [[deps.OrdinaryDiffEqDifferentiation]]
 deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "ConstructionBase", "DiffEqBase", "DifferentiationInterface", "FastBroadcast", "FiniteDiff", "ForwardDiff", "FunctionWrappersWrappers", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEqCore", "SciMLBase", "SciMLOperators", "SparseMatrixColorings", "StaticArraysCore"]
-git-tree-sha1 = "f8310c055e3097b3856972c06e63686b64806681"
+git-tree-sha1 = "d44a802aff84db13b6a3cb24d499c95f81776bc5"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
-version = "3.11.1"
+version = "3.11.4"
 weakdeps = ["SparseArrays"]
 
     [deps.OrdinaryDiffEqDifferentiation.extensions]
@@ -1766,9 +1766,9 @@ version = "2.7.0"
 
 [[deps.OrdinaryDiffEqNonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "CommonSolve", "ConstructionBase", "DiffEqBase", "FastBroadcast", "FastClosures", "ForwardDiff", "LinearAlgebra", "LinearSolve", "MuladdMacro", "NonlinearSolve", "NonlinearSolveBase", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "PreallocationTools", "RecursiveArrayTools", "SciMLBase", "SciMLOperators", "SciMLPublic", "SimpleNonlinearSolve", "SparseArrays", "StaticArraysCore"]
-git-tree-sha1 = "983b427d531529c391feb031f84dbef9cff1d04f"
+git-tree-sha1 = "700cd6cb734e5513d6c74435bf9e3a3b73895931"
 uuid = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
-version = "2.9.3"
+version = "2.9.4"
 
 [[deps.OrdinaryDiffEqRosenbrock]]
 deps = ["ADTypes", "ArrayInterface", "DiffEqBase", "DifferentiationInterface", "FastBroadcast", "FiniteDiff", "ForwardDiff", "LinearAlgebra", "LinearSolve", "MacroTools", "MuladdMacro", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqRosenbrockTableaus", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase"]


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Update the SimpleHandwrittenPDE Manifest from `OrdinaryDiffEqNonlinearSolve 2.9.3` to `2.9.4`, the first release containing the KenCarp/LinearSolve fix from https://github.com/SciML/OrdinaryDiffEq.jl/pull/4391. The targeted package update also moves `OrdinaryDiffEqDifferentiation 3.11.1` to `3.11.4`; no Project compat or benchmark source changes are needed.

The previous benchmark refresh incorrectly identified `2.9.3` as the companion release. Git history confirms the fix is not an ancestor of the `2.9.3` tag and is an ancestor of `2.9.4`.

## Failing before

On exact current master (`76978f4f`) and its pinned Manifest, a corrected low-tolerance probe started the first `KenCarp3()` default-linear-solver solve at tolerance `1e-7` and did not return after 3,644 seconds of one-core CPU time. I terminated that exact process after the one-hour threshold. Its termination stack was:

```text
Krylov.gmres!
LinearSolve.solve!(::DefaultLinearSolver)
OrdinaryDiffEqDifferentiation.dolinsolve
OrdinaryDiffEqNonlinearSolve.compute_step!
OrdinaryDiffEqSDIRK.perform_step!
```

The current master folder job remains in progress on `amdci1-1` after more than 38 hours: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33306014679/job/99247956935.

## Passing after

With only the Manifest update, the same probe completed all 45 requested solver/tolerance pairs with `ReturnCode.Success`. The first compiled `KenCarp3()` solve took 28.882 seconds; subsequent default and explicit Krylov KenCarp solves took 0.190–1.666 seconds, and all ARKODE controls also completed.

The exact affected page then completed locally:

```sh
timeout 14400 julia +1.10.11 --threads=auto --startup-file=no \
  --project=.validation/root-env benchmark.jl \
  benchmarks/SimpleHandwrittenPDE/ks_fdm_wpd.jmd
```

All 13 chunks completed and the command exited 0. The rendered phase took 1,943.584 seconds and produced a 36,528-byte Markdown page with ten nonempty figures and no embedded Julia exception or stack trace.

Environment and repository gates:

```text
Pkg.resolve(): no changes
Pkg.precompile(strict=true): exit 0 (17 precompiled, 469 already precompiled)
Core | 45/45 | 37.1s
QA   | 19/19 | 1m00.5s
Runic on the tangled page: exit 0
typos on the changed Manifest: exit 0
git diff --check: exit 0
```

## Scope

The current-master source already contains the restored benchmark ranges from https://github.com/SciML/SciMLBenchmarks.jl/pull/1785. This PR supplies the missing registered release needed for those pages to exercise the repaired solver path. I validated the affected KS finite-difference page, not the complete ten-page folder; the PR's full-folder self-hosted run is the publication candidate. No GPU, downstream, or `GROUP=Everything` jobs were run.

## Links

- LinearSolve tolerance fix: https://github.com/SciML/LinearSolve.jl/pull/1255
- LinearSolve follow-up: https://github.com/SciML/LinearSolve.jl/pull/1263
- OrdinaryDiffEq companion fix: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4391
- Restored benchmark ranges: https://github.com/SciML/SciMLBenchmarks.jl/pull/1785
- Current stuck master job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33306014679/job/99247956935

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
