### PR TITLE
Initialize StiffSDE timing matrices

### DIFF
--- a/benchmarks/StiffSDE/Oval2Timings.jmd
+++ b/benchmarks/StiffSDE/Oval2Timings.jmd
@@ -13,8 +13,8 @@ prob = EnsembleProblem(remake(prob,tspan=(0.0,1.0)),prob_func=prob_func)
 js = 16:21
 dts = 1.0 ./ 2.0 .^ (js)
 trajectories = 1000
-fails = Array{Int}(undef,length(dts),3)
-times = Array{Float64}(undef,length(dts),3)
+fails = fill(-1, length(dts), 3)
+times = fill(NaN, length(dts), 3)
 ```
 
 ## Timing Runs

--- a/test/core.jl
+++ b/test/core.jl
@@ -274,6 +274,14 @@ end
     end
 end
 
+@testset "StiffSDE timing matrix initialization" begin
+    benchmark = joinpath(
+        dirname(@__DIR__), "benchmarks", "StiffSDE", "Oval2Timings.jmd"
+    )
+    @test benchmark_assignment(benchmark, "fails") == :(fill(-1, length(dts), 3))
+    @test benchmark_assignment(benchmark, "times") == :(fill(NaN, length(dts), 3))
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
Re-applies #1815 onto current master. That PR conflicted after #1811, #1813 and #1826 landed, because all four append a testset to `test/core.jl`.

`Oval2Timings.jmd` allocated its results with `Array{Int}(undef, ...)` and `Array{Float64}(undef, ...)`. Any cell not written by a completed solve was then read as uninitialized memory, so a failed or skipped run reported arbitrary values rather than an obvious sentinel. Fill with `-1` and `NaN` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R