### PR TITLE
Pin AdaptiveSDE DiffEqNoiseProcess 5.34 + plot-label test

### DIFF
--- a/benchmarks/AdaptiveSDE/Manifest.toml
+++ b/benchmarks/AdaptiveSDE/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "13af59e779f79b6bab78d8932fbca524d1f91292"
+project_hash = "e7a5357c04f793b64e4e7f52f3193151b0a25b3a"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "d9aaef7c63466eee4de23b4d9dad03629df54bea"

--- a/benchmarks/AdaptiveSDE/Project.toml
+++ b/benchmarks/AdaptiveSDE/Project.toml
@@ -11,7 +11,7 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [compat]
 DiffEqBase = "7"
-DiffEqNoiseProcess = "5.0"
+DiffEqNoiseProcess = "5.34"
 OrdinaryDiffEqCore = "4"
 Plots = "1.4"
 SDEProblemLibrary = "0.1, 1"

--- a/test/core.jl
+++ b/test/core.jl
@@ -107,6 +107,19 @@ end
     end
 end
 
+@testset "AdaptiveSDE plot labels" begin
+    benchmark = joinpath(
+        dirname(@__DIR__), "benchmarks", "AdaptiveSDE", "AdaptiveEfficiencyTests.jmd"
+    )
+    assignment = only(
+        line for line in eachline(benchmark) if startswith(strip(line), "leg=") ||
+            startswith(strip(line), "leg =")
+    )
+    labels = Core.eval(@__MODULE__, Meta.parse(split(assignment, "="; limit = 2)[2]))
+    @test size(labels) == (1, 3)
+    @test vec(labels) == ["RSwM1", "RSwM2", "RSwM3"]
+end
+
 @testset "HybridJumps Hawkes specialization" begin
     benchmark = read(
         joinpath(dirname(@__DIR__), "benchmarks", "HybridJumps", "MultivariateHawkes.jmd"),


### PR DESCRIPTION
## Summary
- Rebased after https://github.com/SciML/SciMLBenchmarks.jl/pull/1605 merged (grant AdaptiveSDE modernization is on master).
- Remaining delta: pin `DiffEqNoiseProcess = \"5.34\"` in AdaptiveSDE `Project.toml` (Manifest already has 5.34.0) and add the AdaptiveSDE plot-label Core regression from #1687.

## Test plan
- [x] Local AdaptiveSDE plot-label smoke test passes
- [ ] CI Tests / Runic / Spell Check green