### PR TITLE
Update DiffEqGPU Lorenz ensemble API

### DIFF
--- a/benchmarks/DiffEqGPU/Manifest.toml
+++ b/benchmarks/DiffEqGPU/Manifest.toml
@@ -454,9 +454,9 @@ version = "4.19.3"
 
 [[deps.DiffEqGPU]]
 deps = ["Adapt", "ChainRulesCore", "CommonSolve", "DiffEqBase", "Distributed", "DocStringExtensions", "ForwardDiff", "GPUArraysCore", "KernelAbstractions", "LinearAlgebra", "LinearSolve", "MuladdMacro", "Parameters", "PrecompileTools", "Random", "RecursiveArrayTools", "SciMLBase", "SciMLPublic", "Setfield", "SimpleDiffEq", "SimpleNonlinearSolve", "StaticArrays", "StaticArraysCore", "TOML", "UnPack", "ZygoteRules"]
-git-tree-sha1 = "8ee12cd8bcc07c157864eab48d9ef3b4f547221c"
+git-tree-sha1 = "4f2a692413d2c7dd21f9d4adfad0c1742f43c805"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
-version = "3.20.1"
+version = "3.20.2"
 
     [deps.DiffEqGPU.extensions]
     AMDGPUExt = ["AMDGPU"]

--- a/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
+++ b/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
@@ -60,7 +60,7 @@ function make_ensemble(n; T::Type = Float32)
     p = SVector{1, T}(21)
     plist = range(zero(T), T(21); length = max(n, 2))[1:n]
     prob = ODEProblem{false}(lorenz, u0, tspan, p)
-    prob_func = (prob, i, repeat) -> remake(prob, p = SVector{1, T}(plist[i]))
+    prob_func = (prob, ctx) -> remake(prob, p = SVector{1, T}(plist[ctx.sim_id]))
     return EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)
 end
 
@@ -137,7 +137,7 @@ let
         save_everystep = false, adaptive = false, dt = 0.001f0)
     sol_cpu = solve(ens, Tsit5(), EnsembleSerial(); trajectories = 2,
         save_everystep = false, adaptive = false, dt = 0.001f0)
-    err = maximum(i -> maximum(abs.(sol_gpu[i].u[end] .- sol_cpu[i].u[end])), 1:2)
+    err = maximum(i -> maximum(abs.(sol_gpu.u[i].u[end] .- sol_cpu.u[i].u[end])), 1:2)
     println("kernel vs CPU |Δu|∞ at t=1: ", err)
     @assert err < 1.0f-2
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -162,10 +162,6 @@ end
     lorenz_source = read(lorenz_path, String)
     @test occursin("make_ensemble(2)", lorenz_source)
     @test !occursin("make_ensemble(1)", lorenz_source)
-    @test occursin("prob_func = (prob, ctx)", lorenz_source)
-    @test !occursin("prob_func = (prob, i, repeat)", lorenz_source)
-    @test occursin("sol_gpu.u[i].u[end]", lorenz_source)
-    @test occursin("sol_cpu.u[i].u[end]", lorenz_source)
     lorenz_expression = benchmark_assignment(lorenz_path, "plist")
     lorenz_grid = Core.eval(@__MODULE__, :((n, T) -> $lorenz_expression))
     @test collect(Base.invokelatest(lorenz_grid, 1, Float32)) == Float32[0]

--- a/test/core.jl
+++ b/test/core.jl
@@ -162,6 +162,10 @@ end
     lorenz_source = read(lorenz_path, String)
     @test occursin("make_ensemble(2)", lorenz_source)
     @test !occursin("make_ensemble(1)", lorenz_source)
+    @test occursin("prob_func = (prob, ctx)", lorenz_source)
+    @test !occursin("prob_func = (prob, i, repeat)", lorenz_source)
+    @test occursin("sol_gpu.u[i].u[end]", lorenz_source)
+    @test occursin("sol_cpu.u[i].u[end]", lorenz_source)
     lorenz_expression = benchmark_assignment(lorenz_path, "plist")
     lorenz_grid = Core.eval(@__MODULE__, :((n, T) -> $lorenz_expression))
     @test collect(Base.invokelatest(lorenz_grid, 1, Float32)) == Float32[0]


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

Update `lorenz_ensemble.jmd` to the current two-argument `EnsembleProblem.prob_func` context API and the current `EnsembleSolution.u` trajectory layout. This restores the one missing DiffEqGPU output page without weakening its original `dt = 0.001f0` kernel-versus-CPU accuracy assertion.

This is a stacked validation PR. It temporarily includes the prerequisite DiffEqGPU 3.20.2 manifest commit, because that release contains the fixed-step endpoint correction from https://github.com/SciML/DiffEqGPU.jl/pull/526. The manifest commit will be opened and merged separately before this PR is made mergeable; this PR must not merge with both commits still in its diff.

## Verification

Failing before the source change, with the four new source assertions applied:

```text
GROUP=Core julia +1.11.9 --project=. -e "using Pkg; Pkg.test()"
Core | 169 passed, 4 failed, 173 total, 4m16.2s
```

Passing after the source change:

```text
GROUP=Core julia +1.11.9 --project=. -e "using Pkg; Pkg.test()"
Core | 173 passed, 173 total, 39.1s

GROUP=QA julia +1.11.9 --project=. -e "using Pkg; Pkg.test()"
QA | 21 passed, 21 total, 1m54.4s
```

A clean CPU-kernel reproducer using the exact DiffEqGPU 3.20.2 release and the unchanged benchmark timestep completed at the requested endpoint and satisfied the existing threshold:

```text
DiffEqGPU=3.20.2
kernel_end_times=Float32[1.0, 1.0]
kernel_vs_cpu_error=0.0002975464
```

The prerequisite manifest was also checked independently:

```text
CondaPkg.resolve() with an isolated fresh Pixi cache: condapkg_resolve=ok
Pkg.precompile(strict=true): 118 dependencies precompiled, 356 cached
strict_precompile=ok version=3.20.2
Core | 169 passed, 169 total, 56.1s
QA | 21 passed, 21 total, 1m50.2s
```

Runic check, `typos`, and `git diff --check` passed for the changed source and test.

## Not verified locally

This machine has no CUDA GPU, so I did not claim a local V100 run. The PR intentionally triggers the full DiffEqGPU folder on the hosted V100 and remains draft until that artifact is inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512