### PR TITLE
CUTEst harness: two-run timing with measured compile time, solver warm-up, stronger degenerate-result guard

### DIFF
--- a/benchmarks/OptimizationCUTEst/CUTEst_bounded.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_bounded.jmd
@@ -47,6 +47,7 @@ bounded_summary = summarize_results(bounded_results)
 
 plot_solve_times(bounded_results, "CUTEst bounded constrained Optimization.jl solve time")
 plot_success_rates(bounded_summary, "CUTEst bounded constrained Optimization.jl success rate")
+plot_compile_times(bounded_results, "CUTEst bounded constrained Optimization.jl compile time")
 ```
 
 ```julia, echo = false

--- a/benchmarks/OptimizationCUTEst/CUTEst_quadratic.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_quadratic.jmd
@@ -40,6 +40,7 @@ quadratic_summary = summarize_results(quadratic_results)
 
 plot_solve_times(quadratic_results, "CUTEst quadratic Optimization.jl solve time")
 plot_success_rates(quadratic_summary, "CUTEst quadratic Optimization.jl success rate")
+plot_compile_times(quadratic_results, "CUTEst quadratic Optimization.jl compile time")
 ```
 
 ```julia, echo = false

--- a/benchmarks/OptimizationCUTEst/CUTEst_unbounded.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_unbounded.jmd
@@ -50,6 +50,7 @@ unbounded_summary = summarize_results(unbounded_results)
 plot_solve_times(unbounded_results, "CUTEst unbounded constrained Optimization.jl solve time")
 plot_success_rates(unbounded_summary,
     "CUTEst unbounded constrained Optimization.jl success rate")
+plot_compile_times(unbounded_results, "CUTEst unbounded constrained Optimization.jl compile time")
 ```
 
 ```julia, echo = false

--- a/benchmarks/OptimizationCUTEst/CUTEst_unconstrained.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_unconstrained.jmd
@@ -41,6 +41,7 @@ unc_summary = summarize_results(unc_results)
 
 plot_solve_times(unc_results, "CUTEst unconstrained Optimization.jl solve time")
 plot_success_rates(unc_summary, "CUTEst unconstrained Optimization.jl success rate")
+plot_compile_times(unc_results, "CUTEst unconstrained Optimization.jl compile time")
 ```
 
 ```julia, echo = false

--- a/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
+++ b/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
@@ -147,10 +147,35 @@ end
 
 elapsed_seconds(started_ns) = (time_ns() - started_ns) / 1.0e9
 
-# Timing columns:
-#   secs                 wall-clock time around `solve(...)` only (primary metric)
+# `Base.cumulative_compile_time_ns()` returns `(compile_ns, recompile_ns)` on Julia >= 1.9
+# (a bare integer on older versions); recompilation is a subset of compilation, so the
+# first element is the total compile time (this is what `@time` reports).
+compile_ns(t) = t isa Tuple ? first(t) : t
+compile_seconds_since(before) = (compile_ns(Base.cumulative_compile_time_ns()) - compile_ns(before)) / 1.0e9
+
+solve_once(prob, solver_name) = solve(
+    prob, optimizer_from_name(solver_name);
+    maxiters = SOLVE_MAXITERS,
+    maxtime = SOLVE_TIMEOUT_SECONDS
+)
+
+# The second (clean) solve is skipped when the first one already hit the time cap or
+# errored, so a timed-out pair costs one cap, not two.
+rerun_worthwhile(first_retcode, first_solve_secs) =
+    first_retcode != "MaxTime" && first_solve_secs < SOLVE_TIMEOUT_SECONDS
+
+# Each (problem, solver) pair is solved twice. Timing columns:
+#   first_solve_secs     wall-clock time of the first `solve(...)`, includes any compilation
+#   compile_secs         Julia compilation time measured during the first solve
+#                        (`Base.cumulative_compile_timing`). Solver-level compilation is
+#                        absorbed by `warmup_solvers`, so this column shows per-problem-shape
+#                        recompilation (bounds / constraints present or not) if any
+#   secs                 wall-clock time of the second `solve(...)` on a fresh
+#                        `OptimizationProblem` from the same `nlp` (primary metric); equals
+#                        `first_solve_secs` when the rerun is skipped
 #   decode_secs          wall-clock time of the CUTEst SIF decode / `CUTEstModel(name)`
 #   solver_reported_secs `sol.stats.time` when the backend provides it, otherwise NaN
+# `retcode` comes from the second run, `first_retcode` from the first.
 function run_single_solve(problem_name, solver_name)
     nlp = nothing
     decode_started = time_ns()
@@ -166,31 +191,56 @@ function run_single_solve(problem_name, solver_name)
             solver = solver_name,
             n_vars = -1,
             secs = 0.0,
+            first_solve_secs = 0.0,
+            compile_secs = 0.0,
             decode_secs = elapsed_seconds(decode_started),
             solver_reported_secs = NaN,
             retcode = "LOAD_FAILED",
+            first_retcode = "LOAD_FAILED",
             status = "LOAD_FAILED",
         )
     end
     decode_secs = elapsed_seconds(decode_started)
 
+    first_solve_secs = 0.0
+    compile_secs = 0.0
+    first_retcode = "FAILED"
     solve_started = time_ns()
     try
         prob = OptimizationNLPModels.OptimizationProblem(nlp)
+        Base.cumulative_compile_timing(true)
+        compile_before = Base.cumulative_compile_time_ns()
         solve_started = time_ns()
-        sol = solve(prob, optimizer_from_name(solver_name);
-            maxiters = SOLVE_MAXITERS,
-            maxtime = SOLVE_TIMEOUT_SECONDS)
-        secs = elapsed_seconds(solve_started)
+        sol = try
+            solve_once(prob, solver_name)
+        finally
+            first_solve_secs = elapsed_seconds(solve_started)
+            compile_secs = compile_seconds_since(compile_before)
+            Base.cumulative_compile_timing(false)
+        end
+        first_retcode = retcode_name(sol.retcode)
+        secs = first_solve_secs
+
+        if rerun_worthwhile(first_retcode, first_solve_secs)
+            prob = OptimizationNLPModels.OptimizationProblem(nlp)
+            solve_started = time_ns()
+            sol = solve_once(prob, solver_name)
+            secs = elapsed_seconds(solve_started)
+        else
+            print(" [rerun skipped: first run ended with $first_retcode]")
+        end
 
         return (;
             problem = problem_name,
             solver = solver_name,
             n_vars = nlp.meta.nvar,
             secs = secs,
+            first_solve_secs = first_solve_secs,
+            compile_secs = compile_secs,
             decode_secs = decode_secs,
             solver_reported_secs = solve_seconds(sol, NaN),
             retcode = retcode_name(sol.retcode),
+            first_retcode = first_retcode,
             status = "OK",
         )
     catch err
@@ -202,9 +252,12 @@ function run_single_solve(problem_name, solver_name)
             solver = solver_name,
             n_vars = nlp.meta.nvar,
             secs = elapsed_seconds(solve_started),
+            first_solve_secs = first_solve_secs,
+            compile_secs = compile_secs,
             decode_secs = decode_secs,
             solver_reported_secs = NaN,
             retcode = "FAILED",
+            first_retcode = first_retcode,
             status = "FAILED",
         )
     finally
@@ -224,23 +277,30 @@ warmup_problem_for(solver_name) =
     WARMUP_UNCONSTRAINED_PROBLEM
 
 # Run one throwaway solve per solver on a tiny problem so that JIT compilation of the
-# solver / NLPModels / MOI code paths is not attributed to the first measured row.
-# `problem` may be a problem name applied to every solver, or `nothing` to pick a
-# tiny unconstrained/constrained problem per solver via `warmup_problem_for`.
+# solver / NLPModels / MOI code paths is not attributed to whichever problem comes first
+# in the benchmark loop. The per-solver compile time measured here is printed and
+# returned; the per-pair `compile_secs` column then only shows recompilation caused by a
+# change of problem shape. `problem` may be a problem name applied to every solver, or
+# `nothing` to pick a tiny unconstrained/constrained problem per solver via
+# `warmup_problem_for`.
 function warmup_solvers(solvers; problem = nothing)
+    rows = NamedTuple[]
+
     println()
-    println("Warming up solvers (JIT), results are discarded:")
+    println("Warming up solvers (JIT), results are not benchmarked:")
     for solver_name in solvers
         problem_name = problem === nothing ? warmup_problem_for(solver_name) : problem
         @printf("  %-18s %-24s", solver_name, problem_name)
         started = time_ns()
         row = run_single_solve(problem_name, solver_name)
+        push!(rows, row)
         @printf(
-            " %s %s %.3fs (total %.3fs)\n", row.status, row.retcode, row.secs,
+            " %s %s first %.3fs compile %.3fs clean %.3fs (total %.3fs)\n", row.status,
+            row.retcode, row.first_solve_secs, row.compile_secs, row.secs,
             elapsed_seconds(started)
         )
     end
-    return nothing
+    return DataFrame(rows)
 end
 
 function run_benchmarks(category, problems, solvers; warmup = true)
@@ -259,16 +319,18 @@ function run_benchmarks(category, problems, solvers; warmup = true)
             row = run_single_solve(problem_name, solver_name)
             push!(rows, merge((category = category,), row))
             @printf(
-                " %s %s %.3fs (decode %.3fs)\n", row.status, row.retcode, row.secs,
-                row.decode_secs
+                " %s %s %.3fs (first %.3fs, compile %.3fs, decode %.3fs)\n", row.status,
+                row.retcode, row.secs, row.first_solve_secs, row.compile_secs, row.decode_secs
             )
         end
     end
 
     results = isempty(rows) ? DataFrame(
             category = String[], problem = String[], solver = String[],
-            n_vars = Int[], secs = Float64[], decode_secs = Float64[],
-            solver_reported_secs = Float64[], retcode = String[], status = String[]
+            n_vars = Int[], secs = Float64[], first_solve_secs = Float64[],
+            compile_secs = Float64[], decode_secs = Float64[],
+            solver_reported_secs = Float64[], retcode = String[], first_retcode = String[],
+            status = String[]
         ) : DataFrame(rows)
 
     assert_has_measurements(results, category)
@@ -344,6 +406,8 @@ function summarize_results(results)
         :retcode => (x -> count(in(SUCCESS_RETCODES), x)) => :successful_runs,
         :retcode => length => :total_runs,
         :secs => median => :median_secs,
+        :compile_secs => median => :median_compile_secs,
+        :compile_secs => sum => :total_compile_secs,
     )
 
     summary.completion_rate = round.(summary.completed_runs ./ summary.total_runs .* 100; digits = 1)
@@ -375,6 +439,30 @@ function plot_solve_times(results, title)
     )
 
     return display(solve_time_plot)
+end
+
+# Compile time measured during the first solve of each pair. Rows with exactly zero
+# compile time (nothing was compiled) cannot be drawn on a log axis and are dropped.
+function plot_compile_times(results, title)
+    compiled = filter([:status, :compile_secs] => (s, c) -> s == "OK" && c > 0, results)
+    if nrow(compiled) == 0
+        println("No rows with nonzero compile time; skipping compile time plot.")
+        return nothing
+    end
+
+    compile_time_plot = @df compiled scatter(
+        :n_vars,
+        :compile_secs,
+        group = :solver,
+        xlabel = "Number of variables",
+        ylabel = "Compile seconds (first solve)",
+        title = title,
+        yscale = :log10,
+        legend = :topleft,
+        size = (900, 600),
+    )
+
+    return display(compile_time_plot)
 end
 
 function plot_success_rates(summary, title)

--- a/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
+++ b/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
@@ -20,6 +20,15 @@ const MAX_NCON = 1_000
 const SOLVE_MAXITERS = 1_000
 const SOLVE_TIMEOUT_SECONDS = 90.0
 
+# A category is considered degenerate (and the page fails) when fewer than this
+# fraction of its rows complete at the harness level (`status == "OK"`), regardless
+# of the solver-reported return code.
+const MIN_COMPLETED_FRACTION = 0.8
+
+# Tiny problems used to trigger JIT compilation before the first measured solve.
+const WARMUP_UNCONSTRAINED_PROBLEM = "ROSENBR"
+const WARMUP_CONSTRAINED_PROBLEM = "HS35"
+
 const SUCCESS_RETCODES = Set(["Success", "Terminated", "FirstOrderOptimal"])
 
 const KNOWN_BAD_PROBLEMS = Set(
@@ -112,6 +121,9 @@ function select_safe_problems(
     return selected
 end
 
+# Solver-reported time (`sol.stats.time`). Its definition differs between backends
+# (some include setup, some only the iteration loop, some never set it), so it is
+# recorded as `solver_reported_secs` for reference only and is NOT the primary metric.
 function solve_seconds(sol, fallback)
     try
         if hasfield(typeof(sol), :stats) && hasfield(typeof(sol.stats), :time)
@@ -133,9 +145,15 @@ function print_exception(prefix, err, bt)
     println(prefix, ": ", sprint(showerror, err, bt))
 end
 
+elapsed_seconds(started_ns) = (time_ns() - started_ns) / 1.0e9
+
+# Timing columns:
+#   secs                 wall-clock time around `solve(...)` only (primary metric)
+#   decode_secs          wall-clock time of the CUTEst SIF decode / `CUTEstModel(name)`
+#   solver_reported_secs `sol.stats.time` when the backend provides it, otherwise NaN
 function run_single_solve(problem_name, solver_name)
     nlp = nothing
-    started = time()
+    decode_started = time_ns()
 
     try
         nlp = CUTEstModel(problem_name)
@@ -147,24 +165,31 @@ function run_single_solve(problem_name, solver_name)
             problem = problem_name,
             solver = solver_name,
             n_vars = -1,
-            secs = time() - started,
+            secs = 0.0,
+            decode_secs = elapsed_seconds(decode_started),
+            solver_reported_secs = NaN,
             retcode = "LOAD_FAILED",
             status = "LOAD_FAILED",
         )
     end
+    decode_secs = elapsed_seconds(decode_started)
 
+    solve_started = time_ns()
     try
         prob = OptimizationNLPModels.OptimizationProblem(nlp)
+        solve_started = time_ns()
         sol = solve(prob, optimizer_from_name(solver_name);
             maxiters = SOLVE_MAXITERS,
             maxtime = SOLVE_TIMEOUT_SECONDS)
-        secs = solve_seconds(sol, time() - started)
+        secs = elapsed_seconds(solve_started)
 
         return (;
             problem = problem_name,
             solver = solver_name,
             n_vars = nlp.meta.nvar,
             secs = secs,
+            decode_secs = decode_secs,
+            solver_reported_secs = solve_seconds(sol, NaN),
             retcode = retcode_name(sol.retcode),
             status = "OK",
         )
@@ -176,7 +201,9 @@ function run_single_solve(problem_name, solver_name)
             problem = problem_name,
             solver = solver_name,
             n_vars = nlp.meta.nvar,
-            secs = time() - started,
+            secs = elapsed_seconds(solve_started),
+            decode_secs = decode_secs,
+            solver_reported_secs = NaN,
             retcode = "FAILED",
             status = "FAILED",
         )
@@ -192,8 +219,34 @@ function run_single_solve(problem_name, solver_name)
     end
 end
 
-function run_benchmarks(category, problems, solvers)
+warmup_problem_for(solver_name) =
+    solver_name in CONSTRAINED_SOLVERS ? WARMUP_CONSTRAINED_PROBLEM :
+    WARMUP_UNCONSTRAINED_PROBLEM
+
+# Run one throwaway solve per solver on a tiny problem so that JIT compilation of the
+# solver / NLPModels / MOI code paths is not attributed to the first measured row.
+# `problem` may be a problem name applied to every solver, or `nothing` to pick a
+# tiny unconstrained/constrained problem per solver via `warmup_problem_for`.
+function warmup_solvers(solvers; problem = nothing)
+    println()
+    println("Warming up solvers (JIT), results are discarded:")
+    for solver_name in solvers
+        problem_name = problem === nothing ? warmup_problem_for(solver_name) : problem
+        @printf("  %-18s %-24s", solver_name, problem_name)
+        started = time_ns()
+        row = run_single_solve(problem_name, solver_name)
+        @printf(
+            " %s %s %.3fs (total %.3fs)\n", row.status, row.retcode, row.secs,
+            elapsed_seconds(started)
+        )
+    end
+    return nothing
+end
+
+function run_benchmarks(category, problems, solvers; warmup = true)
     rows = NamedTuple[]
+
+    warmup && warmup_solvers(solvers)
 
     println()
     println("Running $category benchmarks")
@@ -205,31 +258,77 @@ function run_benchmarks(category, problems, solvers)
             @printf("  %-18s %-24s", solver_name, problem_name)
             row = run_single_solve(problem_name, solver_name)
             push!(rows, merge((category = category,), row))
-            @printf(" %s %s %.3fs\n", row.status, row.retcode, row.secs)
+            @printf(
+                " %s %s %.3fs (decode %.3fs)\n", row.status, row.retcode, row.secs,
+                row.decode_secs
+            )
         end
     end
 
     results = isempty(rows) ? DataFrame(
-        category = String[], problem = String[], solver = String[],
-        n_vars = Int[], secs = Float64[], retcode = String[], status = String[]
-    ) : DataFrame(rows)
+            category = String[], problem = String[], solver = String[],
+            n_vars = Int[], secs = Float64[], decode_secs = Float64[],
+            solver_reported_secs = Float64[], retcode = String[], status = String[]
+        ) : DataFrame(rows)
 
     assert_has_measurements(results, category)
     return results
 end
 
+function count_distribution(values)
+    counts = sort(collect(countmap(values)); by = x -> x[2], rev = true)
+    return join(["$code=$n" for (code, n) in counts], ", ")
+end
+
+# Fails the page when a category is degenerate:
+#   * fewer than `MIN_COMPLETED_FRACTION` of the rows completed at the harness level
+#     (`status == "OK"`), or
+#   * any solver has zero completed rows (every call errored / was killed -> broken backend).
+# Zero *success* (retcode-based) for a solver is only warned about, since global
+# heuristics such as SimulatedAnnealing legitimately report 0% success on some categories.
 function assert_has_measurements(results, category)
-    completed = nrow(results) == 0 ? 0 : count(==("OK"), results.status)
-    completed > 0 && return nothing
+    nrow(results) == 0 && error("CUTEst benchmark for $category produced no rows at all.")
 
-    distribution = nrow(results) == 0 ? "no rows" :
-                   join(["$code=$n" for (code, n) in sort(
-                       collect(countmap(results.retcode)); by = x -> x[2], rev = true)], ", ")
+    completed = count(==("OK"), results.status)
+    completed_fraction = completed / nrow(results)
+    status_distribution = count_distribution(results.status)
+    retcode_distribution = count_distribution(results.retcode)
 
-    error(
-        "CUTEst benchmark for $category produced no completed solver measurements. " *
-        "Return code distribution: $distribution",
-    )
+    failures = String[]
+    if completed_fraction < MIN_COMPLETED_FRACTION
+        msg = @sprintf(
+            "only %d/%d rows (%.1f%%) completed, below MIN_COMPLETED_FRACTION = %.1f%%",
+            completed, nrow(results), 100 * completed_fraction, 100 * MIN_COMPLETED_FRACTION
+        )
+        push!(failures, msg)
+    end
+
+    solvers = unique(results.solver)
+    broken_solvers = filter(solvers) do solver
+        count(row -> row.solver == solver && row.status == "OK", eachrow(results)) == 0
+    end
+    if !isempty(broken_solvers)
+        push!(failures, "solver(s) with zero completed rows: " * join(broken_solvers, ", "))
+    end
+
+    if !isempty(failures)
+        error(
+            "CUTEst benchmark for $category is degenerate: " * join(failures, "; ") *
+                ". Status distribution: $status_distribution. " *
+                "Return code distribution: $retcode_distribution",
+        )
+    end
+
+    no_success_solvers = filter(solvers) do solver
+        count(row -> row.solver == solver && row.retcode in SUCCESS_RETCODES, eachrow(results)) == 0
+    end
+    if !isempty(no_success_solvers)
+        @warn "CUTEst benchmark for $category has solver(s) with 0% success (no retcode in SUCCESS_RETCODES); allowed, but worth a look" category solvers = join(no_success_solvers, ", ") retcode_distribution
+    end
+
+    completed_pct = round(100 * completed_fraction; digits = 1)
+    println("  $category: $completed/$(nrow(results)) rows completed ($completed_pct%); status: $status_distribution")
+    return nothing
 end
 
 function summarize_results(results)


### PR DESCRIPTION
Part of #1857 (items 5 and 7). Follow-up to #1594.

Changes are confined to `benchmarks/OptimizationCUTEst/`: the harness `cutest_benchmark_utils.jl` plus one added `plot_compile_times(...)` line in each of the four `.jmd` pages. `run_benchmarks` / `assert_has_measurements` keep their call signatures and `secs` keeps its name and meaning as the primary solve time, so existing plots keep working.

## Timing methodology (item 5): compile run, then clean run

Per maintainer request, every (problem, solver) pair is solved **twice** in `run_single_solve`:

1. **First run** (compile run): wall-clock time recorded as `first_solve_secs`; Julia compilation during the solve is measured directly with `Base.cumulative_compile_timing(true)` / `Base.cumulative_compile_time_ns()` (what `@time` uses) and recorded as `compile_secs`. On Julia 1.12 `cumulative_compile_time_ns()` returns `(compile_ns, recompile_ns)`; recompilation is a *subset* of compilation (that is what `@time` prints as "of which X% was recompilation"), so `compile_secs` is the first element rather than the sum, to avoid double counting. A bare-integer return on older Julia is handled too. Compile timing is switched off in a `finally`.
2. **Second run** (clean run): a fresh `OptimizationProblem` is built from the same `nlp` and solved again; its wall time is the primary metric `secs`. `retcode` / `solver_reported_secs` come from this run; `first_retcode` is kept as a column so divergent first/second outcomes are visible. (Verified that `solve` does not mutate `prob.u0` for either Optim or Ipopt/MOI; the fresh problem is belt-and-braces.)
3. **Skip rule**: the second run is skipped (and `secs = first_solve_secs`) when the first run returned `MaxTime` or ran for `>= SOLVE_TIMEOUT_SECONDS`, or errored. The skip is printed inline (`[rerun skipped: first run ended with MaxTime]`).

Other timing columns: `decode_secs` (CUTEst SIF decode / `CUTEstModel(name)`), `solver_reported_secs` (`sol.stats.time` when the backend provides it, `NaN` otherwise; reference only since its meaning differs between backends).

### Where compile time is attributed

- `warmup_solvers(solvers; problem = nothing)` still runs one solve per solver on a tiny problem (`ROSENBR` for unconstrained solvers, `HS35` for `CONSTRAINED_SOLVERS`) before the benchmark loop. It now measures and prints the **per-solver** compile time (and returns the rows as a `DataFrame`), so solver-level JIT is not attributed to whichever problem happens to come first.
- The per-pair `compile_secs` column therefore shows only compilation triggered by a change of **problem shape** (bounds present/absent, constraints present/absent) for that solver. Derivatives come from NLPModels (no AD) and every problem is the same `CUTEstModel` type, so recompilation per problem *shape* rather than per problem was the expectation; the data below confirms it.

### Showing compile time in the results

- `summarize_results` gains `median_compile_secs` and `total_compile_secs` per (category, solver).
- New `plot_compile_times(results, title)`: `compile_secs` vs `n_vars`, grouped by solver, log-y, `OK` rows with `compile_secs > 0` only (zero cannot be drawn on a log axis; if every row is zero it prints "No rows with nonzero compile time; skipping compile time plot.", which is itself the "no per-problem recompile" result). Called from all four pages after the existing two plots.
- The warm-up block prints per-solver compile time into the page output.

## Stronger degenerate-result guard (item 7)

`assert_has_measurements(results, category)` now:
- errors if the fraction of rows with `status == "OK"` is below `MIN_COMPLETED_FRACTION = 0.8` (documented constant), printing both the status and retcode distributions;
- errors if ANY solver in the category has zero `OK` rows (every call errored/timed out at the harness level, i.e. a broken backend);
- does NOT error on zero *success* (retcode in `SUCCESS_RETCODES`) for a solver; instead emits a `@warn` listing those solvers, since e.g. `SimulatedAnnealing` / `ParticleSwarm` legitimately report 0% success on some categories;
- prints a one-line completion summary per category when it passes.

## CI budget

The second run roughly doubles the per-pair solve cost for pairs that finish within the cap. Worst-case arithmetic with `SOLVE_TIMEOUT_SECONDS = 90` and `MAX_PROBLEMS_PER_CATEGORY = 50` (solve time only, ignoring decode and warm-up):

| page | problems x solvers | before (1 x cap) | after, no skip rule (2 x cap) | after, with skip rule |
|---|---|---|---|---|
| unconstrained | 50 x 5 = 250 pairs | 250 x 90 s = 6.25 h | 250 x 180 s = 12.5 h | < 12.5 h; a pair that times out costs exactly 1 cap (90 s), a pair that finishes in `t < 90 s` costs `2t` |
| bounded (2 categories) | 2 x 50 x 1 = 100 pairs | 2.5 h | 5 h | same rule |
| unbounded (2 categories) | 2 x 50 x 1 = 100 pairs | 2.5 h | 5 h | same rule |
| quadratic | 50 x 1 = 50 pairs | 1.25 h | 2.5 h | same rule |

The `MaxTime` skip rule limits the pathological case (every pair timing out) to the *old* budget (one cap per pair), and a pair can only approach `2 x cap` if it legitimately finishes just under the cap twice. Realistic pages are dominated by pairs that take milliseconds to seconds, where the doubling is negligible.

## Test evidence

Julia 1.12.4, instantiated `benchmarks/OptimizationCUTEst` project, throwaway scripts under `/tmp` (nothing added to the repo).

**Skip predicate and `u0` non-mutation:**
```
rerun_worthwhile("Success", 1.0) = true
rerun_worthwhile("MaxTime", 1.0) = false
rerun_worthwhile("Success", SOLVE_TIMEOUT_SECONDS) = false
  ROSENBR/LBFGS: u0 unchanged = true, retcode = Success
  HS35/Ipopt: u0 unchanged = true, retcode = Success
```

**Unconstrained: 3 problems x 5 solvers via `run_benchmarks`** (LBFGS shows 0 warm-up compile only because the `u0` check above had already exercised it in this process):
```
Warming up solvers (JIT), results are not benchmarked:
  LBFGS              ROSENBR                  OK Success first 0.001s compile 0.000s clean 0.000s (total 0.329s)
  ConjugateGradient  ROSENBR                  OK Success first 1.241s compile 1.240s clean 0.000s (total 1.594s)
  NelderMead         ROSENBR                  OK Success first 1.224s compile 1.223s clean 0.000s (total 1.556s)
  SimulatedAnnealing ROSENBR                  OK Failure first 0.411s compile 0.408s clean 0.003s (total 0.758s)
  ParticleSwarm      ROSENBR                  OK Failure first 1.315s compile 1.308s clean 0.006s (total 1.668s)

Running unconstrained benchmarks
  LBFGS              ROSENBR                  OK Success 0.000s (first 0.001s, compile 0.000s, decode 0.305s)
  ...
  unconstrained: 15/15 rows completed (100.0%); status: OK=15

 Row │ problem   solver              n_vars  compile_secs  first_solve_secs  secs         retcode  first_retcode  status
   1 │ ROSENBR   LBFGS                    2           0.0       0.000507156  0.000312917  Success  Success        OK
   2 │ ROSENBR   ConjugateGradient        2           0.0       0.000298838  0.000160529  Success  Success        OK
   3 │ ROSENBR   NelderMead               2           0.0       0.000323618  0.000220798  Success  Success        OK
   4 │ ROSENBR   SimulatedAnnealing       2           0.0       0.00283851   0.00265643   Failure  Failure        OK
   5 │ ROSENBR   ParticleSwarm            2           0.0       0.0103279    0.0102695    Failure  Failure        OK
   6 │ BEALE     LBFGS                    2           0.0       0.000354608  0.000172289  Success  Success        OK
   7 │ BEALE     ConjugateGradient        2           0.0       0.000235119  0.000119419  Success  Success        OK
   8 │ BEALE     NelderMead               2           0.0       0.000354817  0.000209238  Success  Success        OK
   9 │ BEALE     SimulatedAnnealing       2           0.0       0.00500929   0.0052442    Failure  Failure        OK
  10 │ BEALE     ParticleSwarm            2           0.0       0.0121728    0.0119825    Failure  Failure        OK
  11 │ HIMMELBB  LBFGS                    2           0.0       0.000551426  0.000365897  Success  Success        OK
  12 │ HIMMELBB  ConjugateGradient        2           0.0       0.000547736  0.000254938  Success  Success        OK
  13 │ HIMMELBB  NelderMead               2           0.0       0.000204469  7.8749e-5    Success  Success        OK
  14 │ HIMMELBB  SimulatedAnnealing       2           0.0       0.00537295   0.00516933   Failure  Failure        OK
  15 │ HIMMELBB  ParticleSwarm            2           0.0       0.0116847    0.0115335    Failure  Failure        OK

Summary:
 Row │ category       solver              completed_runs  successful_runs  total_runs  median_secs  median_compile_secs  total_compile_secs  completion_rate  success_rate
   1 │ unconstrained  LBFGS                            3                3           3  0.000312917                  0.0                 0.0            100.0         100.0
   2 │ unconstrained  ConjugateGradient                3                3           3  0.000160529                  0.0                 0.0            100.0         100.0
   3 │ unconstrained  NelderMead                       3                3           3  0.000209238                  0.0                 0.0            100.0         100.0
   4 │ unconstrained  SimulatedAnnealing               3                0           3  0.00516933                   0.0                 0.0            100.0           0.0
   5 │ unconstrained  ParticleSwarm                    3                0           3  0.0115335                    0.0                 0.0            100.0           0.0
No rows with nonzero compile time; skipping compile time plot.
```
`plot_solve_times` / `plot_success_rates` rendered and were saved with `savefig`; the `@warn` for 0% success (SimulatedAnnealing, ParticleSwarm) fired as designed.

**Shape change for Optim solvers, unconstrained -> bounded (HS3, HS4 have bounds and no constraints), same process:**
```
 Row │ problem  solver             n_vars  compile_secs  first_solve_secs  secs         retcode  first_retcode  status
   1 │ HS3      LBFGS                   2     7.26293         7.26501      0.000363017  Success  Success        OK
   2 │ HS4      LBFGS                   2     0.0103356       0.0111672    0.00106528   Success  Success        OK
   3 │ HS3      ConjugateGradient       2     2.57041         2.57189      0.000510097  Success  Success        OK
   4 │ HS4      ConjugateGradient       2     0.0             0.000620995  0.000470586  Success  Success        OK
   5 │ HS3      NelderMead              2     1.91358         1.91514      0.000516886  Success  Success        OK
   6 │ HS4      NelderMead              2     0.0             0.00110071   0.000933213  Success  Success        OK
```

**Shape changes for Ipopt, fresh process** (warm-up on unconstrained `ROSENBR`, then inequality+bounds `HS35`/`HS21`, equality/no-bounds `HS6`/`HS7`, bounds-only `HS3`):
```
Warming up solvers (JIT), results are not benchmarked:
  Ipopt              ROSENBR                  OK Success first 14.106s compile 14.062s clean 0.035s (total 18.549s)

 Row │ problem  solver  n_vars  compile_secs  first_solve_secs  secs        retcode
   1 │ HS35     Ipopt        3       2.22007         2.23553    0.0101022   Success
   2 │ HS21     Ipopt        2       0.0             0.0145936  0.0130694   Success
   3 │ HS6      Ipopt        2       1.49026         1.50097    0.00769888  Success
   4 │ HS7      Ipopt        2       0.0             0.0109888  0.00973278  Success
   5 │ HS3      Ipopt        2       3.26903         3.27683    0.00568499  Success
```

**Constrained: 2 problems x Ipopt via `run_benchmarks`** (warm-up `HS35` already compiled in this process):
```
  Ipopt              HS35                     OK Success 0.015s (first 0.016s, compile 0.000s, decode 0.299s)
  Ipopt              HS21                     OK Success 0.013s (first 0.014s, compile 0.000s, decode 0.292s)
  constrained: 2/2 rows completed (100.0%); status: OK=2
 Row │ category     solver  completed_runs  successful_runs  total_runs  median_secs  median_compile_secs  total_compile_secs  completion_rate  success_rate
   1 │ constrained  Ipopt                2                2           2    0.0137795                  0.0                 0.0            100.0         100.0
```

`plot_compile_times` was also exercised on a frame with nonzero rows (the Ipopt/LBFGS shape-change numbers above) and renders a log-y scatter grouped by solver.

**Guard on synthetic DataFrames** (unchanged from the first commit):
```
[ok]   50% OK raised: CUTEst benchmark for synthetic is degenerate: only 5/10 rows (50.0%) completed, below MIN_COMPLETED_FRACTION = 80.0%. Status distribution: OK=5, FAILED=5. Return code distribution: Success=5, FAILED=5
[ok]   one solver zero OK (12 rows, 83% completed) raised: CUTEst benchmark for synthetic is degenerate: solver(s) with zero completed rows: B. Status distribution: OK=10, FAILED=2. Return code distribution: Success=10, FAILED=2
[expect warn + pass] zero success for one solver:  -> @warn listing SimulatedAnnealing, then "synthetic: 10/10 rows completed (100.0%)"
[expect pass] healthy frame:                       -> "synthetic: 19/20 rows completed (95.0%)"
[ok]   empty frame raised: CUTEst benchmark for synthetic produced no rows at all.
```

### Observation on per-problem recompilation

- After the per-solver warm-up, `compile_secs` is **exactly 0.0** for every (problem, solver) pair of the same shape: all 15 unconstrained rows across 5 Optim solvers, and both Ipopt constrained rows. There is no per-problem recompilation; the second-run `secs` and the first-run `first_solve_secs` agree to within noise once compile is zero.
- A change of problem **shape** does trigger compilation, once per shape per solver, and the next problem of that shape is back to ~0: for Optim, unconstrained -> bounded costs 7.3 s (LBFGS, via `Fminbox`), 2.6 s (ConjugateGradient), 1.9 s (NelderMead); for Ipopt/MOI, unconstrained -> inequality+bounds 2.2 s, -> equality/no bounds 1.5 s, -> bounds only 3.3 s. The small 0.010 s on the second bounded LBFGS problem is residual method specialization, not a full recompile.
- Consequence for the pages: within a homogeneous category the compile plot will usually be empty (and say so), while categories whose warm-up shape differs from the benchmarked shape (e.g. `HS35` inequality+bounds warm-up vs equality-constrained pages) will show one point per solver per new shape, which is exactly the signal the maintainer asked to see rather than assume.

## Formatting

New/changed lines follow Runic layout (verified by running Runic on a copy and confirming the only remaining diffs are pre-existing untouched hunks). Runic was deliberately NOT run in-place on the whole file because the file on master is not Runic-clean and doing so would reflow ~8 unrelated hunks and create needless conflicts with sibling PRs.

## Expected merge conflicts

Sibling PRs from #1857 (`cutest-unconstrained-solvers`, `cutest-constrained-solvers`, `cutest-solution-quality`, `cutest-problem-selection`, `cutest-hard-timeout`, `cutest-page-docs`) also edit `cutest_benchmark_utils.jl`. Conflicts are most likely in `run_single_solve` (the solve call is now `solve_once` and runs twice; row NamedTuples have new columns), `run_benchmarks` (empty-frame schema, per-row print), `summarize_results` (new compile columns) and `assert_has_measurements`. Resolution should be mechanical: keep the two-run structure and the timing columns, and fold any new columns into the row NamedTuples and the empty-frame schema. Pages differ from master by one added line each, at the end of the plotting block.