### PR TITLE
Cancel superseded master jobs per benchmark target

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -94,6 +94,9 @@ jobs:
         (needs.detect-changes.result == 'success' && needs.detect-changes.outputs.has_changes == 'true') ||
         (needs.manual-matrix.result == 'success' && needs.manual-matrix.outputs.has_changes == 'true')
       )
+    concurrency:
+      group: benchmark-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}-${{ matrix.target }}
+      cancel-in-progress: true
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:

--- a/test/core.jl
+++ b/test/core.jl
@@ -39,6 +39,10 @@ function benchmark_assignment(path, variable)
     return Meta.parse(strip(split(line, "="; limit = 2)[2]))
 end
 
+function workflow_job(workflow, name)
+    return match(Regex("(?ms)^  $(name):\\n(?<body>.*?)(?=^  [a-zA-Z][a-zA-Z0-9_-]*:\\n|\\z)"), workflow)
+end
+
 @testset "DiffEqGPU singleton parameter grids" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks", "DiffEqGPU")
 
@@ -72,9 +76,7 @@ end
 
 @testset "benchmark publication" begin
     workflow = read(joinpath(dirname(@__DIR__), ".github", "workflows", "benchmarks.yml"), String)
-    benchmark_job = match(
-        r"(?ms)^  benchmark:\n(?<body>.*?)(?=^  [a-zA-Z][a-zA-Z0-9_-]*:\n|\z)", workflow
-    )
+    benchmark_job = workflow_job(workflow, "benchmark")
     @test !isnothing(benchmark_job)
     if !isnothing(benchmark_job)
         @test occursin("- name: Publish to SciMLBenchmarksOutput", benchmark_job[:body])
@@ -178,6 +180,17 @@ end
     @test occursin("format('pr-{0}', github.event.pull_request.number)", workflow)
     @test occursin("github.event_name == 'pull_request' || github.ref != 'refs/heads/master'", workflow)
     @test occursin("github.event.action != 'closed'", workflow)
+
+    benchmark_job = workflow_job(workflow, "benchmark")
+    @test !isnothing(benchmark_job)
+    if !isnothing(benchmark_job)
+        @test occursin(
+            "format('pr-{0}', github.event.pull_request.number) || github.ref",
+            benchmark_job[:body],
+        )
+        @test occursin("\${{ matrix.target }}", benchmark_job[:body])
+        @test occursin("cancel-in-progress: true", benchmark_job[:body])
+    end
 
     cancellation_path = joinpath(
         dirname(@__DIR__), ".github", "workflows", "cancel-superseded-benchmarks.yml"


### PR DESCRIPTION
## What changed and why

The workflow-level per-run concurrency group lets unrelated master benchmarks occupy different runners, but it also means an obsolete job keeps running after a newer master push schedules the same benchmark folder. Two SimpleHandwrittenPDE master jobs are currently consuming `amdci1-1` and `amdci3-1` simultaneously; the older one predates the runtime repair and has been running since 2026-08-30.

This adds job-level concurrency keyed by ref (or pull-request number) and `matrix.target`. A newer master or manual run now cancels only an older job for the identical target. Unrelated benchmark folders remain parallel, and one pull request cannot cancel another pull request or a master publication run.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Failure discrimination

With the finalized regression assertions present and the three workflow lines removed, I ran:

```bash
GROUP=Core timeout 3600 julia +1.11 --project=.validation/root-env \
  -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
```

The test found that the benchmark job had no target-specific group and did not cancel in-progress work:

```text
superseded pull request cancellation: Test Failed
  occursin("format('pr-{0}', github.event.pull_request.number) || github.ref", benchmark_job[:body])

superseded pull request cancellation: Test Failed
  occursin("cancel-in-progress: true", benchmark_job[:body])

Core | Pass 87 | Fail 2 | Total 89
```

With the workflow change restored, the identical Core group passed:

```text
Core | Pass 89 | Total 89 | 35.2s
Testing SciMLBenchmarks tests passed
```

## Other verification

```text
GROUP=QA julia +1.11 --project=.validation/root-env -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
QA | Pass 21 | Total 21 | 1m50.8s
Testing SciMLBenchmarks tests passed

actionlint .github/workflows/benchmarks.yml: passed
Runic --check test/core.jl: passed
typos .github/workflows/benchmarks.yml test/core.jl: passed
git diff --check: passed
```

No benchmark source, public API, or documentation changed, so no benchmark weave or docs build was run. The current obsolete SimpleHandwrittenPDE job cannot be retroactively placed in this new concurrency group; it still requires an account with Actions write permission to force-cancel, or it will reach GitHub's five-day job limit.

## Links

- Obsolete SimpleHandwrittenPDE job on `amdci1-1`: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33306014679/job/99247956935
- Repaired SimpleHandwrittenPDE job on `amdci3-1`: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33838946692/job/100917136008
- Concurrency rescue that enabled parallel master runs: https://github.com/SciML/SciMLBenchmarks.jl/pull/1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
