### PR TITLE
Report ESS/s and R-hat for the Stan backend in the FitzHugh-Nagumo benchmark

### DIFF
--- a/benchmarks/BayesianInference/DiffEqBayesFitzHughNagumo.jmd
+++ b/benchmarks/BayesianInference/DiffEqBayesFitzHughNagumo.jmd
@@ -14,21 +14,24 @@ using Plots, StaticArrays, Turing, LinearAlgebra
 ```
 
 ```julia
-"""Display ESS/s (effective samples per second) from a Turing chain."""
+"""Display bulk ESS/s and R-hat for a chain, given its sampling time."""
 function display_ess_per_sec(chain, elapsed)
     stats = summarystats(chain)
     ess_bulk = stats[:, :ess_bulk]
-    println("Elapsed time: $(round(elapsed; digits=2)) seconds\n")
-    println("ESS/s (effective samples per second, bulk):")
+    rhat = stats[:, :rhat]
+    println("Sampling time: $(round(elapsed; digits=2)) seconds\n")
+    println("ESS/s (effective samples per second, bulk) and R-hat:")
     for (i, param) in enumerate(stats[:, :parameters])
-        println("  $param: $(round(ess_bulk[i] / elapsed; digits=1))")
+        println("  $param: $(round(ess_bulk[i] / elapsed; digits=1)) ",
+            "(rhat $(round(rhat[i]; digits=4)))")
     end
     println("\nMinimum ESS/s (bulk): $(round(minimum(ess_bulk) / elapsed; digits=1))")
 end
 
-"""Extract and display Stan's internal timing from its CSV output files."""
+"""Display Stan's internal timing from its CSV output files and return the sampling seconds."""
 function display_stan_timing(stan_result)
     sample_files = stan_result.model.sample_file
+    sampling = 0.0
     for (chain_idx, f) in enumerate(sample_files)
         isfile(f) || continue
         lines = readlines(f)
@@ -39,8 +42,12 @@ function display_stan_timing(stan_result)
             elseif startswith(line, "#") && occursin("seconds", line)
                 println("  ", strip(line[2:end]))
             end
+            if startswith(line, "#") && occursin("(Sampling)", line)
+                sampling = max(sampling, parse(Float64, split(strip(line[2:end]))[1]))
+            end
         end
     end
+    return sampling
 end
 ```
 
@@ -110,7 +117,11 @@ bayesian_result_stan = @time stan_inference(
 Stan's internal timing (excluding data serialization and CSV parsing):
 
 ```julia
-display_stan_timing(bayesian_result_stan)
+elapsed_stan = display_stan_timing(bayesian_result_stan)
+```
+
+```julia
+display_ess_per_sec(bayesian_result_stan.chains, elapsed_stan)
 ```
 
 ### Direct Turing.jl


### PR DESCRIPTION
The FitzHugh-Nagumo benchmark now reports bulk ESS/s and R-hat for the Stan backend, which previously reported only wall time.
`display_stan_timing` printed Stan's per-chain timing from the CSV but returned nothing, so there was no sampling time to divide the ESS by. It now returns the seconds on the `(Sampling)` line.
`summarystats` already computes `ess_bulk` and `rhat` for the Stan chain through the same MCMCDiagnosticTools path as the Turing chain, so both backends are on one estimator. Its `ess_per_sec` column is `missing` for Stan because that chain carries no start and stop time, which is why the rate is computed here rather than read off.
Verified locally against cmdstan 2.39.0 at 800 samples: Stan reports minimum ESS/s 75.6 over 3.61s of sampling, Turing 104.4 over 3.81s. Both benchmarks run a single chain, so R-hat here is the within-chain split diagnostic only.
This relies on `stan_inference` returning an `MCMCChains.Chains`, which holds for the pinned DiffEqBayes 3.13.0. On 3.16.1 it returns a DataFrame instead and this will need revisiting.
