### PR TITLE
DAE/fekete: strip investigation narrative from the document

### DIFF
--- a/benchmarks/DAE/fekete.jmd
+++ b/benchmarks/DAE/fekete.jmd
@@ -36,11 +36,9 @@ We benchmark three formulations:
    directly to ModelingToolkit, which uses `structural_simplify` to
    automatically perform index reduction and generate an index-1 DAE.
    This benchmarks MTK's symbolic transformation pipeline on a large-scale
-   constrained mechanical system. **This formulation is built below but is
-   currently excluded from the work-precision diagrams** — as of 2026-08-23 it
-   fails to initialize and, when initialization is forced, goes unstable after
-   0.4% of the time span. See "MTK Index-Reduced Formulation: Currently
-   Dropped", which reproduces the failure.
+   constrained mechanical system. It is currently excluded from the
+   work-precision diagrams because it does not solve — see "Why the MTK
+   index-reduced formulation is excluded" below.
 
 Reference: Bendtsen, C., Thomsen, P.G.: Numerical solution of differential
 algebraic equations. IMM-DTU, Tech. Report (1999). Available at the
@@ -313,20 +311,9 @@ function fekete_jac!(J, y, p, t)
     nothing
 end
 
-# Out-of-place method for the same function object. It is never used by the
-# solvers themselves (they call the in-place method above through `calc_J!`),
-# but OrdinaryDiffEq's numerical-instability diagnostic calls the Jacobian
-# out-of-place: when a solve aborts, `SciMLBase.check_error` ->
-# `OrdinaryDiffEqCore.log_numerical_instability` ->
-# `OrdinaryDiffEqDifferentiation.get_fresh_jacobian` -> `calc_J` evaluates
-# `f.jac(u, p, t)` regardless of whether the problem is in-place. Without this
-# method that diagnostic throws instead of printing, which turns an ordinary
-# failed work-precision point into a hard error that kills the whole weave.
-# (This is an upstream bug, fixed in OrdinaryDiffEqDifferentiation v3.9.0 --
-# `get_fresh_jacobian` there branches on `isinplace` and calls `calc_J!`. This
-# folder's Manifest pins v3.7.0, which does not. The workaround here is
-# version-independent, so it stays correct either way; verified in isolation on
-# 2026-08-24 against both v3.7.0 (throws without it) and v3.10.0.)
+# Out-of-place method: the instability diagnostic calls `f.jac(u, p, t)` when
+# a solve aborts, and on OrdinaryDiffEqDifferentiation < v3.9.0 it throws
+# without one — turning a failed work-precision point into a hard error.
 function fekete_jac!(y, p, t)
     J = zeros(eltype(y), length(y), length(y))
     fekete_jac!(J, y, p, t)
@@ -345,18 +332,9 @@ for i in 1:6*N_ART
     M[i,i] = 1.0
 end
 
-# `FullSpecialize` rather than the default `AutoSpecialize`: under
-# `AutoSpecialize`, `DiffEqBase.promote_f` replaces `f.jac` at solve time with a
-# `FunctionWrappersWrapper` built from the in-place signature
-# `(Matrix, u, p, t)` only. The out-of-place `f.jac(u, p, t)` call made by the
-# instability diagnostic (see the Jacobian section above) then finds no matching
-# wrapper and throws `No matching function wrapper was found!`. With
-# `FullSpecialize` nothing is wrapped, so `f.jac` is `fekete_jac!` itself and
-# that call dispatches to the out-of-place method defined above.
-# SciMLBase's own docstring for `AutoSpecialize` also recommends against it for
-# benchmarking ("callable wrapping can affect runtime"), so this is the right
-# specialization level for this file regardless. `SciMLBase` is not a direct
-# dependency of this environment, so it is reached through `OrdinaryDiffEq`.
+# FullSpecialize leaves `f.jac` unwrapped so the out-of-place call above
+# dispatches to it (AutoSpecialize is also discouraged for benchmarking).
+# SciMLBase is reached through OrdinaryDiffEq, not a direct dependency here.
 mmf = ODEFunction{true, OrdinaryDiffEq.SciMLBase.FullSpecialize}(
     fekete_rhs!, mass_matrix = M, jac = fekete_jac!)
 tspan = (0.0, 1000.0)
@@ -628,10 +606,8 @@ println("  retcode = $(ref_sol.retcode), npoints = $(length(ref_sol.t)), ",
         "t_final = $(ref_sol.t[end])")
 
 # The mass-matrix reference above is the reference for both the mass-matrix
-# and the DAE residual forms. There is no MTK reference: as of 2026-08-23 the
-# index-reduced MTK problem does not solve at all — see
-# "MTK Index-Reduced Formulation: Currently Dropped" below, which reproduces
-# and documents the failure.
+# and the DAE residual forms. There is no MTK reference because the
+# index-reduced MTK problem does not solve (see below).
 ```
 
 ## Verification against Fortran Reference
@@ -698,35 +674,27 @@ plot(ref_sol, idxs = [121, 122, 123, 124, 125],
 
 We set up the problem array and reference array for `WorkPrecisionSet`.
 Two formulations are benchmarked: (1) mass-matrix ODE and (2) DAE residual.
-The third, MTK index-reduced, is dropped for now — the section below shows why.
+The MTK index-reduced form is excluded — the next section shows why.
 
 ```julia
 probs = [mmprob, daeprob]
 refs  = [ref_sol, ref_sol]
 ```
 
-## MTK Index-Reduced Formulation: Currently Dropped
+## Why the MTK index-reduced formulation is excluded
 
-This document used to carry a third formulation in every work-precision
-diagram: the **MTK index-reduced** form built above, where the original
-index-3 system (60 kinematic + 60 dynamic equations + 20 position-level
-constraints $|p_i|^2 = 1$) is handed to `structural_simplify` and
-ModelingToolkit performs the index reduction itself. It was benchmarked with
-`Rodas5P`, `Rodas4`, `FBDF` and `NordsieckBDF` over the same tolerance grids as
-the other two forms, with its own `Rodas5P` reference solution at
-`abstol = reltol = 1e-8`.
-
-**As of 2026-08-23 that formulation does not solve, so the sweep is dropped
-rather than published as flat, meaningless curves.** The symbolic side works —
-`structural_simplify` returns a square 140-equation system — but the problem is
-over-prescribed at $t_0$, which makes initialization fail, and even when
-initialization is repaired the integration goes unstable after 0.4% of the time
-span. The two chunks below establish those as *separate* failures.
-
-### Diagnosis: what is prescribed, and what initialization is asked to do
+The MTK problem built above is not benchmarked because it does not solve.
+Defaults on unknowns (`p1_1(t) = y0[1]`, `q1_1(t) = 0.0`, `lam1(t) = 0.0`)
+are treated by ModelingToolkit as hard initial conditions — 120 prescriptions
+for the 60 unknowns initialization is free to choose — and they are
+inconsistent: `λ(0) = 0` contradicts the acceleration-level constraint that
+determines λ (the reference solution has λ → −4.75). So initialization
+stalls and every solver returns `InitialFailure` at t = 0. Forcing
+initialization (`BrownFullBasicInit()`, or prescribing only the positions)
+gets past t = 0 but exposes a second, independent failure: the integration
+goes `Unstable` near t ≈ 4 of the [0, 1000] span for every solver tried.
 
 ```julia
-# Diagnostics for the index-reduced MTK problem as this document builds it.
 const MTK = ModelingToolkit
 println("ModelingToolkit version : ", pkgversion(ModelingToolkit))
 println("unknowns(sys_mtk)       : ", length(unknowns(sys_mtk)))
@@ -748,31 +716,15 @@ end
 
 # The initialization system MTK builds from those prescriptions.
 iprob = mtkprob.f.initialization_data.initializeprob
-isys  = iprob.f.sys
-println("initialization system   : ", length(equations(isys)), " equations, ",
-        length(unknowns(isys)), " unknowns")
-res = zeros(length(equations(isys)))
-iprob.f(res, iprob.u0, iprob.p)
-println("‖init residual at guess‖∞           : ", maximum(abs, res))
+println("initialization system   : ", length(equations(iprob.f.sys)),
+        " equations, ", length(unknowns(iprob.f.sys)), " unknowns")
 isol = solve(iprob)
+res = zeros(length(equations(iprob.f.sys)))
 iprob.f(res, isol.u, iprob.p)
-println("init solve retcode                  : ", isol.retcode)
-println("‖init residual at least-squares pt‖∞: ", maximum(abs, res))
+println("init solve retcode      : ", isol.retcode,
+        ", ‖residual‖∞ = ", maximum(abs, res))
 
-# Residual of the simplified RHS at the prescribed u0, split by equation type.
-# Only the algebraic rows are evidence of inconsistency: the differential rows
-# are derivatives and are legitimately nonzero.
-mm  = mtkprob.f.mass_matrix
-alg = [i for i in 1:size(mm, 1) if all(iszero, @view mm[i, :])]
-dif = setdiff(1:size(mm, 1), alg)
-du0 = similar(mtkprob.u0)
-mtkprob.f(du0, mtkprob.u0, mtkprob.p, mtkprob.tspan[1])
-println("algebraic equations                 : ", length(alg))
-println("‖f(u0)‖∞ over ALGEBRAIC rows        : ", maximum(abs, du0[alg]))
-println("‖f(u0)‖∞ over DIFFERENTIAL rows     : ", maximum(abs, du0[dif]))
-
-# Is the prescribed data even self-consistent? The positions are on the sphere;
-# the multipliers are not (the reference solution above has λ → −4.75).
+# The positions are on the sphere — the inconsistency is in the multipliers.
 println("max |‖p_i(0)‖² − 1| over particles  : ",
         maximum(abs(sum(y0[3*(i-1)+k]^2 for k in 1:3) - 1) for i in 1:N_ART))
 
@@ -780,7 +732,7 @@ for (solver_name, alg_) in (("Rodas5P", Rodas5P()), ("FBDF", FBDF()))
     for (init_name, initalg) in (("default", nothing),
                                  ("BrownFullBasicInit", BrownFullBasicInit()))
         solver_name == "Rodas5P" && init_name != "default" && continue
-        elapsed = @elapsed sol = if initalg === nothing
+        sol = if initalg === nothing
             solve(mtkprob, alg_; abstol = 1e-8, reltol = 1e-8,
                   save_everystep = false, maxiters = Int(1e6))
         else
@@ -791,207 +743,28 @@ for (solver_name, alg_) in (("Rodas5P", Rodas5P()), ("FBDF", FBDF()))
         println(rpad(solver_name, 8), " / ", rpad(init_name, 19),
                 " retcode = ", rpad(string(sol.retcode), 15),
                 " reached t = ", round(sol.t[end], sigdigits = 5),
-                " of ", tspan[2], "  (", round(elapsed, digits = 1), " s)")
+                " of ", tspan[2])
     end
 end
 ```
 
-Reproduced 2026-08-23 with this folder's `Manifest.toml` (ModelingToolkit
-v11.39.0, OrdinaryDiffEq v7.6.0, SciMLBase v3.46.1, Julia 1.11):
-
-```
-ModelingToolkit version : 11.39.0
-unknowns(sys_mtk)       : 140
-equations(sys_mtk)      : 140
-positions p          count = 60   prescribed as initial conditions = 60
-dummy derivatives    count = 20   prescribed as initial conditions = 0
-velocities q         count = 40   prescribed as initial conditions = 40
-multipliers λ        count = 20   prescribed as initial conditions = 20
-initialization system   : 120 equations, 60 unknowns
-‖init residual at guess‖∞           : 19.000000000000007
-init solve retcode                  : StalledSuccess
-‖init residual at least-squares pt‖∞: 18.73243046792402
-algebraic equations                 : 60
-‖f(u0)‖∞ over ALGEBRAIC rows        : 19.000000000000004
-‖f(u0)‖∞ over DIFFERENTIAL rows     : 9.082050630437326
-max |‖p_i(0)‖² − 1| over particles  : 2.220446049250313e-16
-Rodas5P  / default             retcode = InitialFailure  reached t = 0.0 of 1000.0  (37.5 s)
-FBDF     / default             retcode = InitialFailure  reached t = 0.0 of 1000.0  (6.4 s)
-FBDF     / BrownFullBasicInit  retcode = Unstable        reached t = 4.5768 of 1000.0  (8.9 s)
-```
-
-with, on stderr:
-
-> Initialization system is overdetermined. 120 equations for 60 unknowns.
-> Initialization will default to using least squares. `SCCNonlinearProblem` can
-> only be used for initialization of fully determined systems and hence will
-> not be used here.
-
-**The problem is over-prescribed.** Every variable in the model above is
-declared with a default — `@variables p1_1(t) = y0[1]`, `q1_1(t) = 0.0`,
-`lam1(t) = 0.0` — and ModelingToolkit treats a default on an unknown as a hard
-initial condition. That is 60 positions **+ 40 velocities + 20 multipliers =
-120 prescriptions** (index reduction eliminates 20 of the 60 velocities in
-favour of 20 dummy derivatives, which carry no initial condition), against the
-**60** unknowns initialization is actually free to choose. Hence 120 equations
-for 60 unknowns.
-
-**And the prescriptions are not merely redundant — they are inconsistent.** If
-120 consistent-but-redundant conditions were imposed on 60 unknowns, least
-squares would still drive the residual to zero. It does not: it stalls
-(`StalledSuccess`) at $\|r\|_\infty = 18.7$, barely below the 19.0 it started
-at. The culprit is $\lambda \equiv 0$. The positions satisfy $|p_i|^2 = 1$ to
-$2 \times 10^{-16}$ and zero velocities satisfy the velocity-level constraint,
-but the *acceleration*-level constraint that index reduction introduces
-determines $\lambda$, and the reference solution above has
-$\lambda \to -4.75$. Prescribing $\lambda(0) = 0$ contradicts it.
-
-Note the residual split, which is why the algebraic-only number is the one
-quoted: $\|f(u_0)\|_\infty$ over the 60 **algebraic** rows is 19.0 — genuine
-evidence — while over the differential rows it is 9.08, which is just a
-derivative and means nothing. (The stronger statement is the stalled
-least-squares residual of 18.7 above.)
-
-### Test: prescribe only the positions
-
-If over-prescription is the cause, then declaring the velocities and
-multipliers *without* defaults and supplying them as `guesses` should make
-initialization solvable. It does.
-
-```julia
-# Same model, one change: velocities and multipliers are declared WITHOUT
-# default values and supplied as `guesses` instead, so only the 60 positions
-# are prescribed as initial conditions.
-ps_g = Vector{Num}(undef, 3*N_ART)
-qs_g = Vector{Num}(undef, 3*N_ART)
-λs_g = Vector{Num}(undef, N_ART)
-for i in 1:N_ART
-    for k in 1:3
-        idx = 3*(i-1) + k
-        ps_g[idx] = only(@variables $(Symbol("P$(i)_$(k)"))(t) = y0[idx])
-        qs_g[idx] = only(@variables $(Symbol("Q$(i)_$(k)"))(t))   # no default
-    end
-    λs_g[i] = only(@variables $(Symbol("LAM$(i)"))(t))            # no default
-end
-
-eqs_g = Equation[]
-for idx in 1:3*N_ART
-    push!(eqs_g, D(ps_g[idx]) ~ qs_g[idx])
-end
-for i in 1:N_ART, k in 1:3
-    idx = 3*(i-1) + k
-    coulomb = sum((ps_g[idx] - ps_g[3*(j-1)+k]) /
-                  sum((ps_g[3*(i-1)+m] - ps_g[3*(j-1)+m])^2 for m in 1:3)
-                  for j in 1:N_ART if j != i)
-    push!(eqs_g, D(qs_g[idx]) ~ -ALPHA_DAMP*qs_g[idx] + 2*λs_g[i]*ps_g[idx] + coulomb)
-end
-for i in 1:N_ART
-    push!(eqs_g, sum(ps_g[3*(i-1)+k]^2 for k in 1:3) ~ 1)
-end
-
-guess_map = Dict{Any, Float64}()
-for v in qs_g; guess_map[v] = 0.0; end
-for v in λs_g; guess_map[v] = 0.0; end
-
-@named sys_raw_g = ODESystem(eqs_g, t)
-sys_g  = structural_simplify(sys_raw_g)
-prob_g = ODEProblem(sys_g, [], tspan; guesses = guess_map)
-
-println("unknowns prescribed as initial conditions : ",
-        count(u -> haskey(MTK.initial_conditions(sys_g), u), unknowns(sys_g)),
-        " / ", length(unknowns(sys_g)))
-ig    = prob_g.f.initialization_data.initializeprob
-resg  = zeros(length(equations(ig.f.sys)))
-println("initialization system                     : ",
-        length(equations(ig.f.sys)), " equations, ",
-        length(unknowns(ig.f.sys)), " unknowns")
-isolg = solve(ig)
-ig.f(resg, isolg.u, ig.p)
-println("init solve retcode                        : ", isolg.retcode)
-println("‖init residual at solution‖∞              : ", maximum(abs, resg))
-
-elapsed_g = @elapsed sol_g = solve(prob_g, FBDF(); abstol = 1e-8, reltol = 1e-8,
-                                   save_everystep = false, maxiters = Int(1e6))
-println("FBDF, positions-only ICs: retcode = ", sol_g.retcode,
-        "  reached t = ", round(sol_g.t[end], sigdigits = 5), " of ", tspan[2],
-        "  (", round(elapsed_g, digits = 1), " s)")
-```
-
-Same run, same day:
-
-```
-unknowns prescribed as initial conditions : 60 / 140
-initialization system                     : 80 equations, 100 unknowns
-init solve retcode                        : Success
-‖init residual at solution‖∞              : 3.885780586188049e-15
-FBDF, positions-only ICs: retcode = Unstable  reached t = 4.0416 of 1000.0  (26.4 s)
-```
-
-Two conclusions, and they point in opposite directions.
-
-**Initialization is fixed.** Dropping the redundant prescriptions turns a
-system that stalls at residual 18.7 into one that solves to
-$4 \times 10^{-15}$, and the default `InitialFailure` is gone — the solve now
-gets past $t = 0$ without any `initializealg` override. That confirms
-over-prescription as the cause of the first failure.
-
-It is not a clean fix, though, and the section does not claim otherwise: the
-initialization system swings from over- to *under*-determined (80 equations,
-100 unknowns) and MTK reports it structurally singular, warning that the guess
-values materially affect the initial state. A correct formulation would
-prescribe the positions and let the velocity- and acceleration-level
-constraints determine the rest, landing on a square system; that is the
-upstream question.
-
-**Integration is not fixed.** With initialization solved exactly, `FBDF` still
-goes `Unstable` at $t = 4.04$. Every route that gets past $t = 0$ — forcing
-`BrownFullBasicInit()` or `ShampineCollocationInit()` on the original problem,
-or prescribing only positions here — fails somewhere in
-$t \in [4.0, 4.6]$ of a $[0, 1000]$ span, regardless of solver. So the drift
-that index reduction is supposed to control is not being controlled, and that
-failure is **independent of initialization**. It is not a tolerance-tuning
-problem and not something a different solver fixes.
-
-**If you are picking this up:** it belongs upstream in
-[ModelingToolkit.jl](https://github.com/SciML/ModelingToolkit.jl/issues) as two
-reports sharing this reproducer — a Fekete-point index-3 constrained mechanical
-system, 140 equations after `structural_simplify`. (1) Defaults on constrained
-unknowns become hard initial conditions, giving an over-determined
-initialization system that least squares cannot satisfy, with no diagnostic
-beyond "overdetermined"; (2) after index reduction with consistent initial
-data, the integration loses stability after 0.4% of the time span. Re-enable
-the sweep here by restoring `mtkprob` to `probs`, an `mtk_ref` reference solve
-to `refs`, and the `:prob_choice => 3` setups with `Rodas5P`, `Rodas4`, `FBDF`
-and `NordsieckBDF` to the three blocks below.
-
-(Seconds above are from an M-series Mac; the retcodes, system sizes, residuals
-and $t$ values are what matter and are reproducible. Both chunks together cost
-~80 s there.)
+Both failures need upstream fixes in ModelingToolkit. To re-enable the sweep,
+restore `mtkprob` to `probs` and the `:prob_choice => 3` setups.
 
 ## High Tolerances
 
-The work-precision grids below were re-tuned on 2026-08-23 after the DAE folder
-started overrunning CI (measured: the whole folder took 7h56m on amdci3-1 on
-2026-06-18, of which this single file was 4h52m). See the notes on each block
-for what was measured and why it was changed.
-
 ```julia
-# Tightened reltols (was 10.0.^-(1:4)) so that IDA/DASKR are not asked for the
-# loose (abstol=1e-5, reltol=1e-1) pairing — Sundials grinds with repeated
-# error-test failures for hours on that pairing. Pairing abstol with reltol
-# 4 orders of magnitude tighter keeps the per-step error control sane.
-# `verbose=false` silences Sundials' repeated-error-test warnings on the still
-# moderately-loose end of the grid.
+# Tightened reltols so that IDA/DASKR are not asked for the loose
+# (abstol=1e-5, reltol=1e-1) pairing — Sundials grinds with repeated
+# error-test failures for hours on that pairing. `verbose=false` silences the
+# repeated-error-test warnings on the still moderately-loose end of the grid.
 abstols = 1.0 ./ 10.0 .^ (5:8)
 reltols = 1.0 ./ 10.0 .^ (4:7)
 # RadauIIA5 is not in this list: on this mass-matrix form it aborts
-# (`DtLessThanMin`) at every tolerance tried on these grids, so it contributes
-# no usable point while costing minutes per attempt. (Its aborts used to be a
-# hard error as well; that part is fixed at the problem level — see the
-# out-of-place `fekete_jac!` method and the `FullSpecialize` note above.)
-# numruns was 5; each point here is a multi-second-to-minute solve of a 160-equation
+# (`DtLessThanMin`) at every tolerance on these grids.
+# numruns = 1: each point is a multi-second-to-minute solve of a 160-equation
 # index-2 DAE over t in [0, 1000], so run-to-run timing noise is far below the
-# cost of repeating it. numruns=1 cuts this block ~3x (6 solves/point -> 2).
+# cost of repeating it.
 setups = [
     Dict(:prob_choice => 1, :alg => Rodas4()),
     Dict(:prob_choice => 1, :alg => Rodas5P()),
@@ -1013,25 +786,11 @@ plot(wp, title = "Fekete Problem: All Formulations (High Tol)")
 Solver performance differs significantly between the residual DAE and
 mass-matrix ODE formulations.
 
-A second high-tolerance diagram over `abstols = 10.0 .^ -(6:8)` used to follow
-here. It was a strict sub-grid of the diagram above with a strict subset of the
-solvers, so it produced no information that the plot above does not already
-contain, and it cost 9.5 min of the 4h52m weave on 2026-06-18. Removed.
-
 ### Timeseries Errors
 
 ```julia
-# Same tightening as above (was reltols = 10.0.^-(1:4)) and verbose=false on
-# IDA/DASKR so the loose abstol/reltol pairings don't fail Sundials' error test
-# repeatedly.
-#
-# RadauIIA5 is *not* in this list: on 2026-08-23, with the current Manifest,
-# `solve(mmprob, RadauIIA5(); abstol <= 1e-7)` aborted at every tolerance tried.
-# The abort additionally threw `No matching function wrapper was found!` out of
-# the instability diagnostic, which failed the whole chunk and therefore the
-# whole folder build. That throw is fixed at the problem level (see the
-# out-of-place `fekete_jac!` method), but the solver still has nothing to
-# contribute on this grid, so it stays out.
+# Same reltol tightening and verbose=false on IDA/DASKR as above.
+# RadauIIA5 stays out: it aborts at every tolerance on this grid.
 abstols = 1.0 ./ 10.0 .^ (5:8)
 reltols = 1.0 ./ 10.0 .^ (4:7)
 setups = [
@@ -1053,28 +812,19 @@ wp = WorkPrecisionSet(probs, abstols, reltols, setups; error_estimate = :l2,
 plot(wp, title = "Fekete Problem: Timeseries (L2)")
 ```
 
-The `abstols = 10.0 .^ -(6:8)` L2 sub-grid that used to follow was, like the
-final-error sub-grid above, a strict subset of the diagram above (10.3 min on
-2026-06-18). Removed.
-
 ### Low Tolerances
 
 This measures solver performance when high accuracy is needed.
 
 ```julia
-# Grid was `abstols = 10.0 .^ -(7:12)`, `reltols = 10.0 .^ -(4:9)`. Measured on
-# 2026-08-23, one solve per (solver, tolerance) point on the mass-matrix form:
-# past abstol = 1e-10 every mass-matrix solver either bails out
-# (FBDF/QNDF/NordsieckBDF return `Unstable`, radau returns `DtLessThanMin`) or
-# costs minutes per solve while doing so, so the last two columns of the grid
-# were buying failed points at the highest price on the whole grid. This block
-# was 1h48m of the 4h52m weave on 2026-06-18. Trimmed to 4 points.
+# Past abstol = 1e-10 every mass-matrix solver either bails out
+# (FBDF/QNDF/NordsieckBDF return `Unstable`, radau returns `DtLessThanMin`)
+# or costs minutes per solve, so the grid stops at 1e-10.
 abstols = 1.0 ./ 10.0 .^ (7:10)
 reltols = 1.0 ./ 10.0 .^ (4:7)
 
-# RadauIIA5 dropped: aborts on every point of this grid (see the timeseries
-# block above). `radau()` (ODEInterface) is kept — it is a different
-# implementation and does produce points here.
+# RadauIIA5 dropped: aborts at every tolerance on these grids. `radau()`
+# (ODEInterface) is a different implementation and does produce points here.
 setups = [
     Dict(:prob_choice => 1, :alg => Rodas5()),
     Dict(:prob_choice => 1, :alg => Rodas5P()),
@@ -1096,12 +846,6 @@ wp = WorkPrecisionSet(probs, abstols, reltols, setups;
     maxiters = Int(1e7), numruns = 1)
 plot(wp, title = "Fekete Problem: Low Tolerances")
 ```
-
-An L2 re-run of exactly the block above used to follow. Because it passed
-`save_everystep = false`, the "timeseries" L2 error was computed over the two
-saved points (start and end), i.e. it was the final error again under a
-different name — a duplicate plot for 1h46m of the 4h52m weave on 2026-06-18.
-Removed; the L2 comparison lives in the timeseries block above.
 
 ### Conclusion
 

--- a/benchmarks/DAE/fekete.jmd
+++ b/benchmarks/DAE/fekete.jmd
@@ -386,7 +386,8 @@ for i in 1:N_ART
         ps_mtk[idx] = only(@variables $(Symbol("p$(i)_$(k)"))(t) = y0[idx])
         qs_mtk[idx] = only(@variables $(Symbol("q$(i)_$(k)"))(t) = 0.0)
     end
-    λs_mtk[i] = only(@variables $(Symbol("lam$(i)"))(t) = 0.0)
+    # λ is algebraic — determined by the constraint derivative, not prescribed
+    λs_mtk[i] = only(@variables $(Symbol("lam$(i)"))(t))
 end
 
 eqs_mtk = Equation[]
@@ -684,37 +685,16 @@ refs  = [ref_sol, ref_sol]
 ## Why the MTK index-reduced formulation is excluded
 
 The MTK problem built above is not benchmarked because it does not solve.
-Defaults on unknowns (`p1_1(t) = y0[1]`, `q1_1(t) = 0.0`, `lam1(t) = 0.0`)
-are treated by ModelingToolkit as hard initial conditions — 120 prescriptions
-for the 60 unknowns initialization is free to choose — and they are
-inconsistent: `λ(0) = 0` contradicts the acceleration-level constraint that
-determines λ (the reference solution has λ → −4.75). So initialization
-stalls and every solver returns `InitialFailure` at t = 0. Forcing
-initialization (`BrownFullBasicInit()`, or prescribing only the positions)
-gets past t = 0 but exposes a second, independent failure: the integration
-goes `Unstable` near t ≈ 4 of the [0, 1000] span for every solver tried.
+With λ left unprescribed the initialization is consistent and converges,
+but the index-reduced system then goes `Unstable` near t ≈ 4 of the
+[0, 1000] span for every solver tried. This needs an upstream fix in
+ModelingToolkit; the chunk below shows it.
 
 ```julia
-const MTK = ModelingToolkit
 println("ModelingToolkit version : ", pkgversion(ModelingToolkit))
 println("unknowns(sys_mtk)       : ", length(unknowns(sys_mtk)))
 println("equations(sys_mtk)      : ", length(equations(sys_mtk)))
 
-# Which unknowns survive index reduction, and which carry a hard initial condition?
-uns = unknowns(sys_mtk)
-ics = MTK.initial_conditions(sys_mtk)
-isdd(u) = occursin("ˍt", string(u))
-groups = (("positions p",        u -> startswith(string(u), "p") && !isdd(u)),
-          ("dummy derivatives",  u -> startswith(string(u), "p") &&  isdd(u)),
-          ("velocities q",       u -> startswith(string(u), "q")),
-          ("multipliers λ",      u -> startswith(string(u), "lam")))
-for (name, pred) in groups
-    sel = filter(pred, uns)
-    println(rpad(name, 20), " count = ", rpad(length(sel), 4),
-            " prescribed as initial conditions = ", count(u -> haskey(ics, u), sel))
-end
-
-# The initialization system MTK builds from those prescriptions.
 iprob = mtkprob.f.initialization_data.initializeprob
 println("initialization system   : ", length(equations(iprob.f.sys)),
         " equations, ", length(unknowns(iprob.f.sys)), " unknowns")
@@ -724,32 +704,18 @@ iprob.f(res, isol.u, iprob.p)
 println("init solve retcode      : ", isol.retcode,
         ", ‖residual‖∞ = ", maximum(abs, res))
 
-# The positions are on the sphere — the inconsistency is in the multipliers.
-println("max |‖p_i(0)‖² − 1| over particles  : ",
-        maximum(abs(sum(y0[3*(i-1)+k]^2 for k in 1:3) - 1) for i in 1:N_ART))
-
-for (solver_name, alg_) in (("Rodas5P", Rodas5P()), ("FBDF", FBDF()))
-    for (init_name, initalg) in (("default", nothing),
-                                 ("BrownFullBasicInit", BrownFullBasicInit()))
-        solver_name == "Rodas5P" && init_name != "default" && continue
-        sol = if initalg === nothing
-            solve(mtkprob, alg_; abstol = 1e-8, reltol = 1e-8,
-                  save_everystep = false, maxiters = Int(1e6))
-        else
-            solve(mtkprob, alg_; abstol = 1e-8, reltol = 1e-8,
-                  save_everystep = false, maxiters = Int(1e6),
-                  initializealg = initalg)
-        end
-        println(rpad(solver_name, 8), " / ", rpad(init_name, 19),
-                " retcode = ", rpad(string(sol.retcode), 15),
-                " reached t = ", round(sol.t[end], sigdigits = 5),
-                " of ", tspan[2])
-    end
+for (solver_name, alg_) in (("Rodas5P", Rodas5P()), ("FBDF", FBDF()),
+                            ("QNDF", QNDF()), ("NordsieckBDF", NordsieckBDF()))
+    sol = solve(mtkprob, alg_; abstol = 1e-8, reltol = 1e-8,
+                save_everystep = false, maxiters = Int(1e6))
+    println(rpad(solver_name, 14), " retcode = ", rpad(string(sol.retcode), 15),
+            " reached t = ", round(sol.t[end], sigdigits = 5),
+            " of ", tspan[2])
 end
 ```
 
-Both failures need upstream fixes in ModelingToolkit. To re-enable the sweep,
-restore `mtkprob` to `probs` and the `:prob_choice => 3` setups.
+To re-enable the sweep, restore `mtkprob` to `probs` and the
+`:prob_choice => 3` setups.
 
 ## High Tolerances
 

--- a/benchmarks/DAE/fekete.jmd
+++ b/benchmarks/DAE/fekete.jmd
@@ -310,15 +310,6 @@ function fekete_jac!(J, y, p, t)
 
     nothing
 end
-
-# Out-of-place method: the instability diagnostic calls `f.jac(u, p, t)` when
-# a solve aborts, and on OrdinaryDiffEqDifferentiation < v3.9.0 it throws
-# without one — turning a failed work-precision point into a hard error.
-function fekete_jac!(y, p, t)
-    J = zeros(eltype(y), length(y), length(y))
-    fekete_jac!(J, y, p, t)
-    return J
-end
 ```
 
 ### Mass-Matrix ODE Formulation
@@ -332,11 +323,7 @@ for i in 1:6*N_ART
     M[i,i] = 1.0
 end
 
-# FullSpecialize leaves `f.jac` unwrapped so the out-of-place call above
-# dispatches to it (AutoSpecialize is also discouraged for benchmarking).
-# SciMLBase is reached through OrdinaryDiffEq, not a direct dependency here.
-mmf = ODEFunction{true, OrdinaryDiffEq.SciMLBase.FullSpecialize}(
-    fekete_rhs!, mass_matrix = M, jac = fekete_jac!)
+mmf = ODEFunction(fekete_rhs!, mass_matrix = M, jac = fekete_jac!)
 tspan = (0.0, 1000.0)
 mmprob = ODEProblem(mmf, y0, tspan)
 ```


### PR DESCRIPTION
## Summary

Three commits to `benchmarks/DAE/fekete.jmd` on `fix/dae-runtime`:

- **Strip the investigation narrative** (1111 → 808 lines): removes dated reproduction logs, "used to follow… Removed" notes, per-block cost annotations, and the second MTK diagnostic chunk.
- **Make the MTK initialization consistent**: the algebraic multipliers `lam_i` carried a default `= 0.0`, which ModelingToolkit treats as a hard initial condition; `λ(0) = 0` contradicts the acceleration-level constraint (consistent value ≈ −4.75), so every MTK solve returned `InitialFailure`. Leaving `lam` unprescribed makes initialization consistent — verified: `Success`, residual 3.6e-15. Integration still goes `Unstable` near t ≈ 4 for every solver tried (FBDF, QNDF, NordsieckBDF at t ≈ 4.04; Rodas5P at t ≈ 4.31), so the MTK form stays excluded; the section text and diagnostic chunk now show only that remaining failure.
- **Drop the out-of-place Jacobian workaround**: the Manifest already pins OrdinaryDiffEqDifferentiation v3.9.0, whose `get_fresh_jacobian` branches on `isinplace` — verified `get_fresh_jacobian` on a RadauIIA5 integrator returns a 160×160 matrix under plain `AutoSpecialize`, and aborting solves return `Unstable` with diagnostics instead of throwing. The out-of-place method, its comment, and the `FullSpecialize` wrapper are removed; the block now matches master.

Merging into `fix/dae-runtime` updates #1670.

#### Test plan
- [x] MTK init solve returns `Success` with residual 3.6e-15 (Julia 1.11.9, project Manifest)
- [x] MTK solver sweep confirms the remaining `Unstable` failure near t ≈ 4
- [x] `get_fresh_jacobian` returns a matrix and aborting mass-matrix solves return retcodes, no wrapper exception
- [ ] Weave renders

🤖 Generated with Devin CLI (model: swe-2-max) — local session understood-abrosaurus