### PR TITLE
Refresh Testing benchmark dependencies

### DIFF
--- a/benchmarks/Testing/Manifest.toml
+++ b/benchmarks/Testing/Manifest.toml
@@ -128,9 +128,9 @@ version = "0.0.20230411+1"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "f4d39eee89f1e58c26bf447f1d4156c0125d6838"
+git-tree-sha1 = "2bfb1e047e2ad0a5ca94365340bde8005d637568"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.8.3+0"
+version = "2.8.4+0"
 
 [[deps.FFMPEG]]
 deps = ["FFMPEG_jll"]
@@ -224,16 +224,11 @@ git-tree-sha1 = "69ffb934a5c5b7e086a0b4fee3427db2556fba6e"
 uuid = "3b182d85-2403-5c21-9c21-1e1f0cc25472"
 version = "1.3.16+0"
 
-[[deps.Grisu]]
-git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
-uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
-version = "1.0.2"
-
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
-git-tree-sha1 = "c3f99f8e7c98031b8845ece9db86dca713ab9bf8"
+git-tree-sha1 = "9d9531a9cb63a9edc33836414e82a07e81710de2"
 uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
-version = "100.14003.0+0"
+version = "100.14004.0+0"
 
 [[deps.Highlights]]
 deps = ["DocStringExtensions", "InteractiveUtils", "REPL"]
@@ -287,9 +282,9 @@ version = "3.100.3+0"
 
 [[deps.LERC_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "17b94ecafcfa45e8360a4fc9ca6b583b049e4e37"
+git-tree-sha1 = "39bca05343661c347aae0bca57a5994a0bf4f08d"
 uuid = "88015f11-f218-50d7-93a8-a6af411a945d"
-version = "4.1.0+0"
+version = "4.2.0+0"
 
 [[deps.LLVMOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -500,9 +495,9 @@ version = "1.58.2+0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "3de8f5e6e90ebfa8d6d1f86997d6cdcd6a912ff3"
+git-tree-sha1 = "ba0dc8a8a67cacac4842631f960c046e4e563675"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.7"
+version = "2.8.8"
 
 [[deps.Pixman_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
@@ -641,9 +636,9 @@ version = "0.7.0"
 
 [[deps.SciMLBenchmarks]]
 deps = ["InteractiveUtils", "Markdown", "Pkg", "PrecompileTools", "Weave"]
-git-tree-sha1 = "a2f0add1b4a5748b6177eb125e152a8f99b4bd78"
+git-tree-sha1 = "207025127589b2f2ce1743a28b35378dbd3819c0"
 uuid = "31c91b34-3c75-11e9-0341-95557aab0344"
-version = "0.2.0"
+version = "0.2.1"
 
     [deps.SciMLBenchmarks.extensions]
     SciMLBenchmarksIJuliaExt = "IJulia"
@@ -661,10 +656,10 @@ version = "1.3.0"
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [[deps.Showoff]]
-deps = ["Dates", "Grisu"]
-git-tree-sha1 = "91eddf657aca81df9ae6ceb20b959ae5653ad1de"
+deps = ["Dates"]
+git-tree-sha1 = "8238217340ad0aaabe11afe39c1098b5bc9f4c8e"
 uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
-version = "1.0.3"
+version = "1.1.1"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"


### PR DESCRIPTION
Ignore this draft until reviewed by @ChrisRackauckas.

## What changed and why

Refresh the single-page Testing benchmark manifest to the current compatible patch releases. This moves the in-manifest SciMLBenchmarks package from 0.2.0 to 0.2.1, Showoff from 1.0.3 to 1.1.1, Parsers from 2.8.7 to 2.8.8, and three JLL patch releases; Grisu is removed because current Showoff no longer depends on it.

This is deliberately a manifest-only mechanical refresh. No benchmark behavior or source is changed.

## Local verification

All commands used Julia 1.10.11, matching the manifest.

```text
bash .github/scripts/build_benchmark.sh benchmarks/Testing
exit 0
markdown/Testing/test.md: 8,270 bytes
plot references: 1
no ERROR/LoadError/Stacktrace/UndefVarError/MethodError markers

GROUP=Core julia +1.10.11 --project=. -e "using Pkg; Pkg.test()"
Core | Pass 169 | Total 169 | Time 1m56.2s
Testing SciMLBenchmarks tests passed

GROUP=QA julia +1.10.11 --project=. -e "using Pkg; Pkg.test()"
QA | Pass 19 | Total 19 | Time 1m04.0s
Testing SciMLBenchmarks tests passed
```

A second `Pkg.resolve()` reported no changes and preserved the manifest SHA-256 `c89e622e3ea6a1f4a279cfe2f4fd49f43fb87d676b8a55fdd629f6033e532fd9`. `typos benchmarks/Testing/Manifest.toml` and `git diff --check` exited 0. Runic and a docs build are not applicable to this generated TOML-only diff.

No dependency is added, so there is no new license impact.

## Not verified

GitHub Actions has not run yet. This folder has no GPU-specific path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512