### PR TITLE
Rebuild benchmarks after support-file changes

### DIFF
--- a/.github/scripts/detect-changed-benchmarks.sh
+++ b/.github/scripts/detect-changed-benchmarks.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 # Detect changed benchmark files and produce a JSON matrix for GHA.
 # Replicates the project-coalescing logic:
 #   - A changed .jmd file triggers a rebuild of just that file
-#   - A changed .toml file (Project.toml/Manifest.toml) triggers a rebuild of its entire benchmark directory
+#   - Any other changed file triggers a rebuild of its entire benchmark directory
 #   - If a directory is already being rebuilt, individual .jmd files in it are suppressed
 #
 # Reads runner configuration from:
@@ -60,8 +60,6 @@ find_project() {
 
 while IFS= read -r f; do
     [[ -z "${f}" ]] && continue
-    # Skip benchmark_config.toml changes — they don't trigger rebuilds
-    [[ "${f}" == */benchmark_config.toml ]] && continue
     proj=$(find_project "$(dirname "${f}")")
     if [[ -z "${proj}" ]]; then
         echo "::warning::Unable to find project for ${f}"
@@ -70,7 +68,7 @@ while IFS= read -r f; do
 
     if [[ "${f}" == *.jmd ]]; then
         FILES["${f}"]="${proj}"
-    elif [[ "${f}" == *.toml ]]; then
+    else
         PROJECTS["${proj}"]=1
     fi
 done <<< "${CHANGED_FILES}"

--- a/.github/scripts/test-detect-changed-benchmarks.sh
+++ b/.github/scripts/test-detect-changed-benchmarks.sh
@@ -57,4 +57,30 @@ if [[ "${TARGETS}" != "benchmarks/Beta" ]]; then
     exit 1
 fi
 
+SUPPORT_BASE_SHA=$(git -C "${FIXTURE}" rev-parse HEAD)
+printf '#!/bin/sh\n' > "${FIXTURE}/benchmarks/Alpha/setup.sh"
+git -C "${FIXTURE}" add benchmarks/Alpha/setup.sh
+git -C "${FIXTURE}" commit -qm "Update Alpha setup"
+
+SUPPORT_OUTPUT_FILE="${TEST_ROOT}/support-github-output"
+(
+    cd "${FIXTURE}"
+    GITHUB_EVENT_NAME=push \
+        PUSH_BASE_SHA="${SUPPORT_BASE_SHA}" \
+        GITHUB_OUTPUT="${SUPPORT_OUTPUT_FILE}" \
+        PATH="${TEST_ROOT}/bin:${PATH}" \
+        .github/scripts/detect-changed-benchmarks.sh
+)
+
+SUPPORT_TARGETS=$(sed -n 's/^matrix=//p' "${SUPPORT_OUTPUT_FILE}" \
+    | grep -o '"target":"[^"]*"' \
+    | cut -d'"' -f4 \
+    | sort || true)
+
+if [[ "${SUPPORT_TARGETS}" != "benchmarks/Alpha" ]]; then
+    printf 'Expected benchmarks/Alpha for a support-file change, got:\n%s\n' \
+        "${SUPPORT_TARGETS}" >&2
+    exit 1
+fi
+
 echo "Push detection selected only changes since the event's before SHA."


### PR DESCRIPTION
## Review status

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The benchmark detector previously scheduled individual `.jmd` changes and full-folder rebuilds for `.toml` changes, but silently ignored every other file below a benchmark project. That caused https://github.com/SciML/SciMLBenchmarks.jl/pull/1801 to skip its benchmark even though it changes `benchmarks/MultiLanguage/setup.sh`.

This treats every non-`.jmd` file below a benchmark project as a full-folder trigger. It covers setup scripts, auxiliary source/data files, and `benchmark_config.toml`; changed notebooks remain individually targeted, and the existing project coalescing still suppresses redundant notebook jobs.

## Failing before / passing after

I added the same setup-file fixture and ran the same detector test before and after the implementation change.

Before:

```text
Diffing against push event base SHA: e8b9a88ea051c0c63cb4121f20e625d50d28e57f
No benchmark changes detected.
Expected benchmarks/Alpha for a support-file change, got:

Process exited 1
```

After:

```text
Diffing against push event base SHA: cd39823dfa78c121a7418ad47a9114f1f6bd293f
Detected benchmark targets:
  benchmarks/Alpha -> runner=["self-hosted", "benchmark"] timeout=12000 julia=1.11
Push detection selected only changes since the event's before SHA.
Process exited 0
```

## Local verification

```text
$ bash .github/scripts/test-detect-changed-benchmarks.sh
Process exited 0

$ GROUP=Core julia +1.11.9 --project=.validation/root-env -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
Core | 85 passed / 85 total | 57.9s

$ GROUP=QA julia +1.11.9 --project=.validation/root-env -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
QA | 21 passed / 21 total | 2m04.2s
```

Also passed `bash -n` for both changed scripts, `typos` over both changed scripts, and `git diff --check`. Runic is not applicable to this shell-only diff. `shfmt` is not installed on this host, and this repository does not declare it as a formatter. No documentation or public API changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512