### PR TITLE
CUTEst: report solution quality (objective, optimality, feasibility) alongside return codes

### DIFF
--- a/benchmarks/OptimizationCUTEst/CUTEst_bounded.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_bounded.jmd
@@ -128,6 +128,10 @@ bounded_summary = summarize_results(bounded_results)
 plot_solve_times(bounded_results, "CUTEst bounded constrained Optimization.jl solve time")
 plot_success_rates(bounded_summary, "CUTEst bounded constrained Optimization.jl success rate")
 plot_compile_times(bounded_results, "CUTEst bounded constrained Optimization.jl compile time")
+plot_performance_profile(bounded_results,
+    "CUTEst bounded constrained Optimization.jl performance profile")
+plot_work_precision(bounded_results,
+    "CUTEst bounded constrained Optimization.jl work-precision")
 ```
 
 ```julia, echo = false

--- a/benchmarks/OptimizationCUTEst/CUTEst_quadratic.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_quadratic.jmd
@@ -113,6 +113,9 @@ quadratic_summary = summarize_results(quadratic_results)
 plot_solve_times(quadratic_results, "CUTEst quadratic Optimization.jl solve time")
 plot_success_rates(quadratic_summary, "CUTEst quadratic Optimization.jl success rate")
 plot_compile_times(quadratic_results, "CUTEst quadratic Optimization.jl compile time")
+plot_performance_profile(quadratic_results,
+    "CUTEst quadratic Optimization.jl performance profile")
+plot_work_precision(quadratic_results, "CUTEst quadratic Optimization.jl work-precision")
 ```
 
 ```julia, echo = false

--- a/benchmarks/OptimizationCUTEst/CUTEst_unbounded.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_unbounded.jmd
@@ -129,6 +129,10 @@ plot_solve_times(unbounded_results, "CUTEst unbounded constrained Optimization.j
 plot_success_rates(unbounded_summary,
     "CUTEst unbounded constrained Optimization.jl success rate")
 plot_compile_times(unbounded_results, "CUTEst unbounded constrained Optimization.jl compile time")
+plot_performance_profile(unbounded_results,
+    "CUTEst unbounded constrained Optimization.jl performance profile")
+plot_work_precision(unbounded_results,
+    "CUTEst unbounded constrained Optimization.jl work-precision")
 ```
 
 ```julia, echo = false

--- a/benchmarks/OptimizationCUTEst/CUTEst_unconstrained.jmd
+++ b/benchmarks/OptimizationCUTEst/CUTEst_unconstrained.jmd
@@ -117,6 +117,10 @@ unc_summary = summarize_results(unc_results)
 plot_solve_times(unc_results, "CUTEst unconstrained Optimization.jl solve time")
 plot_success_rates(unc_summary, "CUTEst unconstrained Optimization.jl success rate")
 plot_compile_times(unc_results, "CUTEst unconstrained Optimization.jl compile time")
+plot_performance_profile(unc_results,
+    "CUTEst unconstrained Optimization.jl performance profile")
+plot_work_precision(unc_results, "CUTEst unconstrained Optimization.jl work-precision";
+    metric = :grad_norm)
 ```
 
 ```julia, echo = false

--- a/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
+++ b/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
@@ -6,6 +6,7 @@ using StatsBase: countmap
 using Statistics
 
 using Optimization
+using NLPModels
 using OptimizationNLPModels
 using OptimizationOptimJL
 using OptimizationOptimJL: LBFGS, ConjugateGradient, NelderMead, SimulatedAnnealing,
@@ -30,6 +31,15 @@ const WARMUP_UNCONSTRAINED_PROBLEM = "ROSENBR"
 const WARMUP_CONSTRAINED_PROBLEM = "HS35"
 
 const SUCCESS_RETCODES = Set(["Success", "Terminated", "FirstOrderOptimal"])
+
+# Solution-quality tolerances used by the "verified" success criterion. A run is a
+# verified success when its return code is in SUCCESS_RETCODES, the returned point
+# violates no constraint or bound by more than FEAS_TOL, and either the projected
+# gradient norm is below OPT_TOL or the objective is within GAP_TOL (relative) of the
+# best feasible objective any solver found for that problem.
+const FEAS_TOL = 1.0e-6
+const OPT_TOL = 1.0e-5
+const GAP_TOL = 1.0e-6
 
 const KNOWN_BAD_PROBLEMS = Set(
     lowercase.(
@@ -166,6 +176,54 @@ solve_once(prob, solver_name) = solve(
 rerun_worthwhile(first_retcode, first_solve_secs) =
     first_retcode != "MaxTime" && first_solve_secs < SOLVE_TIMEOUT_SECONDS
 
+const NO_QUALITY = (; objective = NaN, grad_norm = NaN, cons_viol = NaN)
+
+# Maximum violation of `lo <= v <= hi`, elementwise; 0.0 when everything is within bounds.
+function bound_violation(v, lo, hi)
+    viol = 0.0
+    for i in eachindex(v)
+        viol = max(viol, lo[i] - v[i], v[i] - hi[i])
+    end
+    return viol
+end
+
+# Evaluate the objective, the projected gradient norm and the maximum constraint/bound
+# violation of the NLPModels object at `x`. For unconstrained problems the projected
+# gradient reduces to the infinity norm of the gradient; for problems with general
+# constraints it is only indicative and `cons_viol` is the primary check. Every metric is
+# guarded independently so an evaluation failure yields `NaN` for that metric only.
+function solution_quality(nlp, x)
+    x = collect(Float64, x)
+    meta = nlp.meta
+
+    objective = try
+        Float64(NLPModels.obj(nlp, x))
+    catch
+        NaN
+    end
+
+    grad_norm = try
+        g = NLPModels.grad(nlp, x)
+        proj = clamp.(x .- g, meta.lvar, meta.uvar)
+        maximum(abs, x .- proj; init = 0.0)
+    catch
+        NaN
+    end
+
+    cons_viol = try
+        viol = bound_violation(x, meta.lvar, meta.uvar)
+        if meta.ncon > 0
+            c = NLPModels.cons(nlp, x)
+            viol = max(viol, bound_violation(c, meta.lcon, meta.ucon))
+        end
+        viol
+    catch
+        NaN
+    end
+
+    return (; objective, grad_norm, cons_viol)
+end
+
 # Each (problem, solver) pair is solved twice. Timing columns:
 #   first_solve_secs     wall-clock time of the first `solve(...)`, includes any compilation
 #   compile_secs         Julia compilation time measured during the first solve
@@ -178,6 +236,8 @@ rerun_worthwhile(first_retcode, first_solve_secs) =
 #   decode_secs          wall-clock time of the CUTEst SIF decode / `CUTEstModel(name)`
 #   solver_reported_secs `sol.stats.time` when the backend provides it, otherwise NaN
 # `retcode` comes from the second run, `first_retcode` from the first.
+# Quality columns (`objective`, `grad_norm`, `cons_viol`) are evaluated at the final
+# `sol.u` after the clean (or only) solve; NaN on load/solve failure.
 function run_single_solve(problem_name, solver_name)
     nlp = nothing
     decode_started = time_ns()
@@ -200,6 +260,7 @@ function run_single_solve(problem_name, solver_name)
             retcode = "LOAD_FAILED",
             first_retcode = "LOAD_FAILED",
             status = "LOAD_FAILED",
+            NO_QUALITY...,
         )
     end
     decode_secs = elapsed_seconds(decode_started)
@@ -232,6 +293,12 @@ function run_single_solve(problem_name, solver_name)
             print(" [rerun skipped: first run ended with $first_retcode]")
         end
 
+        quality = try
+            solution_quality(nlp, sol.u)
+        catch
+            NO_QUALITY
+        end
+
         return (;
             problem = problem_name,
             solver = solver_name,
@@ -244,6 +311,7 @@ function run_single_solve(problem_name, solver_name)
             retcode = retcode_name(sol.retcode),
             first_retcode = first_retcode,
             status = "OK",
+            quality...,
         )
     catch err
         bt = catch_backtrace()
@@ -261,6 +329,7 @@ function run_single_solve(problem_name, solver_name)
             retcode = "FAILED",
             first_retcode = first_retcode,
             status = "FAILED",
+            NO_QUALITY...,
         )
     finally
         if nlp !== nothing
@@ -333,9 +402,11 @@ function run_benchmarks(category, problems, solvers; warmup = true)
             n_vars = Int[], secs = Float64[], first_solve_secs = Float64[],
             compile_secs = Float64[], decode_secs = Float64[],
             solver_reported_secs = Float64[], retcode = String[], first_retcode = String[],
-            status = String[]
+            status = String[],
+            objective = Float64[], grad_norm = Float64[], cons_viol = Float64[]
         ) : DataFrame(rows)
 
+    add_quality_columns!(results)
     assert_has_measurements(results, category)
     return results
 end
@@ -343,6 +414,48 @@ end
 function count_distribution(values)
     counts = sort(collect(countmap(values)); by = x -> x[2], rev = true)
     return join(["$code=$n" for (code, n) in counts], ", ")
+end
+
+# Smallest objective among runs whose point is feasible to FEAS_TOL; NaN if none is.
+function best_feasible_objective(objective, cons_viol)
+    best = Inf
+    for (f, v) in zip(objective, cons_viol)
+        if isfinite(f) && isfinite(v) && v <= FEAS_TOL && f < best
+            best = f
+        end
+    end
+    return isfinite(best) ? best : NaN
+end
+
+function is_verified_success(retcode, cons_viol, grad_norm, obj_gap)
+    retcode in SUCCESS_RETCODES || return false
+    isfinite(cons_viol) && cons_viol <= FEAS_TOL || return false
+    return (isfinite(grad_norm) && grad_norm <= OPT_TOL) ||
+        (isfinite(obj_gap) && obj_gap <= GAP_TOL)
+end
+
+# Add the cross-solver quality columns: `best_objective` (per category/problem),
+# the relative gap `obj_gap = (objective - best_objective) / max(1, |best_objective|)`
+# and the boolean `verified_success` criterion. Idempotent.
+function add_quality_columns!(results)
+    if nrow(results) == 0
+        results.best_objective = Float64[]
+        results.obj_gap = Float64[]
+        results.verified_success = Bool[]
+        return results
+    end
+
+    transform!(
+        groupby(results, [:category, :problem]),
+        [:objective, :cons_viol] => best_feasible_objective => :best_objective,
+    )
+    results.obj_gap = (results.objective .- results.best_objective) ./
+        max.(1.0, abs.(results.best_objective))
+    results.verified_success = is_verified_success.(
+        results.retcode, results.cons_viol, results.grad_norm, results.obj_gap
+    )
+
+    return results
 end
 
 # Fails the page when a category is degenerate:
@@ -397,6 +510,8 @@ function assert_has_measurements(results, category)
 end
 
 function summarize_results(results)
+    hasproperty(results, :verified_success) || add_quality_columns!(results)
+
     println()
     println("Return code distribution:")
     for (code, n) in sort(collect(countmap(results.retcode)); by = x -> x[2], rev = true)
@@ -407,6 +522,7 @@ function summarize_results(results)
         groupby(results, [:category, :solver]),
         :status => (x -> count(==("OK"), x)) => :completed_runs,
         :retcode => (x -> count(in(SUCCESS_RETCODES), x)) => :successful_runs,
+        :verified_success => count => :verified_runs,
         :retcode => length => :total_runs,
         :secs => median => :median_secs,
         :compile_secs => median => :median_compile_secs,
@@ -415,6 +531,9 @@ function summarize_results(results)
 
     summary.completion_rate = round.(summary.completed_runs ./ summary.total_runs .* 100; digits = 1)
     summary.success_rate = round.(summary.successful_runs ./ summary.total_runs .* 100; digits = 1)
+    summary.verified_success_rate = round.(
+        summary.verified_runs ./ summary.total_runs .* 100; digits = 1
+    )
 
     println()
     println("Summary:")
@@ -486,4 +605,102 @@ function plot_success_rates(summary, title)
     )
 
     return display(success_rate_plot)
+end
+
+# Dolan–Moré performance ratios for one category: `ratios[solver][i]` is the solve time of
+# `solver` on the i-th problem divided by the fastest verified solve of that problem.
+# Runs that are not verified successes (and problems nobody solved) get ratio Inf.
+function performance_ratios(results)
+    problems = unique(results.problem)
+    solvers = unique(results.solver)
+    ratios = Dict(s => fill(Inf, length(problems)) for s in solvers)
+
+    for (i, problem) in enumerate(problems)
+        rows = filter(r -> r.problem == problem && r.verified_success, results)
+        nrow(rows) == 0 && continue
+        best = max(minimum(rows.secs), 1.0e-9)
+        for r in eachrow(rows)
+            ratios[r.solver][i] = max(r.secs, 1.0e-9) / best
+        end
+    end
+
+    return problems, solvers, ratios
+end
+
+function performance_profile_subplot(results, title)
+    problems, solvers, ratios = performance_ratios(results)
+    nprob = length(problems)
+
+    finite_log_ratios = [log2(r) for v in values(ratios) for r in v if isfinite(r)]
+    tau_max = isempty(finite_log_ratios) ? 1.0 : max(1.0, maximum(finite_log_ratios) * 1.05)
+    taus = sort!(unique!(vcat(0.0, finite_log_ratios, tau_max)))
+
+    subplot = plot(
+        xlabel = "log2(time ratio to best solver)",
+        ylabel = "Fraction of problems solved",
+        title = title,
+        ylims = (0, 1.02),
+        legend = :bottomright,
+    )
+    for solver in solvers
+        log_ratios = log2.(ratios[solver])
+        rho = [count(<=(tau), log_ratios) / nprob for tau in taus]
+        plot!(subplot, taus, rho; seriestype = :steppost, label = solver, linewidth = 2)
+    end
+
+    return subplot
+end
+
+# Performance profile of solve time (Dolan & Moré, 2002), one panel per category.
+function plot_performance_profile(results, title)
+    hasproperty(results, :verified_success) || add_quality_columns!(results)
+    nrow(results) == 0 && return nothing
+
+    categories = unique(results.category)
+    subplots = [
+        performance_profile_subplot(
+                filter(:category => ==(category), results),
+                length(categories) == 1 ? title : "$title: $category"
+            )
+            for category in categories
+    ]
+
+    profile_plot = plot(
+        subplots...; layout = (length(subplots), 1),
+        size = (900, 500 * length(subplots))
+    )
+
+    return display(profile_plot)
+end
+
+# Work-precision scatter: solve time against the attained precision, where precision is
+# `metric` (`:obj_gap` by default, `:grad_norm` is the natural choice for unconstrained
+# problems). Only completed runs with a finite metric are shown; for `:obj_gap` the point
+# must also be feasible to FEAS_TOL so that infeasible points cannot show a spurious gap.
+# Values at or below `floor` are drawn at `floor` so they fit on the log axis.
+function plot_work_precision(results, title; metric = :obj_gap, floor = 1.0e-16)
+    hasproperty(results, :verified_success) || add_quality_columns!(results)
+
+    completed = filter(results) do r
+        r.status == "OK" && isfinite(r[metric]) && r.secs > 0 &&
+            (metric != :obj_gap || (isfinite(r.cons_viol) && r.cons_viol <= FEAS_TOL))
+    end
+    nrow(completed) == 0 && return nothing
+
+    precision = max.(completed[!, metric], floor)
+
+    work_precision_plot = scatter(
+        precision,
+        completed.secs,
+        group = completed.solver,
+        xlabel = "$(metric) (floored at $(floor))",
+        ylabel = "Seconds",
+        title = title,
+        xscale = :log10,
+        yscale = :log10,
+        legend = :topright,
+        size = (900, 600),
+    )
+
+    return display(work_precision_plot)
 end

--- a/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
+++ b/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
@@ -9,7 +9,7 @@ using Optimization
 using OptimizationNLPModels
 using OptimizationOptimJL
 using OptimizationOptimJL: LBFGS, ConjugateGradient, NelderMead, SimulatedAnnealing,
-                           ParticleSwarm
+    ParticleSwarm
 using OptimizationMOI
 using OptimizationMOI: MOI
 using Ipopt
@@ -82,7 +82,8 @@ function problem_metadata(name)
         return (; ok = true, nvar = nlp.meta.nvar, ncon = nlp.meta.ncon)
     catch err
         @warn "Unable to load CUTEst problem metadata" problem = name exception = (
-            err, catch_backtrace())
+            err, catch_backtrace(),
+        )
         return (; ok = false, nvar = -1, ncon = -1)
     finally
         if nlp !== nothing
@@ -90,18 +91,19 @@ function problem_metadata(name)
                 finalize(nlp)
             catch err
                 @warn "Unable to finalize CUTEst problem metadata" problem = name exception = (
-                    err, catch_backtrace())
+                    err, catch_backtrace(),
+                )
             end
         end
     end
 end
 
 function select_safe_problems(
-    candidates;
-    max_problems = MAX_PROBLEMS_PER_CATEGORY,
-    max_var = MAX_NVAR,
-    max_con = MAX_NCON,
-)
+        candidates;
+        max_problems = MAX_PROBLEMS_PER_CATEGORY,
+        max_var = MAX_NVAR,
+        max_con = MAX_NCON,
+    )
     selected = String[]
 
     for name in candidates
@@ -142,7 +144,7 @@ function retcode_name(retcode)
 end
 
 function print_exception(prefix, err, bt)
-    println(prefix, ": ", sprint(showerror, err, bt))
+    return println(prefix, ": ", sprint(showerror, err, bt))
 end
 
 elapsed_seconds(started_ns) = (time_ns() - started_ns) / 1.0e9
@@ -266,7 +268,8 @@ function run_single_solve(problem_name, solver_name)
                 finalize(nlp)
             catch err
                 @warn "Unable to finalize CUTEst problem" problem = problem_name exception = (
-                    err, catch_backtrace())
+                    err, catch_backtrace(),
+                )
             end
         end
     end


### PR DESCRIPTION
Part of #1857 (item 3, "Report solution quality, not just return code and wall time"). Follow-up to #1594, which introduced the shared harness `benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl`.

## What changes

**New per-row columns** (computed in `run_single_solve` from the `CUTEstModel` at `sol.u`, before `finalize(nlp)`; each guarded by `try/catch` so a failed evaluation records `NaN` instead of killing the row):

- `objective` – `NLPModels.obj(nlp, x)`
- `grad_norm` – projected gradient norm `‖x - P_[lvar,uvar](x - ∇f(x))‖_∞`. Reduces to `‖∇f‖_∞` for unconstrained problems; for problems with general constraints it is only indicative and `cons_viol` is the primary check.
- `cons_viol` – max violation of `lcon <= cons(nlp, x) <= ucon` and of the variable bounds (`0.0` when satisfied)

**New post-hoc columns** via `add_quality_columns!` (called at the end of `run_benchmarks`, and idempotently from `summarize_results` / the plot functions if missing):

- `best_objective` – per `(category, problem)`, minimum `objective` over runs with `cons_viol <= FEAS_TOL`
- `obj_gap = (objective - best_objective) / max(1, |best_objective|)`
- `verified_success` – `retcode in SUCCESS_RETCODES && cons_viol <= FEAS_TOL && (grad_norm <= OPT_TOL || obj_gap <= GAP_TOL)`

with documented constants `FEAS_TOL = 1e-6`, `OPT_TOL = 1e-5`, `GAP_TOL = 1e-6`.

**Summary**: `summarize_results` now reports `verified_runs` / `verified_success_rate` next to the unchanged `successful_runs` / `success_rate`, so the difference between "solver said success" and "solution checks out" is visible.

**New plots** (added to all four pages; the two existing plots are kept unchanged):

- `plot_performance_profile(results, title)` – Dolan–Moré performance profile of solve time (ratio to the fastest verified solve per problem, cumulative fraction vs. `log2` ratio, non-verified runs get ratio `Inf`), one panel per category. Implemented in plain Plots; `BenchmarkProfiles.jl` was not added as a dependency (no Manifest change).
- `plot_work_precision(results, title; metric = :obj_gap)` – log-log scatter of solve time vs. attained precision, grouped by solver. The unconstrained page uses `metric = :grad_norm`; the constrained pages use `obj_gap` (feasible points only; zeros floored at `1e-16` for the log axis).

The diff is additive: no existing function or column was renamed, and no untouched lines were reflowed. `using NLPModels` is added (already in `Project.toml`).

## Test evidence (reduced run, 3 unconstrained problems x 5 solvers, 3 constrained problems x Ipopt)

```
15×13 DataFrame
 Row │ category       problem   solver              n_vars  secs         retcode  status  objective    grad_norm    cons_viol  best_objective  obj_gap      verified_success
─────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ unconstrained  ROSENBR   LBFGS                    2  0.000443935  Success  OK      1.65159e-20  3.08574e-9         0.0     1.65159e-20  0.0                      true
   2 │ unconstrained  ROSENBR   ConjugateGradient        2  1.18142      Success  OK      9.37408e-19  2.04377e-9         0.0     1.65159e-20  9.20892e-19              true
   3 │ unconstrained  ROSENBR   NelderMead               2  1.58464      Success  OK      4.65754e-9   0.00271261         0.0     1.65159e-20  4.65754e-9               true
   4 │ unconstrained  ROSENBR   SimulatedAnnealing       2  0.364837     Failure  OK      0.00744011   0.325949           0.0     1.65159e-20  0.00744011              false
   5 │ unconstrained  ROSENBR   ParticleSwarm            2  1.2708       Failure  OK      5.00042      8.62196            0.0     1.65159e-20  5.00042                 false
   6 │ unconstrained  BEALE     LBFGS                    2  0.00019908   Success  OK      8.76497e-19  4.71734e-9         0.0     3.76022e-23  8.76459e-19              true
   7 │ unconstrained  BEALE     ConjugateGradient        2  0.000188828  Success  OK      3.76022e-23  3.79956e-11        0.0     3.76022e-23  0.0                      true
   8 │ unconstrained  BEALE     NelderMead               2  0.000195026  Success  OK      1.66962e-9   0.000217109        0.0     3.76022e-23  1.66962e-9               true
   9 │ unconstrained  BEALE     SimulatedAnnealing       2  0.00301695   Failure  OK      0.00412788   0.0929797          0.0     3.76022e-23  0.00412788              false
  10 │ unconstrained  BEALE     ParticleSwarm            2  0.00658894   Failure  OK      5.88492e-14  7.36082e-7         0.0     3.76022e-23  5.88492e-14             false
  11 │ unconstrained  HIMMELBB  LBFGS                    2  0.000298977  Success  OK      3.96111e-14  7.76562e-9         0.0     6.18227e-50  3.96111e-14              true
  12 │ unconstrained  HIMMELBB  ConjugateGradient        2  0.000225067  Success  OK      8.38885e-18  6.73778e-10        0.0     6.18227e-50  8.38885e-18              true
  13 │ unconstrained  HIMMELBB  NelderMead               2  0.000138044  Success  OK      1.9796e-9    6.61111e-6         0.0     6.18227e-50  1.9796e-9                true
  14 │ unconstrained  HIMMELBB  SimulatedAnnealing       2  0.0047791    Failure  OK      9.25683e-9   3.12217e-5         0.0     6.18227e-50  9.25683e-9               false
  15 │ unconstrained  HIMMELBB  ParticleSwarm            2  0.00902319   Failure  OK      6.18227e-50  0.0                0.0     6.18227e-50  0.0                     false

Summary:
5×10 DataFrame
 Row │ category       solver              completed_runs  successful_runs  verified_runs  total_runs  median_secs  completion_rate  success_rate  verified_success_rate
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ unconstrained  LBFGS                            3                3              3           3  0.000298977            100.0         100.0                  100.0
   2 │ unconstrained  ConjugateGradient                3                3              3           3  0.000225067            100.0         100.0                  100.0
   3 │ unconstrained  NelderMead                       3                3              3           3  0.000195026            100.0         100.0                  100.0
   4 │ unconstrained  SimulatedAnnealing               3                0              0           3  0.0047791              100.0           0.0                    0.0
   5 │ unconstrained  ParticleSwarm                    3                0              0           3  0.00902319             100.0           0.0                    0.0

3×13 DataFrame
 Row │ category                        problem  solver  n_vars  secs        retcode  status  objective      grad_norm    cons_viol    best_objective  obj_gap  verified_success
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ bounded inequality constrained  HS35     Ipopt        3  0.00880408  Success  OK        0.111111     0.444444     9.95505e-9      0.111111         0.0              true
   2 │ bounded inequality constrained  HS118    Ipopt       15  0.0118151   Success  OK      664.82         2.301        1.3994e-7     664.82             0.0              true
   3 │ bounded equality constrained    HS6      Ipopt        2  0.149837    Success  OK        4.60847e-21  1.35771e-10  7.12479e-10     4.60847e-21      0.0              true

Summary:
2×10 DataFrame
 Row │ category                        solver  completed_runs  successful_runs  verified_runs  total_runs  median_secs  completion_rate  success_rate  verified_success_rate
─────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ bounded inequality constrained  Ipopt                2                2              2           2    0.0103096            100.0         100.0                  100.0
   2 │ bounded equality constrained    Ipopt                1                1              1           1    0.149837             100.0         100.0                  100.0
```

A second run hit a transient SIF-decoder I/O error loading HS118, which exercised the failure path: the row came back as `retcode = LOAD_FAILED`, `n_vars = -1`, all quality columns `NaN`, `verified_success = false`, and the summary/plots still rendered.

All six plot functions (`plot_solve_times`, `plot_success_rates`, `plot_performance_profile`, `plot_work_precision` with both `:grad_norm` and `:obj_gap`) were rendered to PNG with `savefig` for both the unconstrained and constrained result sets, and the empty-`DataFrame` path of `add_quality_columns!` was checked.

Already visible in the reduced run: `NelderMead` on ROSENBR reports `Success` with `grad_norm = 2.7e-3` (it passes only via `obj_gap`), while `ParticleSwarm` on HIMMELBB reaches the exact minimizer (`grad_norm = 0`) but reports `Failure` — the kind of discrepancy this PR makes visible.

## Notes for reviewers

- With a single constrained solver (Ipopt), `obj_gap` is `0` for every feasible row, so the constrained work-precision plots are flat until more constrained solvers land (`cutest-constrained-solvers`). The performance profile is likewise trivial with one solver.
- Expected merge conflicts: sibling PRs from #1857 also touch `cutest_benchmark_utils.jl` (`cutest-unconstrained-solvers`, `cutest-constrained-solvers`, `cutest-problem-selection`, `cutest-timing-and-guards`, `cutest-hard-timeout`, `cutest-page-docs`). This PR adds new columns/functions and only extends the `run_single_solve` return tuples, the empty-`DataFrame` constructor in `run_benchmarks`, and the `combine` call in `summarize_results`, so conflicts should be small and mechanical.

Made with [Cursor](https://cursor.com)