### PR TITLE
Fix OptimizationFrameworks SymbolicUtils precompile

### DIFF
--- a/benchmarks/OptimizationFrameworks/Manifest.toml
+++ b/benchmarks/OptimizationFrameworks/Manifest.toml
@@ -1648,7 +1648,7 @@ uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
 version = "1.3.6+0"
 
 [[deps.OpenBLAS32_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "libblastrampoline_jll"]
 git-tree-sha1 = "dd0d9979377e43918a80486a562ddedcc6d9bdf3"
 uuid = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 version = "0.3.33+0"
@@ -2420,9 +2420,9 @@ version = "1.1.0"
 
 [[deps.SymbolicUtils]]
 deps = ["AbstractTrees", "ArrayInterface", "Combinatorics", "ConstructionBase", "DataStructures", "Dictionaries", "DocStringExtensions", "DynamicPolynomials", "EnumX", "ExproniconLite", "Graphs", "LinearAlgebra", "MacroTools", "Moshi", "MultivariatePolynomials", "MutableArithmetics", "NaNMath", "PrecompileTools", "ReadOnlyArrays", "Setfield", "SparseArrays", "SpecialFunctions", "StaticArraysCore", "SymbolicIndexingInterface", "TaskLocalValues", "TermInterface", "WeakCacheSets"]
-git-tree-sha1 = "ae8741c34009171ee8e46d5c209cf0a15c469928"
+git-tree-sha1 = "eda3976d610de0b1d4091c76368b5d05f9d3d4a6"
 uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
-version = "4.26.0"
+version = "4.26.1"
 
     [deps.SymbolicUtils.extensions]
     SymbolicUtilsChainRulesCoreExt = "ChainRulesCore"


### PR DESCRIPTION
## What changed and why

Update the OptimizationFrameworks manifest from SymbolicUtils 4.26.0 to 4.26.1, the first registered patch release that removes duplicate `apply_optimization_rules` and `apply_optimization_rule` definitions. The duplicate methods prevent SymbolicUtils and its dependents from precompiling on Julia 1.11.9.

This is a manifest-only dependency repair. `Pkg.resolve()` also records the missing `libblastrampoline_jll` dependency edge for the already-pinned OpenBLAS32_jll entry.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failure evidence before the fix

On clean upstream `master` at `5a23df024eb7b2c0760af574ac791d609ebe4291`, with Julia 1.11.9 and a fresh depot:

```sh
/home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no \
  --project=benchmarks/OptimizationFrameworks \
  -e 'id = Base.PkgId(Base.UUID("d1185830-fcd6-423d-90d6-eec64667417b"), "SymbolicUtils"); result = Base.compilecache(id); @assert !(result isa Core.PrecompilableError) result'
```

```text
WARNING: Method definition apply_optimization_rules(SymbolicUtils.IRStructure{T} where T, Any, Any) in module Code at .../SymbolicUtils/QkCnQ/src/code.jl:2045 overwritten at .../SymbolicUtils/QkCnQ/src/code.jl:2066.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
ERROR: AssertionError: Error when precompiling module, potentially caused by a __precompile__(false) declaration in the module.
exit status: 1
```

The SciMLBenchmarks history bisects to https://github.com/SciML/SciMLBenchmarks.jl/commit/cbafe70c10768754c99856915a72e094d0b6042a, which updated SymbolicUtils 4.21.0 to 4.26.0. The upstream duplicate-definition history bisects to https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/d11c86c12d2e5e7df782c1ac8cbfb1e34e5a91f0. Upstream removed the duplicate definitions in https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/c19278ee157f7dacf692ed7d56bdf56f18c95508, released as SymbolicUtils 4.26.1.

## Verification after the fix

The identical compile-cache command above completed with exit status 0 and no method-overwrite output.

```sh
/home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no \
  --project=benchmarks/OptimizationFrameworks \
  -e 'using Pkg; Pkg.resolve()'
```

```text
No Changes to `.../benchmarks/OptimizationFrameworks/Project.toml`
No Changes to `.../benchmarks/OptimizationFrameworks/Manifest.toml`
exit status: 0
```

```sh
/home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no \
  --project=benchmarks/OptimizationFrameworks \
  -e 'using Pkg; Pkg.instantiate(); Pkg.precompile(; strict = true)'
```

```text
✓ Symbolics
✓ ModelingToolkitBase
✓ ModelingToolkitTearing
✓ ModelingToolkit
14 dependencies successfully precompiled in 460 seconds. 490 already precompiled.
exit status: 0
```

OptimizationMOI emitted its existing `could not import ModelingToolkitBase.mergedefaults` warning during this run; it still precompiled successfully.

```sh
/home/crackauc/.juliaup/bin/julia +1.11.9 --startup-file=no \
  --project=benchmarks/OptimizationFrameworks \
  -e 'import Enzyme, ForwardDiff, Ipopt, JuMP; import ModelingToolkit as MTK; import Optimization, OptimizationMOI, Plots, ReverseDiff, Test; println("OptimizationFrameworks benchmark imports loaded")'
```

```text
OptimizationFrameworks benchmark imports loaded
exit status: 0
```

Repository checks:

```text
Runic: exit status 0
typos over the changed file: exit status 0
GROUP=Core Pkg.test(): 85/85 passed
GROUP=QA Pkg.test(): 19/19 passed
```

## Not verified

The full CLNLBEAM and optimal-power-flow benchmark weaves were not run; validation is limited to strict precompilation and loading the imports used by the OptimizationFrameworks benchmark. GPU and downstream-package jobs were not run because this change only updates a benchmark-local manifest.

## Reviewer note

This deliberately selects the first fixed patch, SymbolicUtils 4.26.1, instead of refreshing the environment to the newest compatible SymbolicUtils release. A current `Pkg.update("SymbolicUtils")` reaches 4.35.7 and changes additional transitive entries, which is outside this focused precompile repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
