### PR TITLE
Fix ParameterEstimation ModelingToolkit imports (re-apply of #1803)

### DIFF
--- a/benchmarks/ParameterEstimation/FitzHughNagumoParameterEstimation.jmd
+++ b/benchmarks/ParameterEstimation/FitzHughNagumoParameterEstimation.jmd
@@ -8,7 +8,13 @@ author: Vaibhav Dixit, Chris Rackauckas
 ```julia
 using ParameterizedFunctions, OrdinaryDiffEq, DiffEqParamEstim, Optimization
 using OptimizationBBO, OptimizationNLopt, ForwardDiff, Plots, BenchmarkTools
-using ModelingToolkit: t_nounits as t, D_nounits as D
+import ModelingToolkit
+using ModelingToolkit: @mtkbuild, D_nounits as D, t_nounits as t
+@static if isdefined(ModelingToolkit, Symbol("@mtkmodel"))
+    using ModelingToolkit: @mtkmodel
+else
+    using SciCompDSL: @mtkmodel
+end
 gr(fmt = :png)
 ```
 

--- a/benchmarks/ParameterEstimation/LorenzParameterEstimation.jmd
+++ b/benchmarks/ParameterEstimation/LorenzParameterEstimation.jmd
@@ -10,7 +10,13 @@ Note: If data is generated with a fixed time step method and then is tested agai
 ```julia
 using ParameterizedFunctions, OrdinaryDiffEq, DiffEqParamEstim, Optimization
 using OptimizationBBO, OptimizationNLopt, Plots, ForwardDiff, BenchmarkTools
-using ModelingToolkit: t_nounits as t, D_nounits as D
+import ModelingToolkit
+using ModelingToolkit: @mtkbuild, D_nounits as D, t_nounits as t
+@static if isdefined(ModelingToolkit, Symbol("@mtkmodel"))
+    using ModelingToolkit: @mtkmodel
+else
+    using SciCompDSL: @mtkmodel
+end
 gr(fmt = :png)
 ```
 

--- a/benchmarks/ParameterEstimation/LotkaVolterraParameterEstimation.jmd
+++ b/benchmarks/ParameterEstimation/LotkaVolterraParameterEstimation.jmd
@@ -8,7 +8,13 @@ author: Vaibhav Dixit, Chris Rackauckas
 ```julia
 using ParameterizedFunctions, OrdinaryDiffEq, DiffEqParamEstim, Optimization, ForwardDiff
 using OptimizationBBO, OptimizationNLopt, Plots, RecursiveArrayTools, BenchmarkTools
-using ModelingToolkit: t_nounits as t, D_nounits as D
+import ModelingToolkit
+using ModelingToolkit: @mtkbuild, D_nounits as D, t_nounits as t
+@static if isdefined(ModelingToolkit, Symbol("@mtkmodel"))
+    using ModelingToolkit: @mtkmodel
+else
+    using SciCompDSL: @mtkmodel
+end
 gr(fmt = :png)
 ```
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -163,6 +163,26 @@ end
     @test !occursin("SciMLBenchmarks = \"0.1\"", project)
 end
 
+@testset "ParameterEstimation ModelingToolkit imports" begin
+    benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks", "ParameterEstimation")
+    filenames = (
+        "FitzHughNagumoParameterEstimation.jmd",
+        "LorenzParameterEstimation.jmd",
+        "LotkaVolterraParameterEstimation.jmd",
+    )
+    for filename in filenames
+        source = read(joinpath(benchmarks_dir, filename), String)
+        imports = match(r"(?ms)^```julia\n(?<code>.*?)^```", source)
+        @test !isnothing(imports)
+        for name in ("@mtkbuild", "@mtkmodel")
+            @test occursin(name, imports[:code])
+        end
+        @test occursin("@static if isdefined(ModelingToolkit, Symbol(\"@mtkmodel\"))", imports[:code])
+        @test occursin("using ModelingToolkit: @mtkmodel", imports[:code])
+        @test occursin("using SciCompDSL: @mtkmodel", imports[:code])
+    end
+end
+
 @testset "subprocess" begin
     process = SciMLBenchmarks.@subprocess exit()
     @test success(process)


### PR DESCRIPTION
Re-applies https://github.com/SciML/SciMLBenchmarks.jl/pull/1803 onto current master.

#1803 went `CONFLICTING` once #1795, #1833, #1827, #1829 and #1823 landed — all six appended a testset to `test/core.jl`. The three benchmark `.jmd` changes apply unchanged; the new testset is inserted before the `subprocess` testset instead of at the original offset.

## Verification

Diffstat matches #1803 exactly (+41/-3 across the same 4 files).

```
julia --startup-file=no -e 'Meta.parseall(read("test/core.jl",String))'   # parses OK
```

The new testset, run standalone against the updated `.jmd` files:

```
Test Summary:                               | Pass  Total  Time
ParameterEstimation ModelingToolkit imports |   18     18  0.0s
```

I did not run the full `test/core.jl` suite locally; CI covers it.

Closes #1803.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
