### PR TITLE
Skip OpenModelica timings when omc is missing

### DIFF
--- a/benchmarks/ModelingToolkit/RCCircuit.jmd
+++ b/benchmarks/ModelingToolkit/RCCircuit.jmd
@@ -95,14 +95,22 @@ end
 
 ## OpenModelica Timings
 
+`omc` is not installed on the hosted benchmark runners. Skip OpenModelica timings when the compiler is missing rather than aborting the page (Dymola times below are already hardcoded).
+
 ```julia
-# OMJ
-const omod = OMJulia.OMCSession();
-OMJulia.sendExpression(omod, "getVersion()")
-OMJulia.sendExpression(omod, "installPackage(Modelica)")
+omod = try
+    sess = OMJulia.OMCSession()
+    OMJulia.sendExpression(sess, "getVersion()")
+    OMJulia.sendExpression(sess, "installPackage(Modelica)")
+    sess
+catch e
+    @warn "OpenModelica (omc) is not available; skipping OpenModelica timings" exception = (e, catch_backtrace())
+    nothing
+end
 const modelicafile = joinpath(@__DIR__, "RC_Circuit.mo")
 
 function time_open_modelica(n::Int)
+    omod === nothing && return NaN
     totaltime = @elapsed res = begin
         @sync ModelicaSystem(omod, modelicafile, "RC_Circuit.Test.RC_Circuit_MTK_test_$n")
         sendExpression(omod, "simulate(RC_Circuit.Test.RC_Circuit_MTK_test_$n)")
@@ -112,16 +120,18 @@ function time_open_modelica(n::Int)
 end
 
 function run_and_time_om!(total_times, max_sizes, i, n)
+    omod === nothing && return
     if n <= max_sizes[2]
         total_times[i, 2] = time_open_modelica(n)
     end
 end
 
-for (i, n) in enumerate(N)
-    @time run_and_time_om!(total_times, max_sizes, i, n)
+if omod !== nothing
+    for (i, n) in enumerate(N)
+        @time run_and_time_om!(total_times, max_sizes, i, n)
+    end
+    OMJulia.quit(omod)
 end
-
-OMJulia.quit(omod)
 ```
 
 ## Dymola Timings

--- a/benchmarks/ModelingToolkit/ThermalFluid.jmd
+++ b/benchmarks/ModelingToolkit/ThermalFluid.jmd
@@ -317,30 +317,37 @@ end
 
 ## Time OpenModelica
 
+`omc` is not installed on the hosted benchmark runners. Skip OpenModelica timings when the compiler is missing rather than aborting the page (Dymola times below are already hardcoded).
+
 ```julia
 using OMJulia, CSV, DataFrames
-mod = OMJulia.OMCSession();
-OMJulia.sendExpression(mod, "getVersion()")
-OMJulia.sendExpression(mod, "installPackage(Modelica)")
+mod = try
+    sess = OMJulia.OMCSession()
+    OMJulia.sendExpression(sess, "getVersion()")
+    OMJulia.sendExpression(sess, "installPackage(Modelica)")
+    sess
+catch e
+    @warn "OpenModelica (omc) is not available; skipping OpenModelica timings" exception = (e, catch_backtrace())
+    nothing
+end
 modelicafile = "../../benchmarks/ModelingToolkit/DhnControl.mo"
 resultfile = "modelica_res.csv"
 
-@show "Start OpenModelica Timings"
-
-for i in eachindex(N)
-    n = N[i]
-    n > max_sizes[end] && break
-    @show n
-    totaltime = @elapsed res = begin
-        @sync ModelicaSystem(mod, modelicafile, "DhnControl.Test.test_preinsulated_470_$n")
-        sendExpression(mod, "simulate(DhnControl.Test.test_preinsulated_470_$n)")
+if mod !== nothing
+    @show "Start OpenModelica Timings"
+    for i in eachindex(N)
+        n = N[i]
+        n > max_sizes[end] && break
+        @show n
+        totaltime = @elapsed res = begin
+            @sync ModelicaSystem(mod, modelicafile, "DhnControl.Test.test_preinsulated_470_$n")
+            sendExpression(mod, "simulate(DhnControl.Test.test_preinsulated_470_$n)")
+        end
+        @assert res["messages"][1:11] == "LOG_SUCCESS"
+        total_times[i, 2] = totaltime
     end
-    #runtime = res["timeTotal"]
-    @assert res["messages"][1:11] == "LOG_SUCCESS"
-    total_times[i, 2] = totaltime
+    OMJulia.quit(mod)
 end
-
-OMJulia.quit(mod)
 total_times[:, 2]
 ```
 


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

RCCircuit and ThermalFluid aborted the hosted ModelingToolkit weave with
`IOError: could not spawn omc` ([master run 34398693942](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/34398693942)).
Dymola times are already hardcoded; skip OpenModelica the same way when `omc`
is missing so the MTK series still publishes. NaN OM columns are ignored by Makie.

This is a weave-break fix, not a last-2-months same-major Manifest refresh.

## Verification

Local weave of the previously failing page through the CI entrypoint is in progress:

```
PATH=julia-1.11.9/bin:$PATH bash .github/scripts/build_benchmark.sh benchmarks/ModelingToolkit/RCCircuit.jmd
```

The previous master failure was `could not spawn omc` on both pages. This
environment also has no `omc`; the skip path is the hosted path.

## Not verified

ThermalFluid.jmd is the same OM pattern; full-folder weave is deferred to the
self-hosted job (historically ~1.5 h of MTK timings).

## Links

- Failed master weave: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/34398693942
- Prior MTK refresh: https://github.com/SciML/SciMLBenchmarks.jl/pull/1726


> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with Grok Build TUI 1.0.25 (model: grok-4.6)
Agent-Session: local session ID 01a08fa0-c838-70b2-a867-b130df517856 (transcript: /home/crackauc/.grok/sessions/%2Fhome%2Fcrackauc%2Fsandbox%2Ftmp_20260911_054109_16563/01a08fa0-c838-70b2-a867-b130df517856)