### PR TITLE
Update DiffEqGPU linear and CRN ensemble APIs

### DIFF
--- a/benchmarks/DiffEqGPU/crn_sde.jmd
+++ b/benchmarks/DiffEqGPU/crn_sde.jmd
@@ -98,8 +98,8 @@ function make_crn_ensemble(parameters; T::Type = Float32)
     p0 = SVector{6, T}(T(2.3), T(5), T(10), T(0.1), T(3), T(0.1))
     g0 = zeros(SMatrix{4, 8, T})
     prob = SDEProblem{false}(crn_f, crn_g, u0, tspan, p0; noise_rate_prototype = g0)
-    function prob_func(prob, i, repeat)
-        pi = parameters[i]
+    function prob_func(prob, ctx)
+        pi = parameters[ctx.sim_id]
         remake(prob;
             p = SVector{6, T}(pi[1], pi[2], pi[3], pi[4], pi[5], pi[6]),
             u0 = SVector{4, T}(pi[4], pi[4], pi[4], pi[4]))
@@ -125,8 +125,8 @@ let
     ens = make_crn_ensemble(ps)
     sol = solve(ens, GPUEM(), KERNEL; trajectories = 2, save_everystep = false,
         adaptive = false, dt = 0.1f0)
-    println("CRN smoke: 2 trajectories, u[1][end] = ", sol[1].u[end])
-    @assert all(i -> length(sol[i].u[end]) == 4, 1:2)
+    println("CRN smoke: 2 trajectories, u[1][end] = ", sol.u[1].u[end])
+    @assert all(i -> length(sol.u[i].u[end]) == 4, 1:2)
 end
 ```
 
@@ -146,7 +146,7 @@ for N in NS
         min_seconds(() -> (CUDA.@sync solve(ens, GPUEM(), KERNEL; trajectories = n,
             save_everystep = false, adaptive = false, dt = 0.1f0); nothing)))
     @info "crn cpu" N n
-    ens64 = make_crn_ensemble(crn_parameters(N; Float64); T = Float64)
+    ens64 = make_crn_ensemble(crn_parameters(N; T = Float64); T = Float64)
     push!(t_cpu,
         min_seconds(() -> (solve(ens64, EM(), EnsembleThreads(); trajectories = n,
             save_everystep = false, adaptive = false, dt = 0.1); nothing);

--- a/benchmarks/DiffEqGPU/linear_sde.jmd
+++ b/benchmarks/DiffEqGPU/linear_sde.jmd
@@ -77,8 +77,8 @@ let
     ens = make_sde_ensemble()
     sol = solve(ens, GPUEM(), KERNEL; trajectories = 4, save_everystep = false,
         adaptive = false, dt = Float32(1 // 2^8))
-    @assert length(sol) == 4
-    println("GPUEM smoke: 4 trajectories, u[end] = ", sol[1].u[end])
+    @assert length(sol.u) == 4
+    println("GPUEM smoke: 4 trajectories, u[end] = ", sol.u[1].u[end])
 end
 ```
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -52,6 +52,7 @@ end
     @test !occursin("ps = crn_parameters(1)", crn_source)
     @test occursin("GPUEM(), KERNEL; trajectories = 2", crn_source)
     @test !occursin("GPUEM(), KERNEL; trajectories = 1", crn_source)
+    @test occursin("crn_parameters(N; T = Float64)", crn_source)
     for variable in ("S_grid", "D_grid")
         crn_expression = benchmark_assignment(crn_path, variable)
         crn_grid = Core.eval(@__MODULE__, :((N, T) -> $crn_expression))


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Update the linear-SDE and CRN ensemble pages for the current SciMLBase and RecursiveArrayTools APIs. CRN `prob_func` now accepts `EnsembleContext`, both pages access trajectories through the ensemble result's `u` collection, and the CRN CPU call uses its declared `T` keyword.

This is the independently passing part of the now-closed combined GPU migration. The Lorenz page is intentionally excluded: its latest V100 execution stalled for more than 90 minutes on a second runner, while these two exact pages have each completed twice on physical V100s in about 24–26 minutes.

## Failing before

The exact linear-SDE definition and smoke chunk, evaluated with DiffEqGPU's public CPU kernel backend, failed on the old result access:

```text
length(sol)=24 length(sol.u)=4 size(sol)=(3, 2, 4)
ERROR: AssertionError: length(sol) == 4
```

The exact CRN callback failed against current SciMLBase when invoked by `EnsembleThreads`:

```text
MethodError: no method matching prob_func(::SDEProblem, ::EnsembleContext)
Closest candidate: prob_func(::Any, ::Any, ::Any)
```

The V100 run then exposed the malformed CPU keyword call:

```text
MethodError: no method matching crn_parameters(::Int64; Float64::DataType)
Closest candidate: crn_parameters(::Any; T)
```

The new Core assertion fails on the unfixed source because it contains `crn_parameters(N; Float64)` instead of `crn_parameters(N; T = Float64)`.

## Passing after

I re-evaluated the source blocks from both changed pages using DiffEqGPU 3.20.1, CUDA 6.2.2, KernelAbstractions 0.9.42, StaticArrays 1.9.19, and StochasticDiffEq 7.1.5 in a clean local validation environment:

```text
GPUEM smoke: 4 trajectories, u[end] = Float32[0.43955043, 0.4545312, 0.4446765]
LINEAR_SDE_CPU_KERNEL_PASS

CRN smoke: 2 trajectories, u[1][end] = Float32[0.010049682, 0.00994419, 0.009988811, 0.010046866]
CRN_CPU_KERNEL_PASS count=6720
```

All 6,720 generated CPU parameter tuples were also asserted to be `NTuple{6,Float64}`.

Repository gates on Julia 1.11.9:

```text
Core | 92 passed / 92 total | 1m16.8s
QA   | 21 passed / 21 total | 1m45.4s
Runic on test/core.jl: exit 0
typos on all three changed files: exit 0
git diff --check: exit 0
```

The two changed benchmark pages are byte-identical to the versions that passed twice on physical V100s. The latest completed jobs were:

- linear SDE: 25m51s, success
- CRN SDE: 25m54s, success

## Not verified

This host has no NVIDIA device, so this split branch has not run a complete CUDA weave locally. Opening the draft starts fresh physical V100 jobs for both pages. No docs build was run because this changes benchmark-local code and no package documentation or public API.

## Links

- First successful linear-SDE V100 job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33846124641/job/100938368837
- First successful CRN V100 job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33846124641/job/100938368924
- Latest successful linear-SDE V100 job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33852735626/job/100959032250
- Latest successful CRN V100 job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33852735626/job/100959032344
- Closed combined migration: https://github.com/SciML/SciMLBenchmarks.jl/pull/1808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
