### PR TITLE
Initialize StiffSDE timing matrices

### DIFF
--- a/benchmarks/StiffSDE/Oval2Timings.jmd
+++ b/benchmarks/StiffSDE/Oval2Timings.jmd
@@ -13,8 +13,8 @@ prob = EnsembleProblem(remake(prob,tspan=(0.0,1.0)),prob_func=prob_func)
 js = 16:21
 dts = 1.0 ./ 2.0 .^ (js)
 trajectories = 1000
-fails = Array{Int}(undef,length(dts),3)
-times = Array{Float64}(undef,length(dts),3)
+fails = fill(-1, length(dts), 3)
+times = fill(NaN, length(dts), 3)
 ```
 
 ## Timing Runs

--- a/test/core.jl
+++ b/test/core.jl
@@ -215,6 +215,14 @@ end
     @test checked == count("names = names", benchmark)
 end
 
+@testset "StiffSDE timing matrix initialization" begin
+    benchmark = joinpath(
+        dirname(@__DIR__), "benchmarks", "StiffSDE", "Oval2Timings.jmd"
+    )
+    @test benchmark_assignment(benchmark, "fails") == :(fill(-1, length(dts), 3))
+    @test benchmark_assignment(benchmark, "times") == :(fill(NaN, length(dts), 3))
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Initialize StiffSDE's timing and failure matrices with explicit missing-value sentinels instead of leaving them undefined. `RosslerSRI` measures only four of the six timestep rows, but the final plot consumes the entire matrix; the uninitialized tail was therefore rendered as a bogus `2^-Inf` timing curve.

Unmeasured times are now `NaN`, which Plots omits, and unmeasured failure counts are `-1`. The measured benchmark loops and solver configurations are unchanged.

## Failing before / passing after

The new test fails twice against unmodified master:

```text
Expression: benchmark_assignment(benchmark, "fails") == :(fill(-1, length(dts), 3))
Evaluated: Array{Int}(undef, length(dts), 3) == fill(-1, length(dts), 3)

Expression: benchmark_assignment(benchmark, "times") == :(fill(NaN, length(dts), 3))
Evaluated: Array{Float64}(undef, length(dts), 3) == fill(NaN, length(dts), 3)

Core | 85 passed, 2 failed, 87 total
```

The same command passes after the fix:

```text
Test Summary: | Pass  Total   Time
Core          |   87     87  39.4s
Testing SciMLBenchmarks tests passed
```

Command:

```sh
GROUP=Core julia +1.11.9 --project=.validation/root-env \
  -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
```

## Verification

- `GROUP=QA`: 21/21 passed in 2m02.3s.
- Full `Oval2Timings.jmd` weave: exit 0; all 20 chunks completed, producing one Markdown page and its nonempty 1000×800 PNG.
- Visually inspected the regenerated plot: Euler-Maruyama and RK-Mil contain all six measured points, RosslerSRI contains only its four measured points, and no curve collapses to `2^-Inf`.
- The generated Markdown contains no Julia exception or stack-trace markers.
- Runic 1.10.0 check of `test/core.jl`: exit 0.
- `typos --format brief test/core.jl benchmarks/StiffSDE/Oval2Timings.jmd`: exit 0.
- `git diff --check`: exit 0.

The full StiffSDE folder under the separate dependency refresh is not part of this source-only PR; that refresh remains a separate mechanical change.

## Self-hosted verification

The changed page completed on `amdci8-1`: the benchmark build took 9m39s. The exact uploaded artifact contains one Markdown page, one generated script, and one referenced 798×800 PNG, with zero missing or unreferenced figures, zero execution-error markers, and no `-Inf` in the rendered result.

Run: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33861425011

Output draft: https://github.com/SciML/SciMLBenchmarksOutput/pull/53

## Not verified

This source-only PR does not rerun the other four StiffSDE pages. The separate dependency-refresh integration ran all five pages locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
