### PR TITLE
Format OptimizationCUTEst harness with Runic

### DIFF
--- a/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
+++ b/benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl
@@ -9,7 +9,7 @@ using Optimization
 using OptimizationNLPModels
 using OptimizationOptimJL
 using OptimizationOptimJL: LBFGS, ConjugateGradient, NelderMead, SimulatedAnnealing,
-                           ParticleSwarm
+    ParticleSwarm
 using OptimizationMOI
 using OptimizationMOI: MOI
 using Ipopt
@@ -82,7 +82,8 @@ function problem_metadata(name)
         return (; ok = true, nvar = nlp.meta.nvar, ncon = nlp.meta.ncon)
     catch err
         @warn "Unable to load CUTEst problem metadata" problem = name exception = (
-            err, catch_backtrace())
+            err, catch_backtrace(),
+        )
         return (; ok = false, nvar = -1, ncon = -1)
     finally
         if nlp !== nothing
@@ -90,18 +91,19 @@ function problem_metadata(name)
                 finalize(nlp)
             catch err
                 @warn "Unable to finalize CUTEst problem metadata" problem = name exception = (
-                    err, catch_backtrace())
+                    err, catch_backtrace(),
+                )
             end
         end
     end
 end
 
 function select_safe_problems(
-    candidates;
-    max_problems = MAX_PROBLEMS_PER_CATEGORY,
-    max_var = MAX_NVAR,
-    max_con = MAX_NCON,
-)
+        candidates;
+        max_problems = MAX_PROBLEMS_PER_CATEGORY,
+        max_var = MAX_NVAR,
+        max_con = MAX_NCON,
+    )
     selected = String[]
 
     for name in candidates
@@ -142,7 +144,7 @@ function retcode_name(retcode)
 end
 
 function print_exception(prefix, err, bt)
-    println(prefix, ": ", sprint(showerror, err, bt))
+    return println(prefix, ": ", sprint(showerror, err, bt))
 end
 
 elapsed_seconds(started_ns) = (time_ns() - started_ns) / 1.0e9
@@ -266,7 +268,8 @@ function run_single_solve(problem_name, solver_name)
                 finalize(nlp)
             catch err
                 @warn "Unable to finalize CUTEst problem" problem = problem_name exception = (
-                    err, catch_backtrace())
+                    err, catch_backtrace(),
+                )
             end
         end
     end


### PR DESCRIPTION
## Summary
- Apply Runic to `benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl` so `runic --check` passes.
- Formatting only; no behavioral change.
- Follow-up PRs from #1857 (#1860–#1864, #1862) will rebase onto this so they stop inheriting a red Runic check from master (and stop each reflowing the same untouched lines differently).

## Context
#1859 merged with master's harness still failing Runic. Every subsequent PR that touched this file showed a failing format check for pre-existing style.

## Test plan
- [x] `julia -e 'using Runic; exit(Runic.main(["--check", "benchmarks/OptimizationCUTEst/cutest_benchmark_utils.jl"]))'` exits 0
- [ ] CI Runic check green

Made with [Cursor](https://cursor.com)