### PR TITLE
Skip Python GPU timings when CUDA wheels cannot run on V100

### DIFF
--- a/benchmarks/DiffEqGPU/CondaPkg.toml
+++ b/benchmarks/DiffEqGPU/CondaPkg.toml
@@ -1,8 +1,9 @@
 [deps]
 numpy = ""
+python = "3.12.*"
 
 [pip.deps]
 diffrax = ">=0.5"
 equinox = ">=0.11"
 jax = {version=">=0.4", extras=["cuda12"]}
-torch = ">=2.0"
+torch = "@ https://download-r2.pytorch.org/whl/cu126/torch-2.13.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=8695f3c6b7966d44560275b90c5c28e5091ba33ddbb1ab33b2173782ca1e9145"

--- a/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
+++ b/benchmarks/DiffEqGPU/lorenz_ensemble.jmd
@@ -97,20 +97,32 @@ end
 ```
 
 ```julia
-sys = pyimport("sys")
-sys.path.insert(0, @__DIR__)
-eu = pyimport("ensemble_utils")
-jax = pyimport("jax")
-torch = pyimport("torch")
+# Hosted V100s reject some CUDA 13 / generic PyTorch wheels (`no kernel image
+# is available for execution on the device`). Probe once and skip Python GPU
+# timings rather than aborting the Julia ensemble series.
+python_gpu = try
+    sys = pyimport("sys")
+    sys.path.insert(0, @__DIR__)
+    eu = pyimport("ensemble_utils")
+    jax = pyimport("jax")
+    torch = pyimport("torch")
+    jax_devs = jax.devices("gpu")
+    @assert pyconvert(Int, pyimport("builtins").len(jax_devs)) > 0 "JAX did not see a GPU"
+    println("JAX devices: ", jax.devices())
+    @assert pyconvert(Bool, torch.cuda.is_available()) "PyTorch did not see a CUDA GPU"
+    println("PyTorch CUDA: ", torch.cuda.get_device_name(0))
+    torch.zeros(1).cuda()
+    jax.numpy.zeros((1,))
+    (; eu, jax, torch)
+catch e
+    @warn "Python GPU backends unavailable; skipping JAX/PyTorch timings" exception = (e, catch_backtrace())
+    nothing
+end
 
-jax_devs = jax.devices("gpu")
-@assert pyconvert(Int, pyimport("builtins").len(jax_devs)) > 0 "JAX did not see a GPU"
-println("JAX devices: ", jax.devices())
-@assert pyconvert(Bool, torch.cuda.is_available()) "PyTorch did not see a CUDA GPU"
-println("PyTorch CUDA: ", torch.cuda.get_device_name(0))
-
-time_diffrax(n; adaptive) = pyconvert(Float64, eu.time_diffrax(n, adaptive))
-time_torch(n) = pyconvert(Float64, eu.time_torch_rk4(n))
+time_diffrax(n; adaptive) = python_gpu === nothing ? NaN :
+                            pyconvert(Float64, python_gpu.eu.time_diffrax(n, adaptive))
+time_torch(n) = python_gpu === nothing ? NaN :
+                pyconvert(Float64, python_gpu.eu.time_torch_rk4(n))
 ```
 
 Trajectory counts follow the paper's `8, 32, 128, …` geometric sequence.


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

`lorenz_ensemble.jmd` aborted the hosted DiffEqGPU weave with PyTorch/JAX
`CUDA error: no kernel image is available for execution on the device`
([master run 34399062314](https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/34399062314)).
Probe Python GPU once, skip those series on failure, and pin PyTorch to the
CUDA 12.6 wheel so the Julia EnsembleGPUKernel/Array series can still publish.

Does not add a test that greps CondaPkg.toml strings (repo AGENTS.md forbids that).

This is a weave-break fix. Related draft https://github.com/SciML/SciMLBenchmarks.jl/pull/1789
only pins the wheel.

## Verification

No GPU on this host. CPU-side checks:

```
nvidia-smi
# command not found
julia --project=benchmarks/DiffEqGPU -e 'using CUDA; println("CUDA.functional=", CUDA.functional())'
# CUDA.functional=false
# CUDA_CHECK_EXIT:0
```

The page `@assert CUDA.functional()` so it cannot produce markdown here.
The Python skip (`try` around JAX/PyTorch) is after that assert; a CondaPkg/pixi
codec failure also aborts `using PythonCall` before the skip `try`. GPU exclusive
runner should take the full weave after merge/dispatch.

## Links

- Failed master weave: https://github.com/SciML/SciMLBenchmarks.jl/actions/runs/34399062314
- Related pin-only draft: https://github.com/SciML/SciMLBenchmarks.jl/pull/1789

> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with Grok Build TUI 1.0.25 (model: grok-4.6)
Agent-Session: local session ID 01a08fa0-c838-70b2-a867-b130df517856 (transcript: /home/crackauc/.grok/sessions/%2Fhome%2Fcrackauc%2Fsandbox%2Ftmp_20260911_054109_16563/01a08fa0-c838-70b2-a867-b130df517856)
