### PR TITLE
Use benchmark project in LinearSolveDistributed setup

### DIFF
--- a/benchmarks/LinearSolveDistributed/setup.sh
+++ b/benchmarks/LinearSolveDistributed/setup.sh
@@ -6,16 +6,14 @@
 # Any variable written to $BENCHMARK_ENV_FILE is sourced back into the build env.
 set -euo pipefail
 
+BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 echo "--- LinearSolveDistributed setup: pinning MPI backend"
 
-# Pin MPI.jl to the JLL MPICH binary. PETSc_jll's default artifact is built
-# against MPICH, so this keeps the whole stack on one ABI. Writes
-# LocalPreferences.toml in this folder, which the benchmark project then uses.
-julia --project=. -e '
-    using Pkg
-    Pkg.add("MPIPreferences")
+# Load the project containing the committed MPICH preference before downstream setup.
+# PETSc_jll's default artifact is built against MPICH, so this keeps the stack on one ABI.
+julia --project="${BENCH_DIR}" -e '
     using MPIPreferences
-    MPIPreferences.use_jll_binary("MPICH_jll"; export_prefs=true)
 '
 
 # Expose mpiexec to any downstream step that wants it (the .jmd itself gets it

--- a/test/core.jl
+++ b/test/core.jl
@@ -82,6 +82,41 @@ end
     end
 end
 
+@testset "LinearSolveDistributed setup project" begin
+    repository_root = dirname(@__DIR__)
+    benchmark_dir = joinpath(repository_root, "benchmarks", "LinearSolveDistributed")
+    setup = joinpath(benchmark_dir, "setup.sh")
+
+    mktempdir() do directory
+        invocation = joinpath(directory, "invocation")
+        julia = joinpath(directory, "julia")
+        write(
+            julia,
+            "#!/bin/sh\nprintf '%s\\n' \"\$@\" > \"\$INVOCATION_LOG\"\n",
+        )
+        chmod(julia, 0o755)
+        environment_file = joinpath(directory, "benchmark-env")
+        command = addenv(
+            `bash $setup`,
+            "PATH" => string(directory, ':', ENV["PATH"]),
+            "INVOCATION_LOG" => invocation,
+            "BENCHMARK_ENV_FILE" => environment_file,
+        )
+
+        cd(repository_root) do
+            run(command)
+        end
+
+        arguments = readlines(invocation)
+        invocation_text = join(arguments, '\n')
+        @test "--project=$benchmark_dir" in arguments
+        @test !("--project=." in arguments)
+        @test !occursin("Pkg.add", invocation_text)
+        @test !occursin("use_jll_binary", invocation_text)
+        @test read(environment_file, String) == "JULIA_MPI_BINARY=MPICH_jll\n"
+    end
+end
+
 @testset "NeuralNetworks V100 environment" begin
     folder = joinpath(dirname(@__DIR__), "benchmarks", "NeuralNetworks")
     preferences_path = joinpath(folder, "LocalPreferences.toml")


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`build_benchmark.sh` invokes each benchmark setup script from the repository root. LinearSolveDistributed therefore ran `julia --project=.` against the repository project, called `Pkg.add`, and wrote MPI preferences outside the benchmark environment.

This resolves the benchmark directory from the setup script's own path and loads `MPIPreferences` from that absolute project. It relies on the already-committed `MPICH_jll` preference instead of mutating the environment during every build.

## Verification

The same regression test failed against the original setup:

```text
GROUP=Core julia +1.11.9 --project=.validation/root-env-111 -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
Test Summary:                          | Pass  Fail  Total   Time
Core                                   |   86     4     90  41.4s
  LinearSolveDistributed setup project |    1     4      5   2.5s
ERROR: Package SciMLBenchmarks errored during testing
Exit status: 1
```

The exact test passed after the fix:

```text
GROUP=Core julia +1.11.9 --project=.validation/root-env-111 -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
Test Summary: | Pass  Total   Time
Core          |   90     90  36.3s
Testing SciMLBenchmarks tests passed
Exit status: 0
```

QA passed:

```text
GROUP=QA julia +1.11.9 --project=.validation/root-env-111 -e 'using Pkg; Pkg.test("SciMLBenchmarks")'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m43.2s
Testing SciMLBenchmarks tests passed
Exit status: 0
```

Running the real setup from the repository root preserved all tracked environment files:

```text
root_project_before=451f6787b66c33b9f786d34e98a8b50e8c531ed4
root_project_after=451f6787b66c33b9f786d34e98a8b50e8c531ed4
benchmark_project_before=41d383a2d2a65e8403fbc0e596f6be932474b991
benchmark_project_after=41d383a2d2a65e8403fbc0e596f6be932474b991
benchmark_manifest_before=bac186aede0b01425f6697ba3f32cb903f21e852
benchmark_manifest_after=bac186aede0b01425f6697ba3f32cb903f21e852
```

The exact benchmark build smoke, including setup, instantiate, precompile, and package build, also completed:

```text
Elapsed (wall clock) time: 7:56.78
Maximum resident set size: 2629516 kbytes
Exit status: 0
```

Runic, typos, `bash -n`, and `git diff --check` passed.

## Not verified

I did not run the three distributed benchmark pages or an actual multi-process PETSc solve; that validation belongs with the separate dependency refresh. The repository's Julia 1.12 Core test currently has an unrelated nested-manifest MbedTLS failure fixed by https://github.com/SciML/SciMLBenchmarks.jl/pull/1716, so the root test evidence above uses Julia 1.11.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
