### PR TITLE
Ensure pull request closure cancels benchmark runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,13 +12,6 @@ on:
       - '.github/workflows/benchmarks.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    paths:
-      - 'benchmarks/**'
-      - '.github/benchmark_defaults.toml'
-      - '.github/scripts/detect-changed-benchmarks.sh'
-      - '.github/scripts/read-benchmark-config.sh'
-      - '.github/scripts/test-detect-changed-benchmarks.sh'
-      - '.github/workflows/benchmarks.yml'
   workflow_dispatch:
     inputs:
       benchmark_target:

--- a/test/core.jl
+++ b/test/core.jl
@@ -178,6 +178,13 @@ end
     @test occursin("format('pr-{0}', github.event.pull_request.number)", workflow)
     @test occursin("github.event_name == 'pull_request' || github.ref != 'refs/heads/master'", workflow)
     @test occursin("github.event.action != 'closed'", workflow)
+    pull_request_trigger = match(
+        r"(?ms)^  pull_request:\n(?<body>.*?)^  workflow_dispatch:", workflow
+    )
+    @test !isnothing(pull_request_trigger)
+    if !isnothing(pull_request_trigger)
+        @test !occursin("paths:", pull_request_trigger[:body])
+    end
 
     cancellation_path = joinpath(
         dirname(@__DIR__), ".github", "workflows", "cancel-superseded-benchmarks.yml"


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

Pull-request benchmark runs are grouped by pull-request number so a `closed` event can cancel obsolete work, and the detect job already skips closed events. The pull-request trigger nevertheless had a `paths` filter. GitHub did not create a closed-event workflow run when https://github.com/SciML/SciMLBenchmarks.jl/pull/1817 was closed, leaving its obsolete NonlinearProblem benchmark consuming `amdci3-1`.

This removes the pull-request path filter so closure always creates the lightweight cancellation run. Ordinary non-benchmark pull-request events now run change detection on a hosted runner and schedule no self-hosted benchmark targets.

## Failing before

With only the regression assertion added, the Core group failed on the existing trigger:

```text
superseded pull request cancellation: Test Failed
Expression: !(occursin("paths:", pull_request_trigger[:body]))

Core | Pass 86 | Fail 1 | Total 87
ERROR: Package SciMLBenchmarks errored during testing
```

The live operational failure is the obsolete job that remained in progress after its pull request was closed at 2026-09-04 19:15 UTC:

https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33877649127/job/101038473474

## Passing after

After removing the filter, the identical Core group passed:

```text
Core | Pass 87 | Total 87 | 47.0s
Testing SciMLBenchmarks tests passed
```

Additional local checks:

```text
QA | Pass 21 | Total 21 | 2m55.3s
Testing SciMLBenchmarks tests passed
actionlint .github/workflows/benchmarks.yml: exit 0
Runic --check --diff test/core.jl: exit 0
typos .github/workflows/benchmarks.yml test/core.jl: exit 0
git diff --check: exit 0
```

No benchmark source, public API, or documentation changed, so no benchmark weave or docs build was run. The change cannot retroactively cancel the currently running job until it is merged and the pull request is reopened and closed again, or an administrator force-cancels the run.

## Links

- Obsolete run: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33877649127
- Closed pull request: https://github.com/SciML/SciMLBenchmarks.jl/pull/1817
- Existing cancellation workflow: https://github.com/SciML/SciMLBenchmarks.jl/blob/master/.github/workflows/cancel-superseded-benchmarks.yml
- GitHub path-filter behavior: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
