### PR TITLE
Fix Hénon-Heiles Taylor callback state handling

### DIFF
--- a/benchmarks/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jmd
+++ b/benchmarks/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jmd
@@ -55,14 +55,21 @@ const oop_q0 = @SVector [0.1, 0.0]
 const oop_p0 = @SVector [0.0, 0.5]
 
 function hamilton(du, u, p, t)
-    dq, q = @views u[3:4], du[3:4]
-    dp, p = @views u[1:2], du[1:2]
+    dq, q = @views du[3:4], u[3:4]
+    dp, p = @views du[1:2], u[1:2]
 
     dp[1] = -q[1] * (1 + 2q[2])
     dp[2] = -q[2] - (q[1]^2 - q[2]^2)
     dq .= p
 
     return nothing
+end
+
+let u = vcat(iip_p0, iip_q0), du = fill(NaN, 4)
+    u_before = copy(u)
+    hamilton(du, u, nothing, 0.0)
+    @assert u == u_before "hamilton must not mutate its input state"
+    @assert du ≈ [-0.1, -0.01, 0.0, 0.5] "hamilton returned an incorrect derivative"
 end
 
 function hamilton_taylor!(du, u, p, t)


### PR DESCRIPTION
## What changed and why

The Hénon-Heiles `hamilton(du, u, p, t)` callback assigned its derivative views from `u` and its state views from `du`, so TaylorIntegration mutated the state while leaving the derivative buffer unreadable. This swaps those views to follow the in-place ODE callback contract and adds an executable notebook assertion for both state preservation and the analytic initial derivative.

`git bisect run` identified [`f26c05805d0fdbd9fdaf3af43e97ffd32d97f714`](https://github.com/SciML/SciMLBenchmarks.jl/commit/f26c05805d0fdbd9fdaf3af43e97ffd32d97f714), introduced by [PR 157](https://github.com/SciML/SciMLBenchmarks.jl/pull/157), as the first bad commit.

Ignore this draft until reviewed by @ChrisRackauckas.

## Verification

Failing before the fix, after adding only the callback assertions:

```console
$ TMPDIR="$PWD/.tmp" JULIA_NUM_THREADS=auto GKSwstype=100 ~/.juliaup/bin/julia +1.11 --startup-file=no --threads=auto --project=. benchmark.jl benchmarks/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jmd
ERROR: LoadError: AssertionError: hamilton must not mutate its input state
[exit 1]
```

Passing after the two-line view correction, using the same command:

```console
└ Info: Weaved all chunks
└   progress = 1
[ Info: Weaved to .../markdown/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.md
[exit 0]
```

The generated benchmark output reports:

```console
TaylorMethod max energy error: 1.942890293094024e-16 in 101 steps.
TaylorMethod max energy error: 3.885780586188048e-16 in 1001 steps.
```

A read-only 101-savepoint probe against the fully refreshed `DynamicalODE` environment compared the callbacks extracted from the unchanged refresh worktree and this branch:

```console
$ TMPDIR="/home/crackauc/sandbox/tmp_20260825_180339_53321/dynamicalode-taylor-hamiltonian/.tmp" JULIA_NUM_THREADS=auto /home/crackauc/.juliaup/bin/julia +1.11 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260825_180339_53321/dynamicalode-current/benchmarks/DynamicalODE -e 'using OrdinaryDiffEq, TaylorIntegration, LinearAlgebra; function callback(path); source=read(path,String); onlymatch=match(r"(?ms)^function hamilton\(du\s*,\s*u\s*,\s*p\s*,\s*t\).*?^end\s*$",source); isnothing(onlymatch)&&error("callback not found"); onlymatch.match; end; module Bad end; module Fixed end; Base.include_string(Bad,callback(ARGS[1])); Base.include_string(Fixed,callback(ARGS[2])); H(x)=1//2*norm(view(x,1:2))^2+1//2*(x[3]^2+x[4]^2+2x[3]^2*x[4]-2//3*x[4]^3); u0=[0.0,0.5,0.1,0.0]; E=H(u0); for (label,f) in (("refreshed_bad",Bad.hamilton),("refreshed_fixed",Fixed.hamilton)); sol=solve(ODEProblem(f,u0,(0.0,100.0)),TaylorMethod(50),abstol=1e-20,dense=false,saveat=range(0.0,100.0;length=101)); errors=abs.(H.(sol.u).-E); println(label," retcode=",sol.retcode," finite=",all(isfinite,errors)," max_energy_error=",maximum(errors)," final=",sol.u[end]); end' /home/crackauc/sandbox/tmp_20260825_180339_53321/dynamicalode-current/benchmarks/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jmd /home/crackauc/sandbox/tmp_20260825_180339_53321/dynamicalode-taylor-hamiltonian/benchmarks/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jmd
```

```console
refreshed_bad retcode=Success finite=false max_energy_error=NaN final=[-0.0, -0.0, 1.3243375734814e-310, 3.32e-321]
refreshed_fixed retcode=Success finite=true max_energy_error=1.942890293094024e-16 final=[0.03845092895186088, 0.04859483155299654, -0.040194237876070044, 0.679016921772022]
```

Additional checks:

```console
$ git ls-files -z '*.jl' | xargs -0 ~/.juliaup/bin/julia +1.12 --startup-file=no --project=~/.julia/environments/runic -m Runic --check
[exit 0]
$ ~/.juliaup/bin/julia +1.12 --startup-file=no --project=~/.julia/environments/runic -m Runic --check --lines=40:56 script/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jl
[exit 0]
$ git diff -- benchmarks/DynamicalODE/Henon-Heiles_energy_conservation_benchmark.jmd | typos -
[exit 0]
$ TMPDIR="$PWD/.tmp" GROUP=Core ~/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |   85     85  42.2s
$ TMPDIR="$PWD/.tmp" GROUP=QA ~/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   19     19  1m06.0s
```

## CI

The [benchmark workflow](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33884970657) completed successfully. Its uploaded Markdown artifact independently reports the same TaylorMethod maxima (`1.942890293094024e-16` for 101 points and `3.885780586188048e-16` for 1001 points); Runic, Runic suggestions, and spelling also passed.

## Not verified

The rest of the `DynamicalODE` folder was not rerun because the source and regression guard are confined to this page. No GPU, downstream, dependency, public-API, or rendered-package-doc paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
