### PR TITLE
Release SciMLBenchmarks 0.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBenchmarks"
 uuid = "31c91b34-3c75-11e9-0341-95557aab0344"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Chris Rackauckas, Yingbo Ma, Vaibhav Dixit"]
 
 [deps]


### PR DESCRIPTION
Bumps `SciMLBenchmarks` 0.2.0 -> 0.2.1 (patch).

Source files changed since 0.2.0:
- `src/SciMLBenchmarks.jl`

Commits:
- Fix SpringBlock state ordering after MTK compilation (#1709)
- Fix QA compatibility after v0.2 release (#1711)
- Refresh IntervalNonlinearProblem dependencies (#1699)
- StiffDDE: import solver algorithms explicitly (#1700)
- Fix PDESystemLibrary benchmark output (#1706)
- Refresh AutomaticDifferentiationSparse dependencies (#1705)
- Fix NonStiffBVP orbital benchmark solves (#1703)
- Refresh NonStiffDDE dependencies (#1698)
- Refresh Surrogates benchmark dependencies (#1707)
- StiffODE: relax LinearSolve/AlgebraicMultigrid caps to reach OrdinaryDiffEqDifferentiation 3.10 (#1676)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
