### PR TITLE
Reserve benchmark runners for benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,16 +5,20 @@ on:
     branches: [master]
     paths:
       - 'src/**/*.jl'
+      - 'test/**'
       - '*.toml'
+      - '.github/workflows/test.yml'
   pull_request:
     paths:
       - 'src/**/*.jl'
+      - 'test/**'
       - '*.toml'
+      - '.github/workflows/test.yml'
 
 jobs:
   test:
     name: Julia Tests
-    runs-on: [self-hosted, benchmark]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7

--- a/test/core.jl
+++ b/test/core.jl
@@ -82,6 +82,18 @@ end
     end
 end
 
+@testset "root test workflow" begin
+    workflow = read(joinpath(dirname(@__DIR__), ".github", "workflows", "test.yml"), String)
+    test_job = match(r"(?ms)^  test:\n(?<body>.*?)(?=^  [a-zA-Z][a-zA-Z0-9_-]*:\n|\z)", workflow)
+    @test occursin("      - 'test/**'", workflow)
+    @test occursin("      - '.github/workflows/test.yml'", workflow)
+    @test !isnothing(test_job)
+    if !isnothing(test_job)
+        @test occursin("runs-on: ubuntu-latest", test_job[:body])
+        @test !occursin("self-hosted", test_job[:body])
+    end
+end
+
 @testset "NeuralNetworks V100 environment" begin
     folder = joinpath(dirname(@__DIR__), "benchmarks", "NeuralNetworks")
     preferences_path = joinpath(folder, "LocalPreferences.toml")


### PR DESCRIPTION
## Review status

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Run the root Julia test job on GitHub-hosted `ubuntu-latest` instead of the three-machine `[self-hosted, benchmark]` pool. The job only tests the root package and weaves the small Testing fixture; it does not need benchmark hardware. A currently queued example is https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33852055025/job/100956848905.

Also trigger that workflow when `test/**` or `.github/workflows/test.yml` changes. Previously changes to the tests and to the workflow itself could merge without exercising this job.

## Failing before / passing after

I added the same five workflow assertions and ran the same Core group before and after editing the workflow.

Before:

```text
Test Summary:        | Pass  Fail  Total  Time
root test workflow   |    1     4      5  2.3s
Core                 |   86     4     90  43.5s
ERROR: Some tests did not pass
Process exited 1
```

The four failures were the missing `test/**` trigger, missing workflow self-trigger, missing `ubuntu-latest`, and presence of `self-hosted`.

After:

```text
Test Summary: | Pass  Total   Time
Core          |   90     90  36.1s
Testing SciMLBenchmarks tests passed
Process exited 0
```

## Local verification

The workflow uses Julia 1.10, so I ran its package test command on that version as well:

```text
$ julia +1.10.11 --project=.validation/root-env-110 -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
Test Summary: | Pass  Total   Time
Core          |   90     90  37.4s
Testing SciMLBenchmarks tests passed
```

Additional validation:

```text
Julia 1.11.9 Core | 90 passed / 90 total
Julia 1.11.9 QA   | 21 passed / 21 total
actionlint .github/workflows/test.yml: passed
Runic test/core.jl: passed
typos over changed files: passed
git diff --check: passed
```

The actual GitHub-hosted execution is not claimed locally. This PR now triggers its own Tests workflow, which will provide that verification. No documentation or public API changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512