### PR TITLE
Bump PINNOptimizers to NeuralPDE 6.3.1

### DIFF
--- a/benchmarks/PINNOptimizers/Manifest.toml
+++ b/benchmarks/PINNOptimizers/Manifest.toml
@@ -2044,9 +2044,9 @@ version = "0.7.2"
 
 [[deps.NeuralPDE]]
 deps = ["ADTypes", "Adapt", "ArrayInterface", "ChainRulesCore", "ComponentArrays", "ConcreteStructs", "Cubature", "Distributions", "DocStringExtensions", "DomainSets", "ForwardDiff", "Functors", "Integrals", "IntervalSets", "LinearAlgebra", "Lux", "LuxCore", "MLDataDevices", "ModelingToolkit", "ModelingToolkitBase", "MonteCarloMeasurements", "NeuralOperators", "Optimisers", "Optimization", "OptimizationOptimisers", "PrecompileTools", "Printf", "QuasiMonteCarlo", "Random", "RecursiveArrayTools", "RuntimeGeneratedFunctions", "SciMLBase", "SciMLPublic", "Statistics", "SymbolicIndexingInterface", "SymbolicUtils", "Symbolics", "WeightInitializers", "Zygote"]
-git-tree-sha1 = "efc1e64fbc65e83652dd600810c920f622ea8716"
+git-tree-sha1 = "a38beec17ccc56e2da7f2a3c172c8cc34032d1e2"
 uuid = "315f7962-48a3-4962-8226-d0f33b1235f0"
-version = "6.2.5"
+version = "6.3.1"
 
     [deps.NeuralPDE.extensions]
     NeuralPDEBPINNExt = ["AdvancedHMC", "LogDensityProblems", "MCMCChains"]


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Refresh only NeuralPDE in the PINNOptimizers manifest from 6.2.5 to 6.3.1. NeuralPDE 6.3.1 includes the fix from https://github.com/SciML/NeuralPDE.jl/pull/1141 for empty prototype batches reaching Lux/cuBLASLt; that exact path made every PINNOptimizers page fail on the V100 with `CUBLAS_STATUS_INVALID_VALUE`.

This is deliberately a two-line manifest-only update. It does not mix benchmark behavior changes into the dependency refresh.

## Verification

All local commands used Julia 1.11.9, matching the manifest.

```text
$ julia +1.11.9 --project=benchmarks/PINNOptimizers -e 'using Pkg; Pkg.update("NeuralPDE"); Pkg.resolve()'
NeuralPDE v6.2.5 ⇒ v6.3.1
Manifest.toml | 2 insertions, 2 deletions
```

```text
$ julia +1.11.9 --project=benchmarks/PINNOptimizers -e 'using Pkg; Pkg.precompile(strict=true); using NeuralPDE; println(pkgversion(NeuralPDE))'
1 dependency successfully precompiled in 110 seconds. 639 already precompiled.
6.3.1
```

```text
$ GROUP=Core julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core          |  169    169  59.0s
Testing SciMLBenchmarks tests passed

$ GROUP=QA julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  1m59.4s
Testing SciMLBenchmarks tests passed
```

`Pkg.resolve()` reported no further changes. `typos benchmarks/PINNOptimizers/Manifest.toml` and `git diff --check` passed. Runic is not applicable to a machine-generated TOML-only diff.

## Not verified locally

This host has no NVIDIA GPU, so the six full PINNOptimizer pages were not run locally. The physical-V100 benchmark job is the final production validation. The focused V100 regression in NeuralPDE passed before the fix was released, but that does not substitute for these benchmark pages.

No docs build was run because this changes no public API, docstring, or documentation source.

## Links

- NeuralPDE fix: https://github.com/SciML/NeuralPDE.jl/pull/1141
- Prior failing PINNOptimizers job: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33514166560/job/99876944600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
