### PR TITLE
Fix Turing differential equation model iteration

### DIFF
--- a/benchmarks/AutomaticDifferentiationTuring/models/delaydiffeq.jl
+++ b/benchmarks/AutomaticDifferentiationTuring/models/delaydiffeq.jl
@@ -41,8 +41,8 @@ ddedata = rand.(Poisson.(q .* Array(sol_dde)))
         reltol = 1.0e-6,
     )
     ϵ = 1.0e-5
-    for i in eachindex(predicted)
-        data[:, i] ~ arraydist(Poisson.(q .* predicted[i] .+ ϵ))
+    for i in axes(predicted, 2)
+        data[:, i] ~ arraydist(Poisson.(q .* predicted[:, i] .+ ϵ))
     end
     return nothing
 end

--- a/benchmarks/AutomaticDifferentiationTuring/models/ordinarydiffeq.jl
+++ b/benchmarks/AutomaticDifferentiationTuring/models/ordinarydiffeq.jl
@@ -28,8 +28,8 @@ odedata = rand.(Poisson.(q * Array(sol)))
     q ~ truncated(Normal(1.7, 0.2); lower = 0, upper = 3)
     p = [α, β, γ, δ]
     predicted = solve(prob, Tsit5(); p = p, saveat = 0.1, abstol = 1.0e-6, reltol = 1.0e-6)
-    for i in eachindex(predicted)
-        data[:, i] ~ product_distribution(Poisson.(q .* predicted[i] .+ 1.0e-5))
+    for i in axes(predicted, 2)
+        data[:, i] ~ product_distribution(Poisson.(q .* predicted[:, i] .+ 1.0e-5))
     end
     return nothing
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -43,6 +43,19 @@ function workflow_job(workflow, name)
     return match(Regex("(?ms)^  $(name):\\n(?<body>.*?)(?=^  [a-zA-Z][a-zA-Z0-9_-]*:\\n|\\z)"), workflow)
 end
 
+@testset "Turing differential equation time slices" begin
+    models_dir = joinpath(
+        dirname(@__DIR__), "benchmarks", "AutomaticDifferentiationTuring", "models"
+    )
+    for model_name in ("ordinarydiffeq", "delaydiffeq")
+        model = read(joinpath(models_dir, model_name * ".jl"), String)
+        @test occursin("axes(predicted, 2)", model)
+        @test occursin("predicted[:, i]", model)
+        @test !occursin("eachindex(predicted)", model)
+        @test !occursin("predicted.u", model)
+    end
+end
+
 @testset "DiffEqGPU singleton parameter grids" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks", "DiffEqGPU")
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Iterate over the solution's saved-time axis and index each state as the public array slice `predicted[:, i]` in the Turing ODE and DDE models. Add a Core regression test covering both model sources.

The dependency refresh in https://github.com/SciML/SciMLBenchmarks.jl/pull/1822 moved RecursiveArrayTools from 3.54.0 to 4.5.1. RecursiveArrayTools 4 made `AbstractVectorOfArray` a proper `AbstractArray`, so `eachindex(predicted)` now traverses scalar component/time indices; these models still treated each index as a saved time point. The change was intentional and breaking upstream, so this is a benchmark migration rather than an OrdinaryDiffEq or RecursiveArrayTools bug.

## Verification

### Failing before

On a clean detached `upstream/master` checkout at `e80b05363fe9885643d3c9110a5711399e1302d5`, constructing each model's `LogDensityFunction` failed before any backend ran:

```text
ordinarydiffeq: BoundsError: attempt to access 2×101 Matrix{Int64} at index [1:2, 1, 2]
delaydiffeq: MethodError: no method matching arraydist(::Distributions.Poisson{Float64})
```

The isolated solution-indexing probe showed the dependency boundary:

```text
RecursiveArrayTools=3.54.0
size=(2, 11) length=11 saved=11
eachindex=Base.OneTo{Int64} first_index=1 first_value_type=Vector{Float64}

RecursiveArrayTools=4.5.1
size=(2, 11) length=22 saved=11
eachindex=CartesianIndices{2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}} first_index=CartesianIndex(1, 1) first_value_type=Float64
```

After adding the regression test but before changing the models:

```sh
GROUP=Core /home/crackauc/.juliaup/bin/julia +1.10.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:                              | Pass  Fail  Total   Time
Core                                       |   93     6     99  32.1s
  Turing differential equation time slices |    2     6      8   1.3s
```

### Passing after

The same Core command:

```text
Test Summary: | Pass  Total   Time
Core          |   99     99  31.3s
Testing SciMLBenchmarks tests passed
```

Both changed models reached all eight AD backends using the exact Julia 1.12.7 folder environment, with no constructor or worker-process failures. FiniteDifferences, ForwardDiff, ReverseDiff, and ReverseDiffCompiled returned successful benchmark measurements for both models; ordinarydiffeq also succeeded with EnzymeRvs. The remaining Mooncake and Enzyme statuses are backend-specific errors or incorrect-gradient results recorded by the benchmark after model construction. ReverseDiff is significant here: accessing `predicted.u` instead would fail because the differentiated solve returns a `ReverseDiff.TrackedArray`.

```sh
cd benchmarks/AutomaticDifferentiationTuring
JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260825_180339_53321/automaticdifferentiationturing-current/.validation/depot:/home/crackauc/.julia /home/crackauc/.juliaup/bin/julia +1.12.7 --startup-file=no --project=. turing_ad_worker.jl ordinarydiffeq FiniteDifferences
JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260825_180339_53321/automaticdifferentiationturing-current/.validation/depot:/home/crackauc/.julia /home/crackauc/.juliaup/bin/julia +1.12.7 --startup-file=no --project=. turing_ad_worker.jl delaydiffeq FiniteDifferences
```

The same two commands were run with the final argument replaced by each of `ForwardDiff`, `ReverseDiff`, `ReverseDiffCompiled`, `MooncakeRvs`, `MooncakeFwd`, `EnzymeFwd`, and `EnzymeRvs`.

```text
META    External libraries  5
BEGIN   FiniteDifferences
RESULT  FiniteDifferences   ok  78.51171838956725  0.0076579545  9.7539e-5
RESULT  ForwardDiff         ok  5.487720706260031  0.000547016  9.968000000000001e-5
RESULT  ReverseDiff         ok  23.372376662416585  0.0025113385  0.00010744900000000001
RESULT  ReverseDiffCompiled ok  5.193506480821263   0.000531706  0.000102379
RESULT  MooncakeRvs         error
RESULT  MooncakeFwd         error
RESULT  EnzymeFwd           wrong
RESULT  EnzymeRvs           ok  81.57597951471757  0.0082032805  0.00010056000000000001

META    External libraries  5
BEGIN   FiniteDifferences
RESULT  FiniteDifferences   ok  67.4698576820393  0.0383624165  0.000568586
RESULT  ForwardDiff         ok  0.7852662888631453  0.0006270155  0.0007984750000000001
RESULT  ReverseDiff         ok  6.693756815273915  0.003824324  0.0005713270000000001
RESULT  ReverseDiffCompiled ok  1.4126027088453548 0.000802085  0.0005678065000000001
RESULT  MooncakeRvs         error
RESULT  MooncakeFwd         error
RESULT  EnzymeFwd           error
RESULT  EnzymeRvs           error
```

```sh
GROUP=QA /home/crackauc/.juliaup/bin/julia +1.10.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Total     Time
QA            |   19     19  1m04.9s
Testing SciMLBenchmarks tests passed
```

Runic `--check`, `typos` over the three changed files, and `git diff --check` all exited 0.

## Not verified

I did not rerun the full 62-model page; its immediately preceding local run took 4h40m. The hosted folder-level benchmark is still running. No documentation build was run because this changes benchmark model implementation and a test only, with no public API or documentation changes.

## Links

- Dependency refresh: https://github.com/SciML/SciMLBenchmarks.jl/pull/1822
- RecursiveArrayTools breaking interface change: https://github.com/SciML/RecursiveArrayTools.jl/pull/547
- Exact upstream commit: https://github.com/SciML/RecursiveArrayTools.jl/commit/cde5c35ba194beb7b736ce5eb5f8de678efd6f66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
