### PR TITLE
OptimizationCUTEst: document page structure, selection rules, solvers, and success criteria

### DIFF
--- a/benchmarks/OptimizationCUTEst/CUTEst_bounded.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_bounded.jmd
@@ -5,8 +5,29 @@ author: Prashant Andoriya
 
 # CUTEst Bounded Constrained Optimization.jl Benchmarks
 
-This benchmark runs bounded constrained CUTEst problems through the Optimization.jl
-interface using `OptimizationNLPModels`.
+This benchmark runs constrained problems from the
+[CUTEst](https://github.com/JuliaSmoothOptimizers/CUTEst.jl) test set through the
+Optimization.jl interface using `OptimizationNLPModels`. Two candidate pools are used:
+
+  - equality constrained: `CUTEst.select_sif_problems(min_con = 1, only_equ_con = true, only_free_var = false)`
+  - inequality constrained: `CUTEst.select_sif_problems(min_con = 1, only_ineq_con = true, only_free_var = false)`
+
+`min_con = 1` requires at least one general (linear or nonlinear) constraint,
+`only_equ_con` keeps problems whose constraints are all equalities, and `only_ineq_con`
+keeps problems with no equality constraints. `only_free_var = false` is CUTEst's default
+and does not restrict variable bounds, so these pools contain problems with and without
+bounds on the variables; the companion `CUTEst_unbounded` page is the subset with
+`only_free_var = true`. Tightening this page to bounded variables only
+(`only_bnd_var = true`) is a selection change tracked in
+[SciMLBenchmarks#1857](https://github.com/SciML/SciMLBenchmarks.jl/issues/1857).
+
+All four CUTEst pages in this folder share the harness in `cutest_benchmark_utils.jl`,
+which defines the selection constants, the solver constructors, the run loop, and the
+summary and plotting helpers. The prose below describes the harness as it stands;
+refinements to the solver sets, solution-quality metrics, performance profiles, problem
+selection, and timing methodology are tracked in #1857.
+
+## Setup
 
 ```julia
 ENV["GKSwstype"] = "100"
@@ -21,6 +42,24 @@ using Printf
 
 include(joinpath(isdefined(Main, :WEAVE_ARGS) ? WEAVE_ARGS[:folder] : @__DIR__,
     "cutest_benchmark_utils.jl"))
+```
+
+## Problem selection
+
+`select_safe_problems` walks each candidate pool in the order returned by
+`CUTEst.select_sif_problems`, skips any name in the hand-maintained `KNOWN_BAD_PROBLEMS`
+list, loads each remaining problem once to read its metadata, keeps it only if
+`nvar <= MAX_NVAR` and `ncon <= MAX_NCON`, and stops after `MAX_PROBLEMS_PER_CATEGORY`
+problems. Problems whose metadata cannot be loaded are skipped. The values in effect for
+this run are printed below.
+
+```julia
+println("MAX_PROBLEMS_PER_CATEGORY = ", MAX_PROBLEMS_PER_CATEGORY)
+println("MAX_NVAR = ", MAX_NVAR)
+println("MAX_NCON = ", MAX_NCON)
+println("SOLVE_MAXITERS = ", SOLVE_MAXITERS)
+println("SOLVE_TIMEOUT_SECONDS = ", SOLVE_TIMEOUT_SECONDS)
+println("KNOWN_BAD_PROBLEMS = ", join(sort(collect(KNOWN_BAD_PROBLEMS)), ", "))
 
 bounded_equality_problems = select_safe_problems(
     collect(CUTEst.select_sif_problems(min_con = 1, only_equ_con = true,
@@ -33,8 +72,36 @@ bounded_inequality_problems = select_safe_problems(
 )
 
 println("Selected bounded equality-constrained problems: ", length(bounded_equality_problems))
+println(join(bounded_equality_problems, ", "))
 println("Selected bounded inequality-constrained problems: ", length(bounded_inequality_problems))
+println(join(bounded_inequality_problems, ", "))
+```
 
+## Solvers
+
+`CONSTRAINED_SOLVERS` currently contains only `Ipopt`, run through `OptimizationMOI`.
+It is the only optimizer wired into the harness that accepts general equality and
+inequality constraints via Optimization.jl; the Optim.jl algorithms on the unconstrained
+page do not. Ipopt is configured with `max_iter = SOLVE_MAXITERS`,
+`max_wall_time = SOLVE_TIMEOUT_SECONDS`, `tol = 1.0e-6`, `print_level = 0`, and
+`hessian_approximation = "limited-memory"`. The limited-memory setting is used because
+`OptimizationNLPModels` supplies the objective gradient and Hessian and the constraint
+values and Jacobian from the CUTEst model, but not the constraint Hessians needed for an
+exact Hessian of the Lagrangian. The same
+iteration and time limits are also passed to `solve` as `maxiters` and `maxtime`. Adding
+further constrained backends and an exact-Hessian Ipopt variant is item 1 of #1857.
+
+## Run
+
+Each (problem, solver) pair is solved once by `run_single_solve`. A row records the return
+code as reported by Optimization.jl and a `status` of `OK` when `solve` returned,
+`FAILED` when it threw, or `LOAD_FAILED` when the CUTEst problem could not be
+constructed. The reported time is `sol.stats.time` when the solver provides a finite,
+non-negative value, and otherwise the wall-clock time measured around problem construction
+and `solve` together. `run_benchmarks` errors if a category yields no `OK` rows, so a
+broken environment fails the build instead of producing an empty page.
+
+```julia
 bounded_results = vcat(
     run_benchmarks("bounded equality constrained", bounded_equality_problems,
         CONSTRAINED_SOLVERS),
@@ -43,6 +110,19 @@ bounded_results = vcat(
 )
 
 display(bounded_results)
+```
+
+## Summary
+
+`summarize_results` groups rows by category and solver. `completion_rate` is the share of
+runs with `status == "OK"`, i.e. the solver returned at all. `success_rate` is the share
+of runs whose return code is in `SUCCESS_RETCODES` (`Success`, `Terminated`,
+`FirstOrderOptimal`). Runs that stopped at `MaxIters` or `MaxTime` count as completed but
+not successful. `median_secs` is the median of the per-run time described above over all
+rows for that category and solver, including unsuccessful ones. No solution-quality
+metric (objective value, KKT residual, constraint violation) is recorded yet; see #1857.
+
+```julia
 bounded_summary = summarize_results(bounded_results)
 
 plot_solve_times(bounded_results, "CUTEst bounded constrained Optimization.jl solve time")

--- a/benchmarks/OptimizationCUTEst/CUTEst_quadratic.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_quadratic.jmd
@@ -5,8 +5,21 @@ author: Prashant Andoriya
 
 # CUTEst Quadratic Optimization.jl Benchmarks
 
-This benchmark runs CUTEst quadratic problems with linear constraints through the
-Optimization.jl interface using `OptimizationNLPModels`.
+This benchmark runs quadratic programs from the
+[CUTEst](https://github.com/JuliaSmoothOptimizers/CUTEst.jl) test set through the
+Optimization.jl interface using `OptimizationNLPModels`. The candidate pool is
+`CUTEst.select_sif_problems(objtype = "quadratic", contype = "linear")`, i.e. problems
+whose MASTSIF classification has a quadratic objective and linear constraints. No filter is
+applied on variable bounds or on the equality/inequality mix of the constraints.
+
+All four CUTEst pages in this folder share the harness in `cutest_benchmark_utils.jl`,
+which defines the selection constants, the solver constructors, the run loop, and the
+summary and plotting helpers. The prose below describes the harness as it stands;
+refinements to the solver sets, solution-quality metrics, performance profiles, problem
+selection, and timing methodology are tracked in
+[SciMLBenchmarks#1857](https://github.com/SciML/SciMLBenchmarks.jl/issues/1857).
+
+## Setup
 
 ```julia
 ENV["GKSwstype"] = "100"
@@ -21,6 +34,24 @@ using Printf
 
 include(joinpath(isdefined(Main, :WEAVE_ARGS) ? WEAVE_ARGS[:folder] : @__DIR__,
     "cutest_benchmark_utils.jl"))
+```
+
+## Problem selection
+
+`select_safe_problems` walks the candidates in the order returned by
+`CUTEst.select_sif_problems`, skips any name in the hand-maintained `KNOWN_BAD_PROBLEMS`
+list, loads each remaining problem once to read its metadata, keeps it only if
+`nvar <= MAX_NVAR` and `ncon <= MAX_NCON`, and stops after `MAX_PROBLEMS_PER_CATEGORY`
+problems. Problems whose metadata cannot be loaded are skipped. The values in effect for
+this run are printed below.
+
+```julia
+println("MAX_PROBLEMS_PER_CATEGORY = ", MAX_PROBLEMS_PER_CATEGORY)
+println("MAX_NVAR = ", MAX_NVAR)
+println("MAX_NCON = ", MAX_NCON)
+println("SOLVE_MAXITERS = ", SOLVE_MAXITERS)
+println("SOLVE_TIMEOUT_SECONDS = ", SOLVE_TIMEOUT_SECONDS)
+println("KNOWN_BAD_PROBLEMS = ", join(sort(collect(KNOWN_BAD_PROBLEMS)), ", "))
 
 quadratic_linear_problems = select_safe_problems(
     collect(CUTEst.select_sif_problems(objtype = "quadratic", contype = "linear"))
@@ -28,7 +59,35 @@ quadratic_linear_problems = select_safe_problems(
 
 println("Selected quadratic problems with linear constraints: ",
     length(quadratic_linear_problems))
+println(join(quadratic_linear_problems, ", "))
+```
 
+## Solvers
+
+`CONSTRAINED_SOLVERS` currently contains only `Ipopt`, run through `OptimizationMOI`.
+It is the only optimizer wired into the harness that accepts general equality and
+inequality constraints via Optimization.jl; the Optim.jl algorithms on the unconstrained
+page do not. Ipopt is configured with `max_iter = SOLVE_MAXITERS`,
+`max_wall_time = SOLVE_TIMEOUT_SECONDS`, `tol = 1.0e-6`, `print_level = 0`, and
+`hessian_approximation = "limited-memory"`. The limited-memory setting is used because
+`OptimizationNLPModels` supplies the objective gradient and Hessian and the constraint
+values and Jacobian from the CUTEst model, but not the constraint Hessians needed for an
+exact Hessian of the Lagrangian. The same
+iteration and time limits are also passed to `solve` as `maxiters` and `maxtime`. Ipopt
+treats these problems as general nonlinear programs; no QP-specific solver is used yet.
+Adding further constrained backends and an exact-Hessian Ipopt variant is item 1 of #1857.
+
+## Run
+
+Each (problem, solver) pair is solved once by `run_single_solve`. A row records the return
+code as reported by Optimization.jl and a `status` of `OK` when `solve` returned,
+`FAILED` when it threw, or `LOAD_FAILED` when the CUTEst problem could not be
+constructed. The reported time is `sol.stats.time` when the solver provides a finite,
+non-negative value, and otherwise the wall-clock time measured around problem construction
+and `solve` together. `run_benchmarks` errors if a category yields no `OK` rows, so a
+broken environment fails the build instead of producing an empty page.
+
+```julia
 quadratic_results = run_benchmarks(
     "quadratic linear",
     quadratic_linear_problems,
@@ -36,6 +95,19 @@ quadratic_results = run_benchmarks(
 )
 
 display(quadratic_results)
+```
+
+## Summary
+
+`summarize_results` groups rows by category and solver. `completion_rate` is the share of
+runs with `status == "OK"`, i.e. the solver returned at all. `success_rate` is the share
+of runs whose return code is in `SUCCESS_RETCODES` (`Success`, `Terminated`,
+`FirstOrderOptimal`). Runs that stopped at `MaxIters` or `MaxTime` count as completed but
+not successful. `median_secs` is the median of the per-run time described above over all
+rows for that category and solver, including unsuccessful ones. No solution-quality
+metric (objective value, KKT residual, constraint violation) is recorded yet; see #1857.
+
+```julia
 quadratic_summary = summarize_results(quadratic_results)
 
 plot_solve_times(quadratic_results, "CUTEst quadratic Optimization.jl solve time")

--- a/benchmarks/OptimizationCUTEst/CUTEst_unbounded.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_unbounded.jmd
@@ -5,8 +5,27 @@ author: Prashant Andoriya
 
 # CUTEst Unbounded Constrained Optimization.jl Benchmarks
 
-This benchmark runs constrained CUTEst problems with free variables through the
-Optimization.jl interface using `OptimizationNLPModels`.
+This benchmark runs constrained problems with free variables from the
+[CUTEst](https://github.com/JuliaSmoothOptimizers/CUTEst.jl) test set through the
+Optimization.jl interface using `OptimizationNLPModels`. Two candidate pools are used:
+
+  - equality constrained: `CUTEst.select_sif_problems(min_con = 1, only_equ_con = true, only_free_var = true)`
+  - inequality constrained: `CUTEst.select_sif_problems(min_con = 1, only_ineq_con = true, only_free_var = true)`
+
+`min_con = 1` requires at least one general (linear or nonlinear) constraint,
+`only_equ_con` keeps problems whose constraints are all equalities, `only_ineq_con` keeps
+problems with no equality constraints, and `only_free_var = true` keeps only problems in
+which every variable is free (no lower or upper bounds). These pools are therefore subsets
+of the pools used by the `CUTEst_bounded` page, which does not restrict variable bounds.
+
+All four CUTEst pages in this folder share the harness in `cutest_benchmark_utils.jl`,
+which defines the selection constants, the solver constructors, the run loop, and the
+summary and plotting helpers. The prose below describes the harness as it stands;
+refinements to the solver sets, solution-quality metrics, performance profiles, problem
+selection, and timing methodology are tracked in
+[SciMLBenchmarks#1857](https://github.com/SciML/SciMLBenchmarks.jl/issues/1857).
+
+## Setup
 
 ```julia
 ENV["GKSwstype"] = "100"
@@ -21,6 +40,24 @@ using Printf
 
 include(joinpath(isdefined(Main, :WEAVE_ARGS) ? WEAVE_ARGS[:folder] : @__DIR__,
     "cutest_benchmark_utils.jl"))
+```
+
+## Problem selection
+
+`select_safe_problems` walks each candidate pool in the order returned by
+`CUTEst.select_sif_problems`, skips any name in the hand-maintained `KNOWN_BAD_PROBLEMS`
+list, loads each remaining problem once to read its metadata, keeps it only if
+`nvar <= MAX_NVAR` and `ncon <= MAX_NCON`, and stops after `MAX_PROBLEMS_PER_CATEGORY`
+problems. Problems whose metadata cannot be loaded are skipped. The values in effect for
+this run are printed below.
+
+```julia
+println("MAX_PROBLEMS_PER_CATEGORY = ", MAX_PROBLEMS_PER_CATEGORY)
+println("MAX_NVAR = ", MAX_NVAR)
+println("MAX_NCON = ", MAX_NCON)
+println("SOLVE_MAXITERS = ", SOLVE_MAXITERS)
+println("SOLVE_TIMEOUT_SECONDS = ", SOLVE_TIMEOUT_SECONDS)
+println("KNOWN_BAD_PROBLEMS = ", join(sort(collect(KNOWN_BAD_PROBLEMS)), ", "))
 
 unbounded_equality_problems = select_safe_problems(
     collect(CUTEst.select_sif_problems(min_con = 1, only_equ_con = true,
@@ -34,9 +71,37 @@ unbounded_inequality_problems = select_safe_problems(
 
 println("Selected unbounded equality-constrained problems: ",
     length(unbounded_equality_problems))
+println(join(unbounded_equality_problems, ", "))
 println("Selected unbounded inequality-constrained problems: ",
     length(unbounded_inequality_problems))
+println(join(unbounded_inequality_problems, ", "))
+```
 
+## Solvers
+
+`CONSTRAINED_SOLVERS` currently contains only `Ipopt`, run through `OptimizationMOI`.
+It is the only optimizer wired into the harness that accepts general equality and
+inequality constraints via Optimization.jl; the Optim.jl algorithms on the unconstrained
+page do not. Ipopt is configured with `max_iter = SOLVE_MAXITERS`,
+`max_wall_time = SOLVE_TIMEOUT_SECONDS`, `tol = 1.0e-6`, `print_level = 0`, and
+`hessian_approximation = "limited-memory"`. The limited-memory setting is used because
+`OptimizationNLPModels` supplies the objective gradient and Hessian and the constraint
+values and Jacobian from the CUTEst model, but not the constraint Hessians needed for an
+exact Hessian of the Lagrangian. The same
+iteration and time limits are also passed to `solve` as `maxiters` and `maxtime`. Adding
+further constrained backends and an exact-Hessian Ipopt variant is item 1 of #1857.
+
+## Run
+
+Each (problem, solver) pair is solved once by `run_single_solve`. A row records the return
+code as reported by Optimization.jl and a `status` of `OK` when `solve` returned,
+`FAILED` when it threw, or `LOAD_FAILED` when the CUTEst problem could not be
+constructed. The reported time is `sol.stats.time` when the solver provides a finite,
+non-negative value, and otherwise the wall-clock time measured around problem construction
+and `solve` together. `run_benchmarks` errors if a category yields no `OK` rows, so a
+broken environment fails the build instead of producing an empty page.
+
+```julia
 unbounded_results = vcat(
     run_benchmarks("unbounded equality constrained", unbounded_equality_problems,
         CONSTRAINED_SOLVERS),
@@ -45,6 +110,19 @@ unbounded_results = vcat(
 )
 
 display(unbounded_results)
+```
+
+## Summary
+
+`summarize_results` groups rows by category and solver. `completion_rate` is the share of
+runs with `status == "OK"`, i.e. the solver returned at all. `success_rate` is the share
+of runs whose return code is in `SUCCESS_RETCODES` (`Success`, `Terminated`,
+`FirstOrderOptimal`). Runs that stopped at `MaxIters` or `MaxTime` count as completed but
+not successful. `median_secs` is the median of the per-run time described above over all
+rows for that category and solver, including unsuccessful ones. No solution-quality
+metric (objective value, KKT residual, constraint violation) is recorded yet; see #1857.
+
+```julia
 unbounded_summary = summarize_results(unbounded_results)
 
 plot_solve_times(unbounded_results, "CUTEst unbounded constrained Optimization.jl solve time")

--- a/benchmarks/OptimizationCUTEst/CUTEst_unconstrained.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_unconstrained.jmd
@@ -5,8 +5,28 @@ author: Prashant Andoriya
 
 # CUTEst Unconstrained Optimization.jl Benchmarks
 
-This benchmark runs unconstrained CUTEst problems through the Optimization.jl interface
-using `OptimizationNLPModels`.
+This benchmark runs unconstrained problems from the
+[CUTEst](https://github.com/JuliaSmoothOptimizers/CUTEst.jl) test set through the
+Optimization.jl interface using `OptimizationNLPModels`. The problem class is selected with
+`CUTEst.select_sif_problems(contype = "unc")`, i.e. problems with no constraints and no
+variable bounds.
+
+All four CUTEst pages in this folder (`CUTEst_unconstrained`, `CUTEst_bounded`,
+`CUTEst_unbounded`, `CUTEst_quadratic`) share the harness in `cutest_benchmark_utils.jl`,
+which defines the selection constants, the solver constructors, the run loop, and the
+summary and plotting helpers. The prose below describes the harness as it stands on this
+page; refinements to the solver sets, solution-quality metrics, performance profiles,
+problem selection, and timing methodology are tracked in
+[SciMLBenchmarks#1857](https://github.com/SciML/SciMLBenchmarks.jl/issues/1857).
+
+This page supersedes the former `CUTEst_safe_solvers.jmd`, which was removed in
+[#1594](https://github.com/SciML/SciMLBenchmarks.jl/pull/1594). That page ran the same
+`contype = "unc"` problem set with a three-solver subset (`LBFGS`, `ConjugateGradient`,
+`NelderMead`) of the solvers used here and a copy of the run loop, so it duplicated this
+page with less coverage and was dropped when the pages were consolidated onto the shared
+harness.
+
+## Setup
 
 ```julia
 ENV["GKSwstype"] = "100"
@@ -21,6 +41,24 @@ using Printf
 
 include(joinpath(isdefined(Main, :WEAVE_ARGS) ? WEAVE_ARGS[:folder] : @__DIR__,
     "cutest_benchmark_utils.jl"))
+```
+
+## Problem selection
+
+`select_safe_problems` walks the candidates in the order returned by
+`CUTEst.select_sif_problems`, skips any name in the hand-maintained `KNOWN_BAD_PROBLEMS`
+list, loads each remaining problem once to read its metadata, keeps it only if
+`nvar <= max_var` and `ncon <= max_con`, and stops after `max_problems` problems. The
+defaults are `MAX_PROBLEMS_PER_CATEGORY`, `MAX_NVAR`, and `MAX_NCON`; this page keeps the
+variable cap and sets `max_con = 0` because the problems are unconstrained. Problems whose
+metadata cannot be loaded are skipped. The values in effect for this run are printed below.
+
+```julia
+println("MAX_PROBLEMS_PER_CATEGORY = ", MAX_PROBLEMS_PER_CATEGORY)
+println("MAX_NVAR = ", MAX_NVAR)
+println("SOLVE_MAXITERS = ", SOLVE_MAXITERS)
+println("SOLVE_TIMEOUT_SECONDS = ", SOLVE_TIMEOUT_SECONDS)
+println("KNOWN_BAD_PROBLEMS = ", join(sort(collect(KNOWN_BAD_PROBLEMS)), ", "))
 
 unconstrained_problems = select_safe_problems(
     collect(CUTEst.select_sif_problems(contype = "unc"));
@@ -29,7 +67,31 @@ unconstrained_problems = select_safe_problems(
 )
 
 println("Selected unconstrained problems: ", length(unconstrained_problems))
+println(join(unconstrained_problems, ", "))
+```
 
+## Solvers
+
+`UNCONSTRAINED_SOLVERS` lists the Optim.jl algorithms run through `OptimizationOptimJL`:
+`LBFGS`, `ConjugateGradient`, `NelderMead`, `SimulatedAnnealing`, and `ParticleSwarm`.
+Each is constructed with its default options. Gradients come from the NLPModels interface,
+so the two gradient-based methods use CUTEst's analytic derivatives rather than finite
+differences. Every solve is called with `maxiters = SOLVE_MAXITERS` and
+`maxtime = SOLVE_TIMEOUT_SECONDS`. The global heuristics (`SimulatedAnnealing`,
+`ParticleSwarm`) are run with the same budget and reported alongside the local methods;
+separating them is part of #1857.
+
+## Run
+
+Each (problem, solver) pair is solved once by `run_single_solve`. A row records the return
+code as reported by Optimization.jl and a `status` of `OK` when `solve` returned,
+`FAILED` when it threw, or `LOAD_FAILED` when the CUTEst problem could not be
+constructed. The reported time is `sol.stats.time` when the solver provides a finite,
+non-negative value, and otherwise the wall-clock time measured around problem construction
+and `solve` together. `run_benchmarks` errors if a category yields no `OK` rows, so a
+broken environment fails the build instead of producing an empty page.
+
+```julia
 unc_results = run_benchmarks(
     "unconstrained",
     unconstrained_problems,
@@ -37,6 +99,19 @@ unc_results = run_benchmarks(
 )
 
 display(unc_results)
+```
+
+## Summary
+
+`summarize_results` groups rows by solver. `completion_rate` is the share of runs with
+`status == "OK"`, i.e. the solver returned at all. `success_rate` is the share of runs
+whose return code is in `SUCCESS_RETCODES` (`Success`, `Terminated`,
+`FirstOrderOptimal`). Runs that stopped at `MaxIters` or `MaxTime` count as completed but
+not successful. `median_secs` is the median of the per-run time described above over all
+rows for that solver, including unsuccessful ones. No solution-quality metric (objective
+value, gradient norm) is recorded yet; see #1857.
+
+```julia
 unc_summary = summarize_results(unc_results)
 
 plot_solve_times(unc_results, "CUTEst unconstrained Optimization.jl solve time")


### PR DESCRIPTION
Part of #1857 (item 8, "Page structure and documentation"). Follow-up to #1594.

## Summary

Each of the four CUTEst pages (`CUTEst_unconstrained`, `CUTEst_bounded`, `CUTEst_unbounded`, `CUTEst_quadratic`) now has prose, written against the harness as it currently stands, covering:

- the problem class and the exact `CUTEst.select_sif_problems` filter used;
- the selection rules (`MAX_PROBLEMS_PER_CATEGORY`, `MAX_NVAR`, `MAX_NCON`, `KNOWN_BAD_PROBLEMS`, first-in-SIF-order, metadata-load skip), described by constant name rather than hard-coded numbers;
- the solver set and its configuration (Optim.jl defaults with `maxiters`/`maxtime` on the unconstrained page; Ipopt with `max_iter`, `max_wall_time`, `tol`, `hessian_approximation = "limited-memory"` on the constrained pages), and why the constrained pages use only Ipopt;
- the success criterion (`SUCCESS_RETCODES`; `MaxIters`/`MaxTime` count as completed but not successful) and the meaning of `completion_rate` vs `success_rate` and `median_secs`;
- how time is measured (`sol.stats.time` with a wall-clock fallback that includes problem construction);
- a shared sentence pointing to #1857 for planned refinements (broader solver sets, quality metrics, performance profiles, selection, timing).

The single code chunk per page is split into Setup / Problem selection / Run / Summary chunks. The selection chunk prints the active constants and the selected problem names so the rendered artifact is self-describing. `CUTEst_unconstrained.jmd` notes that it supersedes `CUTEst_safe_solvers.jmd` (removed in #1594) and why.

Two harness facts are documented rather than changed, since sibling PRs own the harness:

- `only_free_var = false` on the bounded page is CUTEst's default and does not restrict variable bounds, so that page's pool is a superset of the unbounded page's pool. The prose says so and points to #1857 for tightening to `only_bnd_var = true`.
- `OptimizationNLPModels` supplies objective gradient/Hessian and constraint values/Jacobian but not constraint Hessians, which is why Ipopt runs with a limited-memory Hessian.

## Scope

Documentation and page structure only. No computational change: the code executed by each page is identical apart from the added `println` calls. `cutest_benchmark_utils.jl` is not modified. No emojis, no README added (no other benchmark folder has one).

## Verification

Tangle + parse check (Weave in a temporary env, Julia 1.12.4):

```
[ Info: Tangled to /tmp/tangled/CUTEst_unconstrained.jl
[ Info: Tangled to /tmp/tangled/CUTEst_bounded.jl
[ Info: Tangled to /tmp/tangled/CUTEst_unbounded.jl
[ Info: Tangled to /tmp/tangled/CUTEst_quadratic.jl
PARSE_OK CUTEst_unconstrained 24 top-level exprs
PARSE_OK CUTEst_bounded 28 top-level exprs
PARSE_OK CUTEst_unbounded 28 top-level exprs
PARSE_OK CUTEst_quadratic 25 top-level exprs
```

`typos benchmarks/OptimizationCUTEst/` passes.

Smoke run of the unconstrained selection chunk with `max_problems = 3` (temporary script outside the repo) to confirm the new output renders:

```
MAX_PROBLEMS_PER_CATEGORY = 50
KNOWN_BAD_PROBLEMS = bloweya, chardis1, cleuven4, cmpc10, cmpc3, cvxqp2, dittert, hier13, lukvle8, lukvli7, mpc2, mss1, ninenew, patternne, reading2, reading6
Selected unconstrained problems: 3
LUKSAN13LS, JUDGE, FBRAIN3LS
```

The full pages were not run (multi-hour).

Made with [Cursor](https://cursor.com)