### PR TITLE
Update HybridJumps saving callback APIs

### DIFF
--- a/benchmarks/HybridJumps/Synapse.jmd
+++ b/benchmarks/HybridJumps/Synapse.jmd
@@ -1944,12 +1944,12 @@ function (affect!::SavingAffect)(integrator, force_save = false)
         if curt != integrator.t # If <t, interpolate
             if integrator isa SciMLBase.AbstractODEIntegrator
                 # Expand lazy dense for interpolation
-                DiffEqBase.addsteps!(integrator)
+                SciMLBase.addsteps!(integrator)
             end
-            if !DiffEqBase.isinplace(integrator.sol.prob)
+            if !SciMLBase.isinplace(integrator.sol.prob)
                 curu = integrator(curt)
             else
-                curu = first(get_tmp_cache(integrator))
+                curu = first(SciMLBase.get_tmp_cache(integrator))
                 integrator(curu, curt) # inplace since save_func allocates
             end
             copyat_or_push!(affect!.saved_values.t, affect!.saveiter, curt)
@@ -1980,23 +1980,34 @@ function (affect!::SavingAffect)(integrator, force_save = false)
             Val{false}
         )
     end
-    derivative_discontinuity!(integrator, false)
+    if isdefined(SciMLBase, :derivative_discontinuity!)
+        return SciMLBase.derivative_discontinuity!(integrator, false)
+    end
+    return SciMLBase.u_modified!(integrator, false)
 end
 
 # adapted from DiffEqCallbacks.jl/src/saving.jl
-function saving_initialize!(cb, u, t, integrator)
+function saving_initialize!(cb, u, t, integrator, last_modified_value)
     integrator.p.xd .= integrator.p.xd0
-    cb.affect!.saveat = deepcopy(integrator.opts.saveat)
+    last_modified_value[] = copy(integrator.p.xd)
+    saveat = deepcopy(integrator.opts.saveat)
+    while !isempty(cb.affect!.saveat)
+        pop!(cb.affect!.saveat)
+    end
+    while !isempty(saveat)
+        push!(cb.affect!.saveat, pop!(saveat))
+    end
     cb.affect!.save_everystep = integrator.opts.save_everystep
     cb.affect!.save_start = integrator.opts.save_start
     cb.affect!.save_end = integrator.opts.save_end
     cb.affect!.saveiter = 0
-    cb.affect!.save_start && cb.affect!(integrator, true)
+    return cb.affect!.save_start && cb.affect!(integrator, true)
 end
 
 # adapted from DiffEqCallbacks.jl/src/saving.jl
 function SavingCallback(save_func, saved_values::SavedValues; save_modified = true)
     saveat_internal = DataStructures.BinaryHeap{eltype(saved_values.t)}(DataStructures.FasterForward())
+    last_modified_value = Ref{eltype(saved_values.saveval)}()
     affect! = SavingAffect(
         save_func,
         saved_values,
@@ -2011,7 +2022,8 @@ function SavingCallback(save_func, saved_values::SavedValues; save_modified = tr
     # saves every step regardless of save_modified
     condition = if save_modified
         function (u, t, integrator)
-            if integrator.u_modified
+            if integrator.p.xd != last_modified_value[]
+                copyto!(last_modified_value[], integrator.p.xd)
                 push!(affect!.saveat, t)
             end
 
@@ -2022,10 +2034,11 @@ function SavingCallback(save_func, saved_values::SavedValues; save_modified = tr
             return true
         end
     end
-    DiscreteCallback(
+    return DiscreteCallback(
         condition,
         affect!;
-        initialize = saving_initialize!,
+        initialize = (cb, u, t, integrator) ->
+        saving_initialize!(cb, u, t, integrator, last_modified_value),
         save_positions = (false, false)
     )
 end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Update the custom HybridJumps saving callback to work with both the currently pinned SciMLBase 2 stack and the pending SciMLBase 3 dependency refresh. The callback now calls the owner-qualified SciMLBase APIs, refills its existing saving heap instead of assigning an incompatible heap implementation, and tracks changes to the benchmark's discrete state instead of reading the removed `ODEIntegrator.u_modified` field.

This is a source-only fix. The dependency refresh remains separate.

## Failing before

The exact benchmark wrapper on clean current master with Julia 1.10.11 failed after reaching the first JumpProcesses Coevolve solve:

```sh
.github/scripts/build_benchmark.sh benchmarks/HybridJumps/Synapse.jmd
```

```text
ERROR: LoadError: UndefVarError: `derivative_discontinuity!` not defined
weave_folder: 1 file(s) failed: [("benchmarks/HybridJumps", "Synapse.jmd")]
```

The refreshed dependency environment exposed the next two stale callback assumptions with the same wrapper:

```text
convert DataStructures.BinaryHeap to BinaryHeaps.BinaryHeap
type ODEIntegrator has no field u_modified
```

Each run exited 1 before the final compatibility patch.

## Passing after

The same exact wrapper completed on both environments:

```text
Current manifest (Julia 1.10.11)  | exit 0 | 1h11m13s
Refreshed manifest (Julia 1.10.11)| exit 0 | 1h00m38s
```

Each run generated `Synapse.md` (84,811 bytes) with four image references backed by four nonempty PNGs, zero broken local references, and zero fatal Julia/Weave signatures.

Repository checks:

```text
Core | 169/169 pass | 48.8s
QA   | 21/21 pass  | 1m44.8s
Runic on the two wholly modified helper functions | pass
typos benchmarks/HybridJumps/Synapse.jmd --diff | pass
git diff --check | pass
```

## Not verified

The hosted benchmark job has not run yet. No GPU path or public package API is changed. No separate docs build was run because the affected `.jmd` page was built directly with the repository's authoritative benchmark wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
