### PR TITLE
Avoid rebuilding every benchmark package

### DIFF
--- a/src/SciMLBenchmarks.jl
+++ b/src/SciMLBenchmarks.jl
@@ -42,7 +42,6 @@ function weave_file(folder, file, build_list = (:script, :github))
         withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
             Pkg.instantiate()
         end
-        Pkg.build()
         Pkg.precompile()
     end
 


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Remove the unconditional `Pkg.build()` from `weave_file` after the benchmark environment is instantiated. The all-manifest rebuild makes a Julia 1.10 benchmark manifest unusable from Julia 1.12 when that manifest contains a Julia 1.10 bundled stdlib that Julia 1.12 no longer ships; the existing `Pkg.instantiate()` and `Pkg.precompile()` path completed the Testing weave on both Julia versions tested.

The specific failure is `MbedTLS_jll`: `benchmarks/Testing/Manifest.toml` correctly records bundled `MbedTLS_jll` 2.28.1010 for its declared Julia 1.10.11 environment, without a package tree path. Julia 1.12.7 no longer has `MbedTLS_jll` as a stdlib, so `Pkg.build()` fails while enumerating that cross-version manifest. The benchmark CI setup still retains its separate root-environment `Pkg.build()` for Conda.

## Failing before the fix

On clean `upstream/master` `e80b05363fe9885643d3c9110a5711399e1302d5`:

```text
$ GROUP=Core julia +1.12.7 --project=. -e 'using Pkg; Pkg.test()'
weave_file: Error During Test
  Failed to find path for package MbedTLS_jll
Test Summary: | Pass  Error  Total   Time
Core          |   89      1     90  29.5s
ERROR: Package SciMLBenchmarks errored during testing
```

The stack trace enters `Pkg.Operations.build_versions` from the bare `Pkg.build()` in `weave_file`.

A symptom-specific `git bisect run` copied the Testing environment at each revision, ran `Pkg.instantiate(); Pkg.build()` with Julia 1.12.7, and classified only `Failed to find path for package MbedTLS_jll` as bad. It found `cc4abfcee7f55d5be8be72060f382c1de5d1742f` as the first bad repository commit: that 2021 commit created the version-pinned Testing environment. The failure is exposed now by Julia 1.12 removing the bundled `MbedTLS_jll`; it is not from a recent dependency refresh.

## Passing after the fix

```text
$ GROUP=Core julia +1.12.7 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
Core          |   91     91  5m11.8s
     Testing SciMLBenchmarks tests passed

$ GROUP=Core julia +1.10.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
Core          |   91     91  1m18.6s
     Testing SciMLBenchmarks tests passed

$ GROUP=QA julia +1.10.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   19     19  1m16.8s
     Testing SciMLBenchmarks tests passed
```

The existing end-to-end `weave_file` test is the regression test: it fails before the one-line change and passes after it while producing and checking the Testing markdown.

Additional checks:

```text
Runic --check src/SciMLBenchmarks.jl: exit 0
typos src/SciMLBenchmarks.jl: exit 0
git diff --check: exit 0
```

Docs were not run because this changes no public API, docstring, or documentation file. GPU and downstream benchmark folders were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
