### PR TITLE
Skip deleted benchmark files in CI detection

### DIFF
--- a/.github/scripts/detect-changed-benchmarks.sh
+++ b/.github/scripts/detect-changed-benchmarks.sh
@@ -60,6 +60,7 @@ find_project() {
 
 while IFS= read -r f; do
     [[ -z "${f}" ]] && continue
+    [[ "${f}" == *.jmd && ! -f "${f}" ]] && continue
     proj=$(find_project "$(dirname "${f}")")
     if [[ -z "${proj}" ]]; then
         echo "::warning::Unable to find project for ${f}"

--- a/.github/scripts/test-detect-changed-benchmarks.sh
+++ b/.github/scripts/test-detect-changed-benchmarks.sh
@@ -83,4 +83,27 @@ if [[ "${SUPPORT_TARGETS}" != "benchmarks/Alpha" ]]; then
     exit 1
 fi
 
+printf '# Deleted benchmark\n' > "${FIXTURE}/benchmarks/Alpha/deleted.jmd"
+git -C "${FIXTURE}" add benchmarks/Alpha/deleted.jmd
+git -C "${FIXTURE}" commit -qm "Add benchmark to delete"
+DELETION_BASE_SHA=$(git -C "${FIXTURE}" rev-parse HEAD)
+git -C "${FIXTURE}" rm -q benchmarks/Alpha/deleted.jmd
+git -C "${FIXTURE}" commit -qm "Delete benchmark"
+
+DELETION_OUTPUT_FILE="${TEST_ROOT}/deletion-github-output"
+(
+    cd "${FIXTURE}"
+    GITHUB_EVENT_NAME=push \
+        PUSH_BASE_SHA="${DELETION_BASE_SHA}" \
+        GITHUB_OUTPUT="${DELETION_OUTPUT_FILE}" \
+        PATH="${TEST_ROOT}/bin:${PATH}" \
+        .github/scripts/detect-changed-benchmarks.sh
+)
+
+if ! grep -Fxq 'has_changes=false' "${DELETION_OUTPUT_FILE}"; then
+    printf 'Expected a deleted .jmd file to schedule no benchmark, got:\n' >&2
+    sed -n 's/^matrix=//p' "${DELETION_OUTPUT_FILE}" >&2
+    exit 1
+fi
+
 echo "Push detection selected only changes since the event's before SHA."


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Stops changed-benchmark detection from scheduling a `.jmd` path that no longer exists. This surfaced when deleting the unavailable ModelingToolkit Multibody page caused CI to reserve a self-hosted runner for `benchmarks/ModelingToolkit/Multibody_Robot.jmd`, which can only fail as a nonexistent target.

The existence check is limited to `.jmd` files. Deleted setup, project, manifest, or configuration files still follow the existing support-file path and schedule their containing benchmark folder.

## Failure before the fix

The new fixture adds and commits `benchmarks/Alpha/deleted.jmd`, deletes it in the next commit, and detects changes across exactly that deletion:

```text
Detected benchmark targets:
  benchmarks/Alpha/deleted.jmd -> runner=["self-hosted", "benchmark"] timeout=12000 julia=1.11
Expected a deleted .jmd file to schedule no benchmark, got:
[{"target":"benchmarks/Alpha/deleted.jmd","runner":["self-hosted", "benchmark"],"timeout":12000,"julia_version":"1.11"}]
exit=1
```

## Passing after the fix

```sh
TMPDIR=/home/crackauc/tmp bash .github/scripts/test-detect-changed-benchmarks.sh
```

```text
No benchmark changes detected.
Push detection selected only changes since the event's before SHA.
exit=0
```

Repository gates on Julia 1.11.9:

```text
GROUP=Core julia +1.11.9 --startup-file=no --threads=1 --project=. -e 'using Pkg; Pkg.test()'
Core | 91 passed / 91 total | 38.6s

GROUP=QA julia +1.11.9 --startup-file=no --threads=1 --project=. -e 'using Pkg; Pkg.test()'
QA | 21 passed / 21 total | 1m54.6s
```

`typos` over both changed scripts and `git diff --check` exited 0 with no findings. `shfmt` is not installed on this host. `shellcheck` reported only the pre-existing SC1091 informational diagnostic for the script's variable-based `source "${SCRIPT_DIR}/read-benchmark-config.sh"`; it found no diagnostic in the changed code. No docs build was run because this changes an internal CI detector and its shell fixture, not documentation or public API.

## Links

- Run that scheduled the deleted Multibody page: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33945728546/job/101251353372
- Multibody page removal PR: https://github.com/SciML/SciMLBenchmarks.jl/pull/1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
