### PR TITLE
Handle scalar PINN error callback losses

### DIFF
--- a/benchmarks/PINNErrorsVsTime/Manifest.toml
+++ b/benchmarks/PINNErrorsVsTime/Manifest.toml
@@ -2056,9 +2056,9 @@ version = "0.7.2"
 
 [[deps.NeuralPDE]]
 deps = ["ADTypes", "Adapt", "ArrayInterface", "ChainRulesCore", "ComponentArrays", "ConcreteStructs", "Cubature", "Distributions", "DocStringExtensions", "DomainSets", "ForwardDiff", "Functors", "Integrals", "IntervalSets", "LinearAlgebra", "Lux", "LuxCore", "MLDataDevices", "ModelingToolkit", "ModelingToolkitBase", "MonteCarloMeasurements", "NeuralOperators", "Optimisers", "Optimization", "OptimizationOptimisers", "PrecompileTools", "Printf", "QuasiMonteCarlo", "Random", "RecursiveArrayTools", "RuntimeGeneratedFunctions", "SciMLBase", "SciMLPublic", "Statistics", "SymbolicIndexingInterface", "SymbolicUtils", "Symbolics", "WeightInitializers", "Zygote"]
-git-tree-sha1 = "efc1e64fbc65e83652dd600810c920f622ea8716"
+git-tree-sha1 = "a38beec17ccc56e2da7f2a3c172c8cc34032d1e2"
 uuid = "315f7962-48a3-4962-8226-d0f33b1235f0"
-version = "6.2.5"
+version = "6.3.1"
 
     [deps.NeuralPDE.extensions]
     NeuralPDEBPINNExt = ["AdvancedHMC", "LogDensityProblems", "MCMCChains"]

--- a/benchmarks/PINNErrorsVsTime/allen_cahn_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/allen_cahn_et.jmd
@@ -25,6 +25,7 @@ using CUDA, LuxCUDA, ComponentArrays, Random
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"
 println("GPU: ", CUDA.name(CUDA.device()))
 const gpud = gpu_device()
+const cpud = cpu_device()
 
 function allen_cahn(strategy, minimizer, maxIters)
 
@@ -115,7 +116,7 @@ function allen_cahn(strategy, minimizer, maxIters)
         append!(times, ctime / 10^9) #Conversion nanosec to seconds
         append!(losses, l)
         loss_ = loss_function_(p.u, nothing)
-        append!(error, Array(loss_))
+        push!(error, only(cpud(loss_)))
         timeCounter = timeCounter + time_ns() - deltaT_s #timeCounter sums all delays due to the callback functions of the previous iterations
 
         #if (ctime/10^9 > time) #if I exceed the limit time I stop the training

--- a/benchmarks/PINNErrorsVsTime/diffusion_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/diffusion_et.jmd
@@ -25,6 +25,7 @@ using CUDA, LuxCUDA, ComponentArrays, Random
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"
 println("GPU: ", CUDA.name(CUDA.device()))
 const gpud = gpu_device()
+const cpud = cpu_device()
 ```
 
 ```julia
@@ -82,7 +83,7 @@ function diffusion(strategy, minimizer, maxIters)
         append!(times, ctime/10^9) #Conversion nanosec to seconds
         append!(losses, l)
         loss_ = loss_function_(p, nothing)
-        append!(error, Array(loss_))
+        push!(error, only(cpud(loss_)))
 
         timeCounter = timeCounter + time_ns() - deltaT_s #timeCounter sums all delays due to the callback functions of the previous iterations
 

--- a/benchmarks/PINNErrorsVsTime/hamilton_jacobi_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/hamilton_jacobi_et.jmd
@@ -23,6 +23,7 @@ using CUDA, LuxCUDA, ComponentArrays, Random
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"
 println("GPU: ", CUDA.name(CUDA.device()))
 const gpud = gpu_device()
+const cpud = cpu_device()
 ```
 
 ```julia
@@ -130,7 +131,7 @@ function hamilton_jacobi(strategy, minimizer, maxIters)
             # Extract parameters for loss calculation
             params = p.u
             loss_ = loss_function_(p, nothing)
-            push!(error, only(Array(loss_)))
+            push!(error, only(cpud(loss_)))
 
             timeCounter += time_ns() - deltaT_s
             return false

--- a/benchmarks/PINNErrorsVsTime/level_set_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/level_set_et.jmd
@@ -25,6 +25,7 @@ using CUDA, LuxCUDA, ComponentArrays, Random
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"
 println("GPU: ", CUDA.name(CUDA.device()))
 const gpud = gpu_device()
+const cpud = cpu_device()
 ```
 
 ```julia
@@ -122,7 +123,7 @@ function level_set(strategy, minimizer, maxIters)
             # Extract parameters for loss calculation
             params = p.u
             loss_ = loss_function_(p, nothing)
-            push!(error, only(Array(loss_)))
+            push!(error, only(cpud(loss_)))
 
             timeCounter += time_ns() - deltaT_s
             return false

--- a/benchmarks/PINNErrorsVsTime/nernst_planck_et.jmd
+++ b/benchmarks/PINNErrorsVsTime/nernst_planck_et.jmd
@@ -25,6 +25,7 @@ using CUDA, LuxCUDA, ComponentArrays, Random
 @assert CUDA.functional() "This benchmark requires a functional CUDA GPU"
 println("GPU: ", CUDA.name(CUDA.device()))
 const gpud = gpu_device()
+const cpud = cpu_device()
 ```
 
 ```julia
@@ -125,7 +126,7 @@ function nernst_planck(strategy, minimizer, maxIters)
             # Extract parameters for loss calculation
             params = p.u
             loss_ = loss_function_(p, nothing)
-            push!(error, only(Array(loss_)))
+            push!(error, only(cpud(loss_)))
 
             timeCounter += time_ns() - deltaT_s
             return false

--- a/test/core.jl
+++ b/test/core.jl
@@ -408,22 +408,6 @@ end
     @test count("enright_initial_conditions(", source) == 11
 end
 
-@testset "PINN error callback scalar losses" begin
-    folder = joinpath(dirname(@__DIR__), "benchmarks", "PINNErrorsVsTime")
-    for file in (
-            "allen_cahn_et.jmd",
-            "diffusion_et.jmd",
-            "hamilton_jacobi_et.jmd",
-            "level_set_et.jmd",
-            "nernst_planck_et.jmd",
-        )
-        source = read(joinpath(folder, file), String)
-        @test occursin("const cpud = cpu_device()", source)
-        @test occursin("push!(error, only(cpud(loss_)))", source)
-        @test !occursin("Array(loss_)", source)
-    end
-end
-
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")

--- a/test/core.jl
+++ b/test/core.jl
@@ -408,6 +408,22 @@ end
     @test count("enright_initial_conditions(", source) == 11
 end
 
+@testset "PINN error callback scalar losses" begin
+    folder = joinpath(dirname(@__DIR__), "benchmarks", "PINNErrorsVsTime")
+    for file in (
+            "allen_cahn_et.jmd",
+            "diffusion_et.jmd",
+            "hamilton_jacobi_et.jmd",
+            "level_set_et.jmd",
+            "nernst_planck_et.jmd",
+        )
+        source = read(joinpath(folder, file), String)
+        @test occursin("const cpud = cpu_device()", source)
+        @test occursin("push!(error, only(cpud(loss_)))", source)
+        @test !occursin("Array(loss_)", source)
+    end
+end
+
 @testset "weave_file" begin
     benchmarks_dir = joinpath(dirname(@__DIR__), "benchmarks")
     SciMLBenchmarks.weave_file(joinpath(benchmarks_dir, "Testing"), "test.jmd")


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

Transfer each recomputed PINN error loss through the Lux CPU device and extract its
single value before appending it. The current NeuralPDE stack returns a `Float64` for
the diffusion error loss, so `Array(loss_)` throws
`MethodError: no method matching Array(::Float64)`; the new expression also handles a
one-element device array without GPU scalar indexing.

This is a stacked validation PR. It temporarily includes the separate NeuralPDE 6.3.1
manifest prerequisite, which carries the empty-GPU-batch guard from
https://github.com/SciML/NeuralPDE.jl/pull/1141. The manifest bump will be opened and
merged separately before this PR is made mergeable; this PR must not merge with both
commits still in its diff.

## Verification

The unfixed diffusion page failed in the hosted V100 Weave:

```text
ERROR: MethodError: no method matching Array(::Float64)
ERROR: LoadError: weave_folder: 5 file(s) failed
```

Failing job:
https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/33607994369/job/100176366127

The original and replacement expressions were then exercised directly with the
benchmark environment and Julia 1.11.9:

```text
before=MethodError: MethodError: no method matching Array(::Float64)
after_scalar=1.0
after_zero_dim=2.0
after_vector=3.0
```

Repository checks after removing the now-prohibited source-string test:

```text
Core | 169 passed, 169 total, 53.2s
QA   |  21 passed,  21 total, 1m51.0s
```

The prerequisite manifest was checked independently:

```text
Pkg.precompile(strict=true): 70 dependencies precompiled, 590 cached
NeuralPDE version: 6.3.1
Core | 169 passed, 169 total, 55.8s
QA   |  21 passed,  21 total, 1m49.4s
```

`typos` and `git diff --check` passed on every changed file. Runic does not parse the
YAML-front-mattered `.jmd` files; the repository's hosted Runic check passed the prior
benchmark revision, and local Runic passed on `test/core.jl` after removing its
source-inspection test.

## Not verified locally

This machine has no CUDA GPU. The complete post-fix PINNErrorsVsTime Weave has not yet
passed: the replacement hosted V100 job is queued, and all five generated pages must
be inspected before this draft can be treated as verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
